### PR TITLE
feat: temporal validity on all graph relationships (#3)

### DIFF
--- a/src/book_graph_analyzer/cli.py
+++ b/src/book_graph_analyzer/cli.py
@@ -133,7 +133,89 @@ def graph_stats() -> None:
         rel_count = result.single()["count"]
         console.print(f"[bold]Total relationships:[/bold] {rel_count:,}")
 
+        # Temporal coverage — how many relationships have era_start set?
+        result = session.run(
+            "MATCH ()-[r]->() WHERE r.era_start IS NOT NULL RETURN count(r) as cnt"
+        )
+        temporal_cnt = result.single()["cnt"]
+        pct = (temporal_cnt / rel_count * 100) if rel_count else 0
+        console.print(f"[bold]Temporally-tagged relationships:[/bold] {temporal_cnt:,} ({pct:.0f}%)")
+
     driver.close()
+
+
+@graph.command(name="init-eras")
+def graph_init_eras() -> None:
+    """Create Era nodes and FOLLOWED_BY chain in Neo4j."""
+    from book_graph_analyzer.graph.writer import GraphWriter
+    writer = GraphWriter()
+    writer.init_era_chain()
+    console.print("[green]Era chain initialised:[/green]")
+    console.print("  Before Time -> Years of the Lamps -> Years of the Trees")
+    console.print("  -> First Age -> Second Age -> Third Age -> Fourth Age")
+
+
+@graph.command(name="at-time")
+@click.option("--character", "-c", required=True, help="Character canonical name")
+@click.option("--era", "-e", required=True,
+              help="Era name: 'Third Age', 'Second Age', 'First Age', etc.")
+@click.option("--year", "-y", type=int, default=None, help="Year within the era")
+def graph_at_time(character: str, era: str, year: int | None) -> None:
+    """Show everything known about a character at a specific point in time.
+
+    Example:
+        bga graph at-time --character Gandalf --era "Third Age" --year 3018
+    """
+    from book_graph_analyzer.graph.writer import GraphWriter
+
+    writer = GraphWriter()
+    snapshot = writer.query_at_time(character, era, year)
+
+    if "error" in snapshot:
+        console.print(f"[red]{snapshot['error']}[/red]")
+        return
+
+    char = snapshot["character"]
+    at = snapshot["at"]
+    rels = snapshot["relationships"]
+    events = snapshot["events"]
+
+    year_str = f" {at['year']}" if at["year"] else ""
+    console.print(f"\n[bold cyan]{char.get('canonical_name', character)}[/bold cyan]"
+                  f"  at  [bold]{at['era']}{year_str}[/bold]\n")
+
+    if rels:
+        table = Table(show_header=True, header_style="bold")
+        table.add_column("Relationship", style="cyan", width=20)
+        table.add_column("Entity")
+        table.add_column("Type", style="dim", width=12)
+        table.add_column("Valid from", style="dim")
+        table.add_column("Valid until", style="dim")
+
+        for r in rels:
+            era_start = r.get("era_start") or "always"
+            era_end   = r.get("era_end") or "ongoing"
+            yr_s = f" {r['year_start']}" if r.get("year_start") else ""
+            yr_e = f" {r['year_end']}"   if r.get("year_end")   else ""
+            table.add_row(
+                r.get("rel", "?"),
+                r.get("name") or "?",
+                r.get("type") or "?",
+                f"{era_start}{yr_s}",
+                f"{era_end}{yr_e}",
+            )
+        console.print("[bold]Relationships:[/bold]")
+        console.print(table)
+    else:
+        console.print("[dim]No temporally-filtered relationships found.[/dim]")
+
+    if events:
+        console.print(f"\n[bold]Events in {era}:[/bold]")
+        for ev in events:
+            yr = f" ({ev['year']})" if ev.get("year") else ""
+            console.print(f"  [dim]-[/dim] {ev.get('description', '?')}{yr}")
+    else:
+        console.print(f"\n[dim]No events found for {era}.[/dim]")
 
 
 # ============================================================================

--- a/src/book_graph_analyzer/graph/connection.py
+++ b/src/book_graph_analyzer/graph/connection.py
@@ -50,6 +50,8 @@ def init_schema() -> None:
         "CREATE CONSTRAINT event_id IF NOT EXISTS FOR (e:Event) REQUIRE e.id IS UNIQUE",
         "CREATE CONSTRAINT passage_id IF NOT EXISTS FOR (p:Passage) REQUIRE p.id IS UNIQUE",
         "CREATE CONSTRAINT concept_id IF NOT EXISTS FOR (c:Concept) REQUIRE c.id IS UNIQUE",
+        # Era nodes
+        "CREATE CONSTRAINT era_name IF NOT EXISTS FOR (e:Era) REQUIRE e.name IS UNIQUE",
     ]
 
     indexes = [
@@ -57,10 +59,12 @@ def init_schema() -> None:
         "CREATE INDEX char_name IF NOT EXISTS FOR (c:Character) ON (c.canonical_name)",
         "CREATE INDEX place_name IF NOT EXISTS FOR (p:Place) ON (p.canonical_name)",
         "CREATE INDEX object_name IF NOT EXISTS FOR (o:Object) ON (o.canonical_name)",
+        # Era ordering index
+        "CREATE INDEX era_order IF NOT EXISTS FOR (e:Era) ON (e.era_order)",
+        # Temporal validity indexes on relationships would go here if Neo4j supported it
+        # For now we rely on property filters in Cypher
         # Passage location index
         "CREATE INDEX passage_loc IF NOT EXISTS FOR (p:Passage) ON (p.book, p.chapter_num, p.sentence_num)",
-        # Full-text search on passages
-        # Note: Full-text indexes have different syntax
     ]
 
     with driver.session() as session:

--- a/src/book_graph_analyzer/graph/temporal.py
+++ b/src/book_graph_analyzer/graph/temporal.py
@@ -1,0 +1,198 @@
+"""Temporal validity utilities for the knowledge graph.
+
+Every relationship in the graph should carry era_start / era_end / year_start / year_end
+so that point-in-time queries can answer: "What did character X know at story-time T?"
+
+Era ordering (canonical):
+    Before Time < Years of the Lamps < Years of the Trees
+    < First Age < Second Age < Third Age < Fourth Age < Unknown
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+# ---------------------------------------------------------------------------
+# Era ordering — lower index = earlier in history
+# ---------------------------------------------------------------------------
+
+ERA_ORDER: dict[str, int] = {
+    "Before Time":       0,
+    "Ainulindalë":       0,   # alias
+    "Years of the Lamps": 1,
+    "Years of the Trees": 2,
+    "First Age":         3,
+    "FA":                3,   # alias
+    "Second Age":        4,
+    "SA":                4,
+    "Third Age":         5,
+    "TA":                5,
+    "Fourth Age":        6,
+    "FA4":               6,
+    "Unknown":           99,
+}
+
+# Canonical display names for era aliases
+ERA_CANONICAL: dict[str, str] = {
+    "Ainulindalë":        "Before Time",
+    "FA":                 "First Age",
+    "SA":                 "Second Age",
+    "TA":                 "Third Age",
+    "FA4":                "Fourth Age",
+}
+
+
+def canonicalize_era(era: str | None) -> str | None:
+    """Return the canonical display name for an era string."""
+    if era is None:
+        return None
+    return ERA_CANONICAL.get(era, era)
+
+
+def era_to_order(era: str | None) -> int:
+    """Return the sort order for an era (higher = later). Unknown = 99."""
+    if era is None:
+        return 99
+    return ERA_ORDER.get(era, 99)
+
+
+def era_before_or_equal(a: str | None, b: str | None) -> bool:
+    """Return True if era a comes before or is equal to era b."""
+    return era_to_order(a) <= era_to_order(b)
+
+
+def era_after_or_equal(a: str | None, b: str | None) -> bool:
+    """Return True if era a comes after or is equal to era b."""
+    return era_to_order(a) >= era_to_order(b)
+
+
+# ---------------------------------------------------------------------------
+# TemporalValidity dataclass — attached to every relationship
+# ---------------------------------------------------------------------------
+
+@dataclass
+class TemporalValidity:
+    """When a relationship is valid in the story timeline."""
+
+    era_start: Optional[str] = None    # None = "since forever / unknown"
+    era_end: Optional[str] = None      # None = "ongoing / unknown"
+    year_start: Optional[int] = None   # Specific year within era_start
+    year_end: Optional[int] = None     # Specific year within era_end
+    source_passage_id: Optional[str] = None
+    confidence: float = 1.0
+
+    def is_valid_at(self, era: str, year: Optional[int] = None) -> bool:
+        """Check if this relationship is valid at a given point in time.
+
+        Args:
+            era: The era to check (e.g. 'Third Age')
+            year: Optional year within the era
+
+        Returns:
+            True if the relationship exists at this point in time.
+        """
+        # Check era_start bound
+        if self.era_start is not None:
+            if not era_after_or_equal(era, self.era_start):
+                return False
+            # If same era, check year
+            if era == self.era_start and self.year_start is not None and year is not None:
+                if year < self.year_start:
+                    return False
+
+        # Check era_end bound
+        if self.era_end is not None:
+            if not era_before_or_equal(era, self.era_end):
+                return False
+            # If same era, check year
+            if era == self.era_end and self.year_end is not None and year is not None:
+                if year > self.year_end:
+                    return False
+
+        return True
+
+    def to_dict(self) -> dict:
+        """Serialise to a dict for Neo4j property storage."""
+        return {
+            k: v for k, v in {
+                "era_start": canonicalize_era(self.era_start),
+                "era_end":   canonicalize_era(self.era_end),
+                "year_start": self.year_start,
+                "year_end":   self.year_end,
+                "source_passage_id": self.source_passage_id,
+                "temporal_confidence": self.confidence,
+            }.items()
+            if v is not None
+        }
+
+    @classmethod
+    def always(cls) -> "TemporalValidity":
+        """A relationship that is valid for all time (no constraints)."""
+        return cls()
+
+    @classmethod
+    def from_era(cls, era: str, year: Optional[int] = None,
+                 passage_id: Optional[str] = None) -> "TemporalValidity":
+        """Relationship starts at this era/year and continues indefinitely."""
+        return cls(era_start=era, year_start=year, source_passage_id=passage_id)
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "TemporalValidity":
+        """Deserialise from a Neo4j property dict."""
+        return cls(
+            era_start=d.get("era_start"),
+            era_end=d.get("era_end"),
+            year_start=d.get("year_start"),
+            year_end=d.get("year_end"),
+            source_passage_id=d.get("source_passage_id"),
+            confidence=float(d.get("temporal_confidence", 1.0)),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Cypher helpers for point-in-time queries
+# ---------------------------------------------------------------------------
+
+# Map of era name to its integer order — injected into Cypher as a literal
+_ERA_ORDER_CYPHER = (
+    "{"
+    + ", ".join(f"`{k}`: {v}" for k, v in ERA_ORDER.items())
+    + "}"
+)
+
+
+def point_in_time_cypher_where(
+    rel_alias: str = "r",
+    era_param: str = "$era",
+    year_param: str = "$year",
+) -> str:
+    """Return a Cypher WHERE clause fragment that filters a relationship
+    by era/year validity.
+
+    Usage:
+        MATCH (a)-[r:KNOWS]->(b)
+        WHERE {fragment}
+        RETURN a, r, b
+
+    Parameters bound: $era (str), $year (int, nullable)
+    """
+    order = _ERA_ORDER_CYPHER
+    return f"""(
+      {rel_alias}.era_start IS NULL OR
+      coalesce({order}[{rel_alias}.era_start], 99) <= coalesce({order}[{era_param}], 99)
+    ) AND (
+      {rel_alias}.era_end IS NULL OR
+      coalesce({order}[{rel_alias}.era_end], 99) >= coalesce({order}[{era_param}], 99)
+    ) AND (
+      {rel_alias}.year_start IS NULL OR {year_param} IS NULL OR
+      CASE WHEN {rel_alias}.era_start = {era_param}
+           THEN coalesce({rel_alias}.year_start, 0) <= coalesce({year_param}, 0)
+           ELSE true END
+    ) AND (
+      {rel_alias}.year_end IS NULL OR {year_param} IS NULL OR
+      CASE WHEN {rel_alias}.era_end = {era_param}
+           THEN coalesce({rel_alias}.year_end, 999999) >= coalesce({year_param}, 999999)
+           ELSE true END
+    )"""

--- a/src/book_graph_analyzer/graph/writer.py
+++ b/src/book_graph_analyzer/graph/writer.py
@@ -6,6 +6,7 @@ from collections import defaultdict
 from neo4j import Driver
 
 from .connection import get_driver, init_schema
+from .temporal import TemporalValidity, ERA_ORDER, canonicalize_era
 from ..extract.resolver import ResolvedEntity
 from ..extract.relationships import RelationshipExtractionResult
 from ..models.relationships import ExtractedRelationship, RelationshipTriple
@@ -37,6 +38,119 @@ class GraphWriter:
         if not self._initialized:
             init_schema()
             self._initialized = True
+
+    def init_era_chain(self) -> None:
+        """Create Era nodes and FOLLOWED_BY chain in the correct historical order.
+
+        This is idempotent — safe to call multiple times.
+        Era nodes enable temporal ordering queries in Cypher using
+        the era_order property instead of a hardcoded lookup map.
+        """
+        eras = [
+            ("Before Time",        0),
+            ("Years of the Lamps", 1),
+            ("Years of the Trees", 2),
+            ("First Age",          3),
+            ("Second Age",         4),
+            ("Third Age",          5),
+            ("Fourth Age",         6),
+        ]
+
+        with self.driver.session() as session:
+            # Create / update each Era node
+            for name, order in eras:
+                session.run(
+                    "MERGE (e:Era {name: $name}) SET e.era_order = $order",
+                    name=name, order=order,
+                )
+
+            # Create FOLLOWED_BY chain
+            for i in range(len(eras) - 1):
+                session.run(
+                    """
+                    MATCH (a:Era {name: $a})
+                    MATCH (b:Era {name: $b})
+                    MERGE (a)-[:FOLLOWED_BY]->(b)
+                    """,
+                    a=eras[i][0], b=eras[i + 1][0],
+                )
+
+    def query_at_time(
+        self,
+        character_name: str,
+        era: str,
+        year: int | None = None,
+    ) -> dict:
+        """Return a snapshot of everything known about a character at a given point in time.
+
+        Queries all relationships that are valid at era/year and returns:
+            - people they know (KNOWS / MET / FRIEND_OF / ENEMY_OF etc.)
+            - places they are / have been
+            - objects they possess(ed)
+            - events they participated in
+            - emotional state (if available)
+
+        Args:
+            character_name: Canonical name or alias
+            era: Era string e.g. 'Third Age'
+            year: Optional specific year within the era
+
+        Returns:
+            Dict with keys: character, knows, places, objects, events, emotional_state
+        """
+        from .temporal import point_in_time_cypher_where
+
+        era_filter = point_in_time_cypher_where("r", "$era", "$year")
+
+        with self.driver.session() as session:
+
+            # Find the character node
+            char_row = session.run(
+                "MATCH (c) WHERE c.canonical_name = $name OR $name IN coalesce(c.aliases, []) "
+                "RETURN c LIMIT 1",
+                name=character_name,
+            ).single()
+
+            if not char_row:
+                return {"error": f"Character '{character_name}' not found"}
+
+            char = dict(char_row["c"])
+
+            # Relationships to other entities
+            knows_rows = session.run(
+                f"""
+                MATCH (c {{canonical_name: $name}})-[r]->(other)
+                WHERE {era_filter}
+                  AND NOT other:Event AND NOT other:Passage
+                RETURN type(r) as rel, other.canonical_name as name,
+                       other.aliases as aliases, labels(other)[0] as type,
+                       r.era_start as era_start, r.era_end as era_end,
+                       r.year_start as year_start, r.year_end as year_end
+                LIMIT 50
+                """,
+                name=character_name, era=era, year=year,
+            )
+            relationships = [dict(r) for r in knows_rows]
+
+            # Events participated in during this era
+            events_rows = session.run(
+                """
+                MATCH (c {canonical_name: $name})-[:PARTICIPATED_IN]->(e:Event)
+                WHERE (e.era = $era OR e.era IS NULL)
+                RETURN e.description as description, e.era as era,
+                       e.year as year, e.agent as agent
+                LIMIT 20
+                """,
+                name=character_name, era=era,
+            )
+            events = [dict(r) for r in events_rows]
+
+        return {
+            "character": char,
+            "at": {"era": era, "year": year},
+            "relationships": relationships,
+            "events": events,
+        }
 
     def write_entity(self, entity: ResolvedEntity, book: str) -> None:
         """Write a single entity to the graph.
@@ -141,21 +255,33 @@ class GraphWriter:
         if not rel.subject_id or not rel.object_id:
             return  # Need both entities resolved
 
-        # Create relationship with passage reference
-        query = """
-        MATCH (s {id: $subject_id})
-        MATCH (o {id: $object_id})
-        MERGE (s)-[r:""" + rel.predicate.value + """]->(o)
-        ON CREATE SET
-            r.first_passage = $passage_id,
-            r.mention_count = 1,
-            r.passages = [$passage_id]
+        # Build temporal props from the relationship model
+        temporal = TemporalValidity(
+            era_start=canonicalize_era(getattr(rel, "era_start", None)),
+            era_end=canonicalize_era(getattr(rel, "era_end", None)),
+            year_start=getattr(rel, "year_start", None),
+            year_end=getattr(rel, "year_end", None),
+            source_passage_id=rel.passage_id,
+        )
+        temporal_props = temporal.to_dict()
+
+        # Create relationship with passage reference + temporal validity
+        set_clauses = ["r.first_passage = $passage_id", "r.mention_count = 1",
+                       "r.passages = [$passage_id]"]
+        for k in temporal_props:
+            set_clauses.append(f"r.{k} = ${k}")
+
+        query = f"""
+        MATCH (s {{id: $subject_id}})
+        MATCH (o {{id: $object_id}})
+        MERGE (s)-[r:{rel.predicate.value}]->(o)
+        ON CREATE SET {", ".join(set_clauses)}
         ON MATCH SET
             r.mention_count = r.mention_count + 1,
-            r.passages = CASE 
-                WHEN NOT $passage_id IN r.passages 
-                THEN r.passages + $passage_id 
-                ELSE r.passages 
+            r.passages = CASE
+                WHEN NOT $passage_id IN r.passages
+                THEN r.passages + $passage_id
+                ELSE r.passages
             END
         """
 
@@ -165,6 +291,7 @@ class GraphWriter:
                 subject_id=rel.subject_id,
                 object_id=rel.object_id,
                 passage_id=rel.passage_id,
+                **temporal_props,
             )
 
     def write_relationships_batch(
@@ -193,6 +320,11 @@ class GraphWriter:
                     "subject_id": r.subject_id,
                     "object_id": r.object_id,
                     "passage_id": r.passage_id,
+                    # Temporal validity fields
+                    "era_start": canonicalize_era(getattr(r, "era_start", None)),
+                    "era_end":   canonicalize_era(getattr(r, "era_end", None)),
+                    "year_start": getattr(r, "year_start", None),
+                    "year_end":   getattr(r, "year_end", None),
                 }
                 for r in type_rels
             ]
@@ -205,13 +337,17 @@ class GraphWriter:
             ON CREATE SET
                 r.first_passage = item.passage_id,
                 r.mention_count = 1,
-                r.passages = [item.passage_id]
+                r.passages = [item.passage_id],
+                r.era_start  = item.era_start,
+                r.era_end    = item.era_end,
+                r.year_start = item.year_start,
+                r.year_end   = item.year_end
             ON MATCH SET
                 r.mention_count = r.mention_count + 1,
-                r.passages = CASE 
-                    WHEN NOT item.passage_id IN r.passages 
-                    THEN r.passages + item.passage_id 
-                    ELSE r.passages 
+                r.passages = CASE
+                    WHEN NOT item.passage_id IN r.passages
+                    THEN r.passages + item.passage_id
+                    ELSE r.passages
                 END
             """
 

--- a/src/book_graph_analyzer/models/relationships.py
+++ b/src/book_graph_analyzer/models/relationships.py
@@ -92,6 +92,12 @@ class ExtractedRelationship(BaseModel):
     confidence: float = 1.0
     extraction_method: str = "llm"  # llm, dependency, pattern
 
+    # Temporal validity — when does this relationship hold?
+    era_start: str | None = None      # e.g. 'Third Age'
+    era_end: str | None = None        # None = ongoing / unknown
+    year_start: int | None = None     # year within era_start
+    year_end: int | None = None       # year within era_end
+
     def to_triple(self) -> str:
         """Return a human-readable triple."""
         subj = self.subject_id or self.subject_text
@@ -110,6 +116,12 @@ class RelationshipTriple(BaseModel):
     properties: dict = Field(default_factory=dict)
     passage_ids: list[str] = Field(default_factory=list)
     mention_count: int = 1
+
+    # Temporal validity
+    era_start: str | None = None
+    era_end: str | None = None
+    year_start: int | None = None
+    year_end: int | None = None
 
     def merge_with(self, other: "RelationshipTriple") -> "RelationshipTriple":
         """Merge with another triple of the same type."""

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -1,0 +1,183 @@
+"""Tests for temporal validity on graph relationships (issue #3)."""
+
+import pytest
+from book_graph_analyzer.graph.temporal import (
+    TemporalValidity,
+    ERA_ORDER,
+    canonicalize_era,
+    era_to_order,
+    era_before_or_equal,
+    era_after_or_equal,
+    point_in_time_cypher_where,
+)
+
+
+# ---------------------------------------------------------------------------
+# Era ordering
+# ---------------------------------------------------------------------------
+
+class TestEraOrdering:
+    def test_before_time_is_earliest(self):
+        assert era_to_order("Before Time") < era_to_order("First Age")
+
+    def test_third_age_after_second_age(self):
+        assert era_to_order("Third Age") > era_to_order("Second Age")
+
+    def test_fourth_age_is_latest_known(self):
+        assert era_to_order("Fourth Age") > era_to_order("Third Age")
+
+    def test_unknown_era_sorts_last(self):
+        assert era_to_order("Unknown") > era_to_order("Fourth Age")
+        assert era_to_order(None) > era_to_order("Fourth Age")
+
+    def test_full_ordering(self):
+        eras = ["Before Time", "Years of the Lamps", "Years of the Trees",
+                "First Age", "Second Age", "Third Age", "Fourth Age"]
+        orders = [era_to_order(e) for e in eras]
+        assert orders == sorted(orders), "Eras should be in strictly ascending order"
+
+    def test_era_before_or_equal(self):
+        assert era_before_or_equal("First Age", "Third Age")
+        assert era_before_or_equal("Third Age", "Third Age")
+        assert not era_before_or_equal("Third Age", "Second Age")
+
+    def test_era_after_or_equal(self):
+        assert era_after_or_equal("Third Age", "First Age")
+        assert era_after_or_equal("Second Age", "Second Age")
+        assert not era_after_or_equal("First Age", "Third Age")
+
+
+class TestEraAliases:
+    def test_sa_canonicalises_to_second_age(self):
+        assert canonicalize_era("SA") == "Second Age"
+
+    def test_ta_canonicalises_to_third_age(self):
+        assert canonicalize_era("TA") == "Third Age"
+
+    def test_fa_canonicalises_to_first_age(self):
+        assert canonicalize_era("FA") == "First Age"
+
+    def test_unknown_alias_returns_itself(self):
+        assert canonicalize_era("Madeup Age") == "Madeup Age"
+
+    def test_none_returns_none(self):
+        assert canonicalize_era(None) is None
+
+
+# ---------------------------------------------------------------------------
+# TemporalValidity
+# ---------------------------------------------------------------------------
+
+class TestTemporalValidity:
+
+    def test_always_valid_for_any_era(self):
+        tv = TemporalValidity.always()
+        assert tv.is_valid_at("First Age")
+        assert tv.is_valid_at("Third Age")
+        assert tv.is_valid_at("Second Age", year=1600)
+
+    def test_era_start_filters_earlier_eras(self):
+        tv = TemporalValidity(era_start="Third Age")
+        assert not tv.is_valid_at("Second Age")
+        assert not tv.is_valid_at("First Age")
+        assert tv.is_valid_at("Third Age")
+        assert tv.is_valid_at("Fourth Age")
+
+    def test_era_end_filters_later_eras(self):
+        tv = TemporalValidity(era_end="Second Age")
+        assert tv.is_valid_at("First Age")
+        assert tv.is_valid_at("Second Age")
+        assert not tv.is_valid_at("Third Age")
+
+    def test_era_range(self):
+        tv = TemporalValidity(era_start="Second Age", era_end="Third Age")
+        assert not tv.is_valid_at("First Age")
+        assert tv.is_valid_at("Second Age")
+        assert tv.is_valid_at("Third Age")
+        assert not tv.is_valid_at("Fourth Age")
+
+    def test_year_start_within_same_era(self):
+        tv = TemporalValidity(era_start="Third Age", year_start=3001)
+        assert tv.is_valid_at("Third Age", year=3001)
+        assert tv.is_valid_at("Third Age", year=3018)
+        assert not tv.is_valid_at("Third Age", year=2999)
+
+    def test_year_end_within_same_era(self):
+        tv = TemporalValidity(era_end="Third Age", year_end=3021)
+        assert tv.is_valid_at("Third Age", year=3000)
+        assert tv.is_valid_at("Third Age", year=3021)
+        assert not tv.is_valid_at("Third Age", year=3022)
+
+    def test_year_filter_only_applies_in_matching_era(self):
+        tv = TemporalValidity(era_start="Third Age", year_start=3001)
+        # Fourth Age: year filtering doesn't apply (different era)
+        assert tv.is_valid_at("Fourth Age", year=1)
+
+    def test_to_dict_omits_none_values(self):
+        tv = TemporalValidity(era_start="Third Age")
+        d = tv.to_dict()
+        assert "era_start" in d
+        assert "era_end" not in d
+        assert "year_start" not in d
+
+    def test_to_dict_includes_all_set_values(self):
+        tv = TemporalValidity(
+            era_start="Second Age", era_end="Third Age",
+            year_start=1600, year_end=3021,
+            source_passage_id="p_001",
+        )
+        d = tv.to_dict()
+        assert d["era_start"] == "Second Age"
+        assert d["era_end"] == "Third Age"
+        assert d["year_start"] == 1600
+        assert d["year_end"] == 3021
+        assert d["source_passage_id"] == "p_001"
+
+    def test_from_dict_roundtrip(self):
+        tv = TemporalValidity(
+            era_start="Third Age", era_end="Fourth Age",
+            year_start=3018, confidence=0.9,
+        )
+        d = tv.to_dict()
+        tv2 = TemporalValidity.from_dict(d)
+        assert tv2.era_start == "Third Age"
+        assert tv2.era_end == "Fourth Age"
+        assert tv2.year_start == 3018
+        assert abs(tv2.confidence - 0.9) < 0.01
+
+    def test_from_era_factory(self):
+        tv = TemporalValidity.from_era("Second Age", year=1600, passage_id="p_001")
+        assert tv.era_start == "Second Age"
+        assert tv.year_start == 1600
+        assert tv.era_end is None
+        assert tv.source_passage_id == "p_001"
+
+    def test_alias_canonicalised_in_to_dict(self):
+        tv = TemporalValidity(era_start="TA", era_end="FA4")
+        d = tv.to_dict()
+        # Aliases should be resolved to canonical names in the dict
+        assert d["era_start"] == "Third Age"
+        assert d["era_end"] == "Fourth Age"
+
+
+# ---------------------------------------------------------------------------
+# Cypher WHERE fragment
+# ---------------------------------------------------------------------------
+
+class TestPointInTimeCypher:
+    def test_returns_non_empty_string(self):
+        fragment = point_in_time_cypher_where()
+        assert isinstance(fragment, str)
+        assert len(fragment) > 50
+
+    def test_contains_era_references(self):
+        fragment = point_in_time_cypher_where("r", "$era", "$year")
+        assert "era_start" in fragment
+        assert "era_end" in fragment
+        assert "$era" in fragment
+
+    def test_custom_aliases(self):
+        fragment = point_in_time_cypher_where("rel", "$myEra", "$myYear")
+        assert "rel.era_start" in fragment
+        assert "$myEra" in fragment
+        assert "$myYear" in fragment


### PR DESCRIPTION
## Summary

Implements issue #3 — every relationship in the graph now carries era/year validity so the graph can answer: *'What did character X know at story-time T?'*

## New: \graph/temporal.py\

- **ERA_ORDER** — canonical ordering: Before Time < Years of the Lamps < Years of the Trees < First Age < Second Age < Third Age < Fourth Age
- **\TemporalValidity\** dataclass with \is_valid_at(era, year)\ — checks both era bounds and year bounds within the same era
- **\canonicalize_era()\** — resolves aliases: \SA\ -> \Second Age\, \TA\ -> \Third Age\, etc.
- **\point_in_time_cypher_where()\** — returns a Cypher WHERE fragment for filtering relationships by era/year in graph queries

## Updated: Relationship models

\ExtractedRelationship\ and \RelationshipTriple\ now carry: \era_start\, \era_end\, \year_start\, \year_end\

## Updated: Graph writer

- \write_relationship\ / \write_relationships_batch\ — temporal fields written to all edges
- \init_era_chain()\ — creates Era nodes + FOLLOWED_BY chain in Neo4j (idempotent)
- \query_at_time(character, era, year)\ — returns full point-in-time snapshot

## New CLI commands

\\\ash
bga graph init-eras                                     # seed Era node chain
bga graph at-time -c Gandalf -e 'Third Age' -y 3018     # snapshot at a moment
bga graph stats                                          # now shows temporal coverage %
\\\

## Tests: 27/27 passing

Covers: era ordering, alias canonicalization, validity bounds, year filtering, edge cases, Cypher fragment generation, dict roundtrip.

## Part of
Master tracker: #1