### PR TITLE
feat: Invention Engine — Shadow Graph, Lore Incubator, Fog of War

### DIFF
--- a/src/book_graph_analyzer/generate/generator.py
+++ b/src/book_graph_analyzer/generate/generator.py
@@ -14,7 +14,35 @@ from .judge import NarrativeJudge
 
 class SceneGenerator:
     """Generates scenes grounded in Neo4j knowledge graph."""
-    
+
+    FOG_OF_WAR_PROMPT = '''You are writing a scene in the style of J.R.R. Tolkien.
+
+SETTING: {setting}
+CHARACTERS PRESENT: {characters}
+OBJECTS OF NOTE: {objects}
+
+WHAT THE CHARACTER KNOWS:
+{character_knowledge}
+
+SCENE GOAL: {scene_goal}
+
+WORLD RULES TO RESPECT:
+{world_rules}
+
+Write this scene from a position of UNCERTAINTY. The character does not know the history of
+this place or the nature of what they encounter. Write as Tolkien wrote Moria before the
+Fellowship knew what happened to Balin: let the atmosphere speak, let the architecture hint
+at past greatness or horror, let silence carry weight. Do not explain — suggest.
+
+Tolkien's style in scenes of mystery:
+- The landscape itself feels conscious and watching
+- Details are physical and sensory — cold stone, old smell, soundlessness
+- The character notices without understanding
+- Formal, measured prose; no modern psychological interiority
+- Dread or wonder conveyed through what is NOT said
+
+Write 400-800 words. Begin the scene directly, no preamble.'''
+
     GENERATION_PROMPT = '''You are writing a scene in the style of J.R.R. Tolkien.
 
 SETTING: {setting}
@@ -99,8 +127,15 @@ Keep the same general content and length, just fix the problems.'''
         characters: list[str],
         place: str,
         limit: int = 10,
+        fog_of_war: bool = False,
     ) -> dict:
-        """Query Neo4j for relevant context."""
+        """Query Neo4j for relevant context.
+
+        Args:
+            fog_of_war: When True, only fetch the physical description of the place.
+                Character histories and event records are withheld — the LLM writes
+                from the character's limited, ground-level perspective.
+        """
         context = {
             "characters": [],
             "place": None,
@@ -113,7 +148,7 @@ Keep the same general content and length, just fix the problems.'''
             return context
         
         with self.driver.session() as session:
-            # Get character info
+            # In fog_of_war mode: omit character history — just their names/races
             for char_name in characters:
                 result = session.run("""
                     MATCH (c:Character)
@@ -125,14 +160,23 @@ Keep the same general content and length, just fix the problems.'''
                 """, name=char_name)
                 record = result.single()
                 if record:
-                    context["characters"].append({
-                        "name": record["name"],
-                        "type": record["type"],
-                        "description": record["desc"],
-                        "relations": record["relations"],
-                    })
+                    if fog_of_war:
+                        # Strip relational/historical context
+                        context["characters"].append({
+                            "name": record["name"],
+                            "type": record["type"],
+                            "description": None,
+                            "relations": [],
+                        })
+                    else:
+                        context["characters"].append({
+                            "name": record["name"],
+                            "type": record["type"],
+                            "description": record["desc"],
+                            "relations": record["relations"],
+                        })
             
-            # Get place info
+            # Place: always fetch physical description
             if place:
                 result = session.run("""
                     MATCH (p:Place)
@@ -148,8 +192,8 @@ Keep the same general content and length, just fix the problems.'''
                         "region": record["region"],
                     }
             
-            # Get recent events involving these characters
-            if characters:
+            # Events: withheld entirely in fog_of_war mode
+            if characters and not fog_of_war:
                 result = session.run("""
                     MATCH (e:Event)
                     WHERE any(c IN $characters WHERE toLower(e.agent) CONTAINS toLower(c))
@@ -163,6 +207,24 @@ Keep the same general content and length, just fix the problems.'''
                 ]
         
         return context
+
+    def _build_character_knowledge(
+        self,
+        characters: list[str],
+        previous_context: str,
+    ) -> str:
+        """
+        For Fog of War mode: what does the character actually know?
+        Only their personal history from the scene summaries — nothing omniscient.
+        """
+        lines = []
+        if previous_context:
+            lines.append(f"What has happened so far (from the character's perspective):")
+            lines.append(previous_context.strip())
+        else:
+            lines.append(f"{', '.join(characters)} approach this place knowing only what they have witnessed on their journey.")
+            lines.append("They know nothing of this location's history.")
+        return "\n".join(lines)
     
     def get_world_rules(self, categories: list[str] = None) -> str:
         """Get relevant world bible rules as text."""
@@ -184,11 +246,21 @@ Keep the same general content and length, just fix the problems.'''
         place: str,
         previous_context: str = "",
         objects: list[str] = None,
+        fog_of_war: bool = False,
     ) -> Scene:
-        """Generate a scene with full pipeline."""
+        """Generate a scene with full pipeline.
+
+        Args:
+            fog_of_war: When True, restricts context to physical place description only.
+                The characters know nothing of the location's history. The LLM writes
+                from a position of uncertainty — producing naturally ominous, mysterious prose.
+                Use for: entering Moria, approaching a ruined city, Fog-filled valleys.
+        """
         
-        # 1. Get context from Neo4j
-        neo4j_context = self.get_context_from_neo4j(characters, place)
+        # 1. Get context from Neo4j (restricted in fog_of_war mode)
+        neo4j_context = self.get_context_from_neo4j(
+            characters, place, fog_of_war=fog_of_war
+        )
         
         # Format context for prompt
         char_descriptions = []
@@ -215,14 +287,29 @@ Keep the same general content and length, just fix the problems.'''
             )
         
         # 2. Generate initial scene
-        prompt = self.GENERATION_PROMPT.format(
-            setting=place_desc or place,
-            characters="\n".join(char_descriptions) or ", ".join(characters),
-            objects=", ".join(objects or []) or "None specified",
-            previous_context=previous_context or events_text or "Beginning of story",
-            scene_goal=scene_goal,
-            world_rules=self.get_world_rules(),
-        )
+        if fog_of_war:
+            # Fog of War: character only knows their own situation and the physical place.
+            # No history, no events, no omniscient context — pure sensory grounding.
+            character_knowledge = self._build_character_knowledge(
+                characters, previous_context
+            )
+            prompt = self.FOG_OF_WAR_PROMPT.format(
+                setting=place_desc or place,
+                characters="\n".join(char_descriptions) or ", ".join(characters),
+                objects=", ".join(objects or []) or "None specified",
+                character_knowledge=character_knowledge,
+                scene_goal=scene_goal,
+                world_rules=self.get_world_rules(),
+            )
+        else:
+            prompt = self.GENERATION_PROMPT.format(
+                setting=place_desc or place,
+                characters="\n".join(char_descriptions) or ", ".join(characters),
+                objects=", ".join(objects or []) or "None specified",
+                previous_context=previous_context or events_text or "Beginning of story",
+                scene_goal=scene_goal,
+                world_rules=self.get_world_rules(),
+            )
         
         scene_text = self.llm.generate(prompt, temperature=self.config.temperature)
         

--- a/src/book_graph_analyzer/generate/incubator.py
+++ b/src/book_graph_analyzer/generate/incubator.py
@@ -1,0 +1,420 @@
+"""Lore Incubator — pre-drafting invention engine.
+
+Runs BEFORE the Outliner generates a chapter. Invents new entities
+(characters, locations, artifacts) to populate whitespace gaps in the
+canonical record, then commits them to the Shadow Graph as local canon.
+
+The key principle: separate INVENTION from PROSE-WRITING.
+The Drafter never has to be creative — it just executes the Shadow Graph's facts.
+"""
+
+import json
+import random
+import re
+from dataclasses import dataclass, field
+from typing import Optional
+
+from ..llm import LLMClient
+from .shadow.graph import ShadowGraph
+
+
+# ─── Trope Dictionary ────────────────────────────────────────────────────────
+
+class TropeDictionary:
+    """
+    Built-in mythic trope seeds.
+
+    Tolkien's "serendipitous" moments weren't random — they were deep
+    structural patterns from mythology. Injecting one trope per chapter
+    gives the LLM a narrative skeleton to build toward, producing moments
+    that feel inevitable in retrospect.
+    """
+
+    TROPES: list[dict] = [
+        {
+            "name": "The Relic in the Dark",
+            "description": (
+                "The protagonist falls or is trapped in a dark, enclosed place. "
+                "While there, they discover a forgotten item of power that will aid them later."
+            ),
+            "required_elements": ["dark_enclosed_place", "ancient_item"],
+            "scene_type_hint": "discovery",
+            "tolkien_examples": [
+                "Bilbo finds the One Ring in Gollum's cave",
+                "The Fellowship discovers Balin's tomb in Moria",
+            ],
+        },
+        {
+            "name": "The Threshold Guardian",
+            "description": (
+                "A figure — hostile, wise, or both — blocks the path and must be "
+                "confronted, bargained with, or outwitted before progress can continue."
+            ),
+            "required_elements": ["obstacle_figure", "threshold_location"],
+            "scene_type_hint": "council",
+            "tolkien_examples": [
+                "The Balrog at the Bridge of Khazad-dûm",
+                "Tom Bombadil in the Old Forest",
+                "Haldir at the borders of Lórien",
+            ],
+        },
+        {
+            "name": "The Hidden Valley",
+            "description": (
+                "A secret, protected place is revealed to the protagonist — a refuge "
+                "that exists outside normal geography, accessible only to the worthy."
+            ),
+            "required_elements": ["hidden_entrance", "protected_interior"],
+            "scene_type_hint": "discovery",
+            "tolkien_examples": [
+                "The revelation of Rivendell",
+                "The first sight of Gondolin from the Dry River",
+                "Lothlórien seen from the Nimrodel",
+            ],
+        },
+        {
+            "name": "Eucatastrophe",
+            "description": (
+                "At the moment of greatest despair, an entirely unexpected turn "
+                "reverses fortune — a sudden, joyous salvation the protagonist did not engineer."
+            ),
+            "required_elements": ["crisis_point", "unexpected_salvation"],
+            "scene_type_hint": "battle",
+            "tolkien_examples": [
+                "The Eagles at the Battle of Morannon",
+                "Gollum's fall destroying the Ring",
+                "The Rohirrim arriving at the Pelennor",
+            ],
+        },
+        {
+            "name": "The Reluctant Guide",
+            "description": (
+                "A morally ambiguous or unwilling figure leads the protagonist through "
+                "danger they could not navigate alone — their motives are unclear but necessary."
+            ),
+            "required_elements": ["guide_figure", "dangerous_path"],
+            "scene_type_hint": "journey",
+            "tolkien_examples": [
+                "Gollum leading Frodo and Sam to Mordor",
+                "Strider revealing himself at Bree",
+            ],
+        },
+        {
+            "name": "The Divine Messenger",
+            "description": (
+                "A figure of divine or Maia origin appears — often in disguise — "
+                "to deliver a task, warning, or gift that sets the protagonist on their path."
+            ),
+            "required_elements": ["messenger_figure", "sacred_instruction"],
+            "scene_type_hint": "myth_cosmogony",
+            "tolkien_examples": [
+                "Ulmo appears to Tuor at Vinyamar",
+                "Gandalf's true nature as a Maia revealed",
+                "The vision of Manwë given to Frodo on Amon Hen",
+            ],
+        },
+        {
+            "name": "The Corrupted Place",
+            "description": (
+                "A location that was once fair is now twisted. Its history of evil "
+                "is written in the landscape — beauty and ruin coexist, and the past speaks."
+            ),
+            "required_elements": ["ruined_location", "history_of_evil"],
+            "scene_type_hint": "journey",
+            "tolkien_examples": [
+                "Mordor (once a fair valley before Sauron came)",
+                "Dol Guldur in the dark wood",
+                "Angband beneath the Iron Mountains",
+            ],
+        },
+        {
+            "name": "The Last of Their Kind",
+            "description": (
+                "The protagonist encounters the sole survivor of a vanished people or "
+                "order, who carries irreplaceable knowledge — and unbearable grief."
+            ),
+            "required_elements": ["survivor_figure", "lost_people_or_order"],
+            "scene_type_hint": "personal_dialogue",
+            "tolkien_examples": [
+                "Treebeard as the last speaking tree",
+                "A lone Noldor lord in a ruined city of the First Age",
+            ],
+        },
+    ]
+
+    def select_trope(self, chapter_beat: str = "", used_tropes: list[str] = None) -> dict:
+        """
+        Select an appropriate trope for the given chapter beat.
+        Avoids repeating recently used tropes.
+        """
+        used = set(used_tropes or [])
+        available = [t for t in self.TROPES if t["name"] not in used]
+
+        if not available:
+            # All tropes used — reset pool
+            available = self.TROPES
+
+        # Simple keyword match to prefer contextually appropriate tropes
+        if chapter_beat:
+            beat_lower = chapter_beat.lower()
+            scored = []
+            for trope in available:
+                score = 0
+                hint = trope.get("scene_type_hint", "")
+                # Rough keyword matching
+                if hint == "battle" and any(w in beat_lower for w in ["battle", "fight", "attack", "flee", "danger"]):
+                    score += 2
+                elif hint == "journey" and any(w in beat_lower for w in ["travel", "journey", "road", "path", "wilderness"]):
+                    score += 2
+                elif hint == "discovery" and any(w in beat_lower for w in ["find", "discover", "reveal", "ruin", "ancient"]):
+                    score += 2
+                elif hint == "council" and any(w in beat_lower for w in ["speak", "counsel", "meet", "parley", "gate"]):
+                    score += 2
+                scored.append((score, trope))
+
+            scored.sort(key=lambda x: x[0], reverse=True)
+            # Pick from top candidates with some randomness
+            top_score = scored[0][0]
+            top_candidates = [t for s, t in scored if s >= top_score]
+            return random.choice(top_candidates)
+
+        return random.choice(available)
+
+    def get_all(self) -> list[dict]:
+        return self.TROPES
+
+
+# ─── Incubation result ───────────────────────────────────────────────────────
+
+@dataclass
+class IncubationResult:
+    """Output of a single Lore Incubator run."""
+    invented_entities: list[dict] = field(default_factory=list)
+    narrative_seeds: list[str] = field(default_factory=list)
+    trope_used: dict = field(default_factory=dict)
+    raw_response: str = ""
+
+    def summary(self) -> str:
+        lines = [f"Trope: {self.trope_used.get('name', 'None')}"]
+        for entity in self.invented_entities:
+            lines.append(f"  [{entity.get('type')}] {entity.get('name')}: {entity.get('description', '')[:80]}")
+        if self.narrative_seeds:
+            lines.append("Seeds:")
+            for seed in self.narrative_seeds:
+                lines.append(f"  - {seed}")
+        return "\n".join(lines)
+
+
+# ─── Lore Incubator ──────────────────────────────────────────────────────────
+
+_INVENTION_PROMPT = """You are a sub-creator working in J.R.R. Tolkien's legendarium.
+
+A character is traveling through uncharted territory. Your task is NOT to write prose.
+Your task is to INVENT new lore entities that will populate this whitespace.
+
+JOURNEY CONTEXT:
+{journey_context}
+
+WHITESPACE DESCRIPTION:
+{whitespace_description}
+
+WORLD BIBLE CONSTRAINTS (all invented entities must comply):
+{world_bible_rules}
+
+TROPE SEED (incorporate this structural element):
+Name: {trope_name}
+Description: {trope_description}
+Required elements: {trope_required}
+
+EXISTING SHADOW CANON (do not duplicate these):
+{existing_shadow_entities}
+
+Invent EXACTLY these entity types:
+1. One MINOR_CHARACTER (a living being — mortal, Elf, creature, or spirit)
+2. One RUINED_LOCATION (a named place with tragic or mysterious history)
+3. One ARTIFACT (a named object with First or Second Age provenance)
+
+Naming conventions:
+- Elven characters/places: Sindarin or Quenya roots (e.g., Cabed, Tol, Annon, Esgal, Dol, Bar)
+- Mannish characters/places: Anglo-Saxon or Norse roots (e.g., Helm, Beorn, Aldburg, Wulf)
+- Artifacts: evocative compound names (e.g., Mornbrand, Aeglos-minor, Caladring)
+
+All entities must:
+- Have a tragic or mysterious history consistent with the Age
+- Connect thematically to the trope seed
+- Never contradict the World Bible rules
+
+Return ONLY valid JSON (no markdown fences, no preamble):
+{{
+  "invented_entities": [
+    {{
+      "type": "MINOR_CHARACTER",
+      "name": "...",
+      "race": "...",
+      "description": "...",
+      "tragic_history": "...",
+      "role_in_story": "...",
+      "trope_connection": "..."
+    }},
+    {{
+      "type": "RUINED_LOCATION",
+      "name": "...",
+      "region": "...",
+      "description": "...",
+      "former_purpose": "...",
+      "how_it_fell": "...",
+      "what_remains": "..."
+    }},
+    {{
+      "type": "ARTIFACT",
+      "name": "...",
+      "material": "...",
+      "description": "...",
+      "age_of_origin": "...",
+      "tragic_history": "...",
+      "power_or_property": "...",
+      "trope_connection": "..."
+    }}
+  ],
+  "narrative_seeds": [
+    "One sentence: how the MINOR_CHARACTER enters the story",
+    "One sentence: how the RUINED_LOCATION is discovered",
+    "One sentence: how the ARTIFACT is found (tied to the trope seed)"
+  ]
+}}"""
+
+
+class LoreIncubator:
+    """
+    Pre-drafting invention phase.
+
+    Runs before the Outliner generates chapter beats. Invents new entities
+    — minor characters, ruined locations, artifacts — and commits them to
+    the Shadow Graph as local canon before the Drafter ever sees a prompt.
+
+    The key insight: you give the LLM explicit *permission* to invent new
+    things here. This is the only place in the pipeline where hallucination
+    is the desired outcome.
+    """
+
+    def __init__(
+        self,
+        shadow_graph: ShadowGraph,
+        world_bible=None,
+        llm_client: Optional[LLMClient] = None,
+    ):
+        self.shadow_graph = shadow_graph
+        self.world_bible = world_bible
+        self.llm = llm_client or LLMClient()
+        self.tropes = TropeDictionary()
+        self._used_tropes: list[str] = []
+
+    def incubate(
+        self,
+        journey_context: str,
+        whitespace_description: str,
+        trope: dict = None,
+        entity_types: list[str] = None,  # Future: override default 3-type set
+    ) -> IncubationResult:
+        """
+        Run the invention phase for a chapter.
+
+        Args:
+            journey_context: e.g. "Tuor traveling from Nevrast to Gondolin"
+            whitespace_description: e.g. "400-mile gap of unnamed wilderness between coastal cliffs and the Echoriath"
+            trope: Override the auto-selected trope (from TropeDictionary)
+            entity_types: Override the entity types to invent (default: CHARACTER, LOCATION, ARTIFACT)
+
+        Returns:
+            IncubationResult with invented entities and narrative seeds
+        """
+        selected_trope = trope or self.tropes.select_trope(
+            chapter_beat=whitespace_description,
+            used_tropes=self._used_tropes,
+        )
+
+        world_rules = self._get_world_bible_rules()
+        existing_entities = self._get_existing_entity_names()
+
+        prompt = _INVENTION_PROMPT.format(
+            journey_context=journey_context,
+            whitespace_description=whitespace_description,
+            world_bible_rules=world_rules,
+            trope_name=selected_trope["name"],
+            trope_description=selected_trope["description"],
+            trope_required=", ".join(selected_trope.get("required_elements", [])),
+            existing_shadow_entities=existing_entities or "None yet.",
+        )
+
+        try:
+            response = self.llm.generate(prompt, temperature=0.85)
+            data = self._parse_response(response)
+
+            result = IncubationResult(
+                invented_entities=data.get("invented_entities", []),
+                narrative_seeds=data.get("narrative_seeds", []),
+                trope_used=selected_trope,
+                raw_response=response,
+            )
+
+            # Track used tropes to avoid repeats
+            self._used_tropes.append(selected_trope["name"])
+
+            return result
+
+        except Exception as e:
+            print(f"[LoreIncubator] Warning: incubation failed: {e}")
+            return IncubationResult(trope_used=selected_trope, raw_response="")
+
+    def commit_to_shadow(self, result: IncubationResult, scene_id: str = "incubation") -> None:
+        """
+        Write all invented entities to the Shadow Graph.
+        After this call, the Drafter treats them as immutable local canon.
+        """
+        for entity in result.invented_entities:
+            self.shadow_graph.commit_invented_entity(entity, scene_id)
+
+    def incubate_and_commit(
+        self,
+        journey_context: str,
+        whitespace_description: str,
+        chapter_id: str = "pre-draft",
+    ) -> IncubationResult:
+        """Convenience: incubate + commit in one call."""
+        result = self.incubate(journey_context, whitespace_description)
+        self.commit_to_shadow(result, scene_id=chapter_id)
+        return result
+
+    # ─── Helpers ─────────────────────────────────────────────────────────────
+
+    def _get_world_bible_rules(self, max_rules: int = 15) -> str:
+        if not self.world_bible:
+            return "No world bible loaded — invent freely but keep within Tolkien's First Age conventions."
+
+        rules = []
+        for category, rule_list in self.world_bible.rules.items():
+            for rule in rule_list[:3]:  # Sample from each category
+                rules.append(f"[{category.value}] {rule.title}: {rule.description[:120]}")
+                if len(rules) >= max_rules:
+                    break
+            if len(rules) >= max_rules:
+                break
+
+        return "\n".join(rules) if rules else "No rules found."
+
+    def _get_existing_entity_names(self) -> str:
+        entities = self.shadow_graph.get_invented_entities()
+        if not entities:
+            return ""
+        return ", ".join(f"{e.name} ({e.type})" for e in entities[:20])
+
+    def _parse_response(self, response: str) -> dict:
+        """Extract JSON from LLM response, handling various formats."""
+        # Strip markdown fences if present
+        response = re.sub(r'```(?:json)?\s*', '', response).strip()
+
+        json_match = re.search(r'\{[\s\S]*\}', response)
+        if not json_match:
+            raise ValueError("No JSON object found in incubator response")
+
+        return json.loads(json_match.group())

--- a/src/book_graph_analyzer/generate/shadow/__init__.py
+++ b/src/book_graph_analyzer/generate/shadow/__init__.py
@@ -1,0 +1,6 @@
+"""Shadow Graph — mutable story state tracking for generated novels."""
+
+from .graph import ShadowGraph
+from .models import CharacterState, SceneState, StateDelta, InventedEntity
+
+__all__ = ["ShadowGraph", "CharacterState", "SceneState", "StateDelta", "InventedEntity"]

--- a/src/book_graph_analyzer/generate/shadow/graph.py
+++ b/src/book_graph_analyzer/generate/shadow/graph.py
@@ -1,0 +1,414 @@
+"""Shadow Graph — Neo4j-backed mutable story state for a generated novel.
+
+Uses Shadow_* label namespace to stay completely separate from canonical lore.
+All nodes are scoped to a story_id so multiple stories can run in parallel.
+"""
+
+import json
+import re
+from typing import Optional
+
+from ...llm import LLMClient
+from ...graph.connection import get_driver
+from .models import CharacterState, InventedEntity, SceneState, StateDelta
+
+
+# ─── Cypher helpers ──────────────────────────────────────────────────────────
+
+_MERGE_CHARACTER = """
+MERGE (c:Shadow_Character {name: $name, story_id: $story_id})
+RETURN c
+"""
+
+_SET_LOCATION = """
+MATCH (c:Shadow_Character {name: $name, story_id: $story_id})
+MERGE (p:Shadow_Place {name: $location, story_id: $story_id})
+MERGE (c)-[:LOCATED_AT]->(p)
+"""
+
+_ADD_POSSESSION = """
+MATCH (c:Shadow_Character {name: $name, story_id: $story_id})
+MERGE (o:Shadow_Object {name: $item, story_id: $story_id})
+MERGE (c)-[:POSSESSES {acquired_in_scene: $scene_id}]->(o)
+"""
+
+_REMOVE_POSSESSION = """
+MATCH (c:Shadow_Character {name: $name, story_id: $story_id})-[r:POSSESSES]->(o:Shadow_Object {name: $item, story_id: $story_id})
+DELETE r
+"""
+
+_ADD_CONDITION = """
+MATCH (c:Shadow_Character {name: $name, story_id: $story_id})
+MERGE (cond:Shadow_Condition {value: $condition, story_id: $story_id})
+MERGE (c)-[:HAS_CONDITION {last_updated_scene: $scene_id}]->(cond)
+"""
+
+_REMOVE_CONDITION = """
+MATCH (c:Shadow_Character {name: $name, story_id: $story_id})-[r:HAS_CONDITION]->(cond:Shadow_Condition {value: $condition, story_id: $story_id})
+DELETE r
+"""
+
+_RECORD_SCENE = """
+MERGE (s:Shadow_Scene {id: $scene_id, story_id: $story_id})
+SET s.summary = $summary, s.chapter_num = $chapter_num, s.scene_num = $scene_num
+WITH s
+OPTIONAL MATCH (p:Shadow_Place {name: $place, story_id: $story_id})
+FOREACH (x IN CASE WHEN p IS NOT NULL THEN [1] ELSE [] END |
+    MERGE (s)-[:OCCURRED_AT]->(p)
+)
+"""
+
+_LINK_CHARACTER_SCENE = """
+MATCH (c:Shadow_Character {name: $name, story_id: $story_id})
+MATCH (s:Shadow_Scene {id: $scene_id, story_id: $story_id})
+MERGE (s)-[:INVOLVED]->(c)
+"""
+
+_MERGE_INVENTED_ENTITY = """
+MERGE (e:Shadow_Entity {name: $name, story_id: $story_id})
+SET e.type = $type,
+    e.description = $description,
+    e.scene_id = $scene_id,
+    e.properties = $properties
+"""
+
+_GET_CHARACTER = """
+MATCH (c:Shadow_Character {name: $name, story_id: $story_id})
+OPTIONAL MATCH (c)-[:LOCATED_AT]->(p:Shadow_Place)
+OPTIONAL MATCH (c)-[:POSSESSES]->(o:Shadow_Object)
+OPTIONAL MATCH (c)-[:HAS_CONDITION]->(cond:Shadow_Condition)
+RETURN c.name as name,
+       p.name as location,
+       collect(DISTINCT o.name) as possessions,
+       collect(DISTINCT cond.value) as conditions
+"""
+
+_GET_RECENT_SUMMARIES = """
+MATCH (s:Shadow_Scene {story_id: $story_id})
+WHERE s.summary IS NOT NULL AND s.summary <> ""
+RETURN s.summary, s.chapter_num, s.scene_num
+ORDER BY s.chapter_num, s.scene_num DESC
+LIMIT 3
+"""
+
+_GET_INVENTED_ENTITIES = """
+MATCH (e:Shadow_Entity {story_id: $story_id})
+WHERE $type IS NULL OR e.type = $type
+RETURN e.name as name, e.type as type, e.description as description,
+       e.scene_id as scene_id, e.properties as properties
+"""
+
+_DELETE_STORY = """
+MATCH (n)
+WHERE n.story_id = $story_id
+  AND any(label IN labels(n) WHERE label STARTS WITH 'Shadow_')
+DETACH DELETE n
+"""
+
+
+# ─── State delta extraction prompt ───────────────────────────────────────────
+
+_EXTRACT_DELTA_PROMPT = """Extract structured state changes from this scene.
+
+SCENE TEXT:
+\"\"\"{scene_text}\"\"\"
+
+CHARACTERS IN SCENE: {characters}
+
+For each character, identify:
+- location_change: where they are now (null if unchanged / unclear)
+- possessions_gained: items they picked up, received, or now carry
+- possessions_lost: items they dropped, gave away, or lost
+- conditions_added: new physical/mental states (weary, injured, afraid, resolute, etc.)
+- conditions_removed: states that have resolved
+
+Also identify any NEW named entities introduced in the scene:
+- Named characters (minor)
+- Named locations
+- Named artifacts or objects
+
+Return ONLY valid JSON:
+{{
+  "characters": {{
+    "<name>": {{
+      "location_change": "<place name or null>",
+      "possessions_gained": ["<item>"],
+      "possessions_lost": ["<item>"],
+      "conditions_added": ["<condition>"],
+      "conditions_removed": ["<condition>"]
+    }}
+  }},
+  "new_entities": [
+    {{
+      "type": "MINOR_CHARACTER | RUINED_LOCATION | ARTIFACT | PLACE",
+      "name": "<name>",
+      "description": "<one sentence>"
+    }}
+  ],
+  "scene_summary": "<one sentence summary of what happened>"
+}}"""
+
+
+class ShadowGraph:
+    """
+    Mutable story-state graph stored in Neo4j under Shadow_* labels.
+
+    Tracks what is TRUE in the GENERATED novel — separate from Tolkien canon.
+    All nodes are scoped to a story_id for clean multi-story isolation.
+    """
+
+    def __init__(self, story_id: str, driver=None):
+        self.story_id = story_id
+        self._driver = driver or get_driver()
+        self._llm = LLMClient()
+
+    # ─── Write operations ────────────────────────────────────────────────────
+
+    def commit_state_delta(self, delta: StateDelta) -> None:
+        """Write a StateDelta to Neo4j. Non-blocking on failure."""
+        if not self._driver:
+            return
+
+        try:
+            with self._driver.session() as session:
+                for char_name, updates in delta.character_updates.items():
+                    # Ensure character node exists
+                    session.run(_MERGE_CHARACTER, name=char_name, story_id=self.story_id)
+
+                    if updates.get("location_change"):
+                        session.run(_SET_LOCATION, name=char_name,
+                                    story_id=self.story_id,
+                                    location=updates["location_change"])
+
+                    for item in updates.get("possessions_gained", []):
+                        session.run(_ADD_POSSESSION, name=char_name,
+                                    story_id=self.story_id,
+                                    item=item, scene_id=delta.scene_id)
+
+                    for item in updates.get("possessions_lost", []):
+                        session.run(_REMOVE_POSSESSION, name=char_name,
+                                    story_id=self.story_id, item=item)
+
+                    for cond in updates.get("conditions_added", []):
+                        session.run(_ADD_CONDITION, name=char_name,
+                                    story_id=self.story_id,
+                                    condition=cond, scene_id=delta.scene_id)
+
+                    for cond in updates.get("conditions_removed", []):
+                        session.run(_REMOVE_CONDITION, name=char_name,
+                                    story_id=self.story_id, condition=cond)
+
+                # Record the scene node
+                primary_char = next(iter(delta.character_updates), None)
+                primary_location = None
+                if primary_char:
+                    primary_location = delta.character_updates[primary_char].get("location_change")
+
+                session.run(_RECORD_SCENE,
+                            scene_id=delta.scene_id,
+                            story_id=self.story_id,
+                            summary=delta.scene_summary,
+                            chapter_num=delta.chapter_num,
+                            scene_num=delta.scene_num,
+                            place=primary_location or "")
+
+                for char_name in delta.character_updates:
+                    session.run(_LINK_CHARACTER_SCENE,
+                                name=char_name, story_id=self.story_id,
+                                scene_id=delta.scene_id)
+
+                # Commit any invented entities in this delta
+                for entity in delta.invented_entities:
+                    self.commit_invented_entity(entity, delta.scene_id)
+
+        except Exception as e:
+            # Non-blocking: log and continue — never crash scene generation
+            print(f"[ShadowGraph] Warning: state commit failed for scene {delta.scene_id}: {e}")
+
+    def commit_invented_entity(self, entity: dict, scene_id: str) -> None:
+        """
+        Write an invented entity to the Shadow Graph as local canon.
+        Once committed, the Drafter treats it as immutable fact.
+        """
+        if not self._driver:
+            return
+
+        try:
+            properties = {k: v for k, v in entity.items()
+                          if k not in ("type", "name", "description")}
+            with self._driver.session() as session:
+                session.run(
+                    _MERGE_INVENTED_ENTITY,
+                    name=entity.get("name", "Unknown"),
+                    story_id=self.story_id,
+                    type=entity.get("type", "UNKNOWN"),
+                    description=entity.get("description", ""),
+                    scene_id=scene_id,
+                    properties=json.dumps(properties),
+                )
+        except Exception as e:
+            print(f"[ShadowGraph] Warning: entity commit failed: {e}")
+
+    # ─── Read operations ─────────────────────────────────────────────────────
+
+    def get_character_state(self, character_name: str) -> Optional[CharacterState]:
+        """Return current location, possessions, and conditions for a character."""
+        if not self._driver:
+            return None
+
+        try:
+            with self._driver.session() as session:
+                result = session.run(_GET_CHARACTER,
+                                     name=character_name, story_id=self.story_id)
+                record = result.single()
+                if not record:
+                    return None
+
+                return CharacterState(
+                    name=record["name"],
+                    story_id=self.story_id,
+                    location=record["location"],
+                    possessions=[p for p in record["possessions"] if p],
+                    conditions=[c for c in record["conditions"] if c],
+                )
+        except Exception as e:
+            print(f"[ShadowGraph] Warning: character query failed: {e}")
+            return None
+
+    def get_scene_state(self, characters: list[str], place: str) -> SceneState:
+        """
+        Assemble a full SceneState for the context assembler.
+        Queries character states, recent summaries, and invented entities.
+        """
+        char_states = []
+        for name in characters:
+            state = self.get_character_state(name)
+            if state:
+                char_states.append(state)
+            else:
+                # Character not yet in Shadow Graph — return a blank state
+                char_states.append(CharacterState(
+                    name=name,
+                    story_id=self.story_id,
+                ))
+
+        summaries = self._get_recent_summaries()
+        invented = self.get_invented_entities()
+
+        return SceneState(
+            characters=char_states,
+            recent_summaries=summaries,
+            invented_entities=invented,
+        )
+
+    def get_invented_entities(self, entity_type: str = None) -> list[InventedEntity]:
+        """Return all shadow-canon entities, optionally filtered by type."""
+        if not self._driver:
+            return []
+
+        try:
+            with self._driver.session() as session:
+                result = session.run(_GET_INVENTED_ENTITIES,
+                                     story_id=self.story_id, type=entity_type)
+                entities = []
+                for record in result:
+                    props = {}
+                    if record["properties"]:
+                        try:
+                            props = json.loads(record["properties"])
+                        except (json.JSONDecodeError, TypeError):
+                            pass
+                    entities.append(InventedEntity(
+                        type=record["type"],
+                        name=record["name"],
+                        description=record["description"],
+                        story_id=self.story_id,
+                        scene_id=record["scene_id"] or "",
+                        properties=props,
+                    ))
+                return entities
+        except Exception as e:
+            print(f"[ShadowGraph] Warning: entity query failed: {e}")
+            return []
+
+    def _get_recent_summaries(self, limit: int = 3) -> list[str]:
+        if not self._driver:
+            return []
+
+        try:
+            with self._driver.session() as session:
+                result = session.run(_GET_RECENT_SUMMARIES, story_id=self.story_id)
+                return [r["s.summary"] for r in result if r["s.summary"]]
+        except Exception as e:
+            print(f"[ShadowGraph] Warning: summary query failed: {e}")
+            return []
+
+    # ─── Extraction ──────────────────────────────────────────────────────────
+
+    def extract_delta_from_scene(
+        self,
+        scene_text: str,
+        characters: list[str],
+        scene_id: str,
+        chapter_num: int = 0,
+        scene_num: int = 0,
+    ) -> StateDelta:
+        """
+        Ask the LLM to extract a StateDelta from a generated scene.
+        Falls back gracefully to an empty delta on parse failure.
+        """
+        prompt = _EXTRACT_DELTA_PROMPT.format(
+            scene_text=scene_text[:3000],  # Limit to avoid overflow
+            characters=", ".join(characters),
+        )
+
+        try:
+            response = self._llm.generate(prompt, temperature=0.1)
+            json_match = re.search(r'\{[\s\S]*\}', response)
+            if not json_match:
+                raise ValueError("No JSON in response")
+
+            data = json.loads(json_match.group())
+
+            character_updates = {}
+            for char_name, updates in data.get("characters", {}).items():
+                character_updates[char_name] = {
+                    "location_change": updates.get("location_change"),
+                    "possessions_gained": updates.get("possessions_gained", []),
+                    "possessions_lost": updates.get("possessions_lost", []),
+                    "conditions_added": updates.get("conditions_added", []),
+                    "conditions_removed": updates.get("conditions_removed", []),
+                }
+
+            return StateDelta(
+                story_id=self.story_id,
+                scene_id=scene_id,
+                character_updates=character_updates,
+                invented_entities=data.get("new_entities", []),
+                scene_summary=data.get("scene_summary", ""),
+                chapter_num=chapter_num,
+                scene_num=scene_num,
+            )
+
+        except Exception as e:
+            print(f"[ShadowGraph] Warning: delta extraction failed, using empty delta: {e}")
+            return StateDelta(
+                story_id=self.story_id,
+                scene_id=scene_id,
+                chapter_num=chapter_num,
+                scene_num=scene_num,
+            )
+
+    # ─── Maintenance ─────────────────────────────────────────────────────────
+
+    def reset_story(self) -> None:
+        """Delete all Shadow_* nodes for this story_id. Irreversible."""
+        if not self._driver:
+            return
+
+        try:
+            with self._driver.session() as session:
+                session.run(_DELETE_STORY, story_id=self.story_id)
+            print(f"[ShadowGraph] Story {self.story_id} state cleared.")
+        except Exception as e:
+            print(f"[ShadowGraph] Warning: reset failed: {e}")

--- a/src/book_graph_analyzer/generate/shadow/models.py
+++ b/src/book_graph_analyzer/generate/shadow/models.py
@@ -1,0 +1,99 @@
+"""Data models for Shadow Graph story state."""
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+@dataclass
+class InventedEntity:
+    """A new lore entity created by the Incubator — local canon for this story."""
+    type: str               # MINOR_CHARACTER, RUINED_LOCATION, ARTIFACT
+    name: str
+    description: str
+    story_id: str
+    scene_id: str           # Scene in which this entity was introduced
+    properties: dict = field(default_factory=dict)  # type-specific fields
+
+    def to_dict(self) -> dict:
+        return {
+            "type": self.type,
+            "name": self.name,
+            "description": self.description,
+            "story_id": self.story_id,
+            "scene_id": self.scene_id,
+            "properties": self.properties,
+        }
+
+
+@dataclass
+class CharacterState:
+    """Current state of a character in the generated story."""
+    name: str
+    story_id: str
+    location: Optional[str] = None
+    possessions: list[str] = field(default_factory=list)
+    conditions: list[str] = field(default_factory=list)  # e.g. ["weary", "injured_left_arm"]
+    last_scene: str = ""
+
+    def to_prompt_fragment(self) -> str:
+        parts = [f"{self.name}"]
+        if self.location:
+            parts.append(f"located in {self.location}")
+        if self.possessions:
+            parts.append(f"carries: {', '.join(self.possessions)}")
+        if self.conditions:
+            parts.append(f"condition: {', '.join(self.conditions)}")
+        return ". ".join(parts) + "."
+
+
+@dataclass
+class SceneState:
+    """Full assembled current state fed to scene generation."""
+    characters: list[CharacterState] = field(default_factory=list)
+    recent_summaries: list[str] = field(default_factory=list)       # Last 3 scene summaries
+    invented_entities: list[InventedEntity] = field(default_factory=list)  # Shadow-canon entities
+
+    def to_prompt_block(self) -> str:
+        """
+        Compact, LLM-readable current-state block.
+        Kept under ~400 tokens by design.
+        """
+        lines = []
+
+        if self.characters:
+            lines.append("CURRENT STATE:")
+            for ch in self.characters:
+                lines.append(f"  - {ch.to_prompt_fragment()}")
+
+        if self.recent_summaries:
+            lines.append("\nRECENT EVENTS (last scenes):")
+            for summary in self.recent_summaries[-3:]:
+                lines.append(f"  - {summary}")
+
+        if self.invented_entities:
+            lines.append("\nESTABLISHED (local canon for this story):")
+            for entity in self.invented_entities:
+                lines.append(f"  - [{entity.type}] {entity.name}: {entity.description[:100]}")
+
+        return "\n".join(lines)
+
+
+@dataclass
+class StateDelta:
+    """
+    Structured state changes extracted from a generated scene.
+    Written to the Shadow Graph after every scene.
+    """
+    story_id: str
+    scene_id: str
+
+    # {character_name: {location, possessions_gained, possessions_lost, conditions_added, conditions_removed}}
+    character_updates: dict[str, dict] = field(default_factory=dict)
+
+    # New entities introduced or discovered in the scene
+    invented_entities: list[dict] = field(default_factory=list)
+
+    # One-sentence summary of the scene (stored in Shadow_Scene node)
+    scene_summary: str = ""
+    chapter_num: int = 0
+    scene_num: int = 0

--- a/src/book_graph_analyzer/lore/checker.py
+++ b/src/book_graph_analyzer/lore/checker.py
@@ -113,7 +113,7 @@ class ValidationResult:
             ValidationStatus.INVALID: "[X]",
             ValidationStatus.UNKNOWN: "[?]",
             ValidationStatus.PARTIAL: "[~]",
-            ValidationStatus.PLAUSIBLE: "[~]",
+            ValidationStatus.PLAUSIBLE: "[+]",   # [+] = creative addition accepted
         }[self.status]
         
         lines = [
@@ -306,6 +306,47 @@ class LoreChecker:
         """
         claims = self.parser.parse_multiple(text)
         return [self.check(c.original_text) for c in claims]
+
+    def check_addition(self, claim_text: str) -> ValidationResult:
+        """
+        Check whether a claim is a creative ADDITION — not a contradiction.
+
+        This is the permissive RAG path used by the LoreChecker when evaluating
+        newly invented entities from the Lore Incubator. The distinction:
+
+            CONTRADICTION (hard fail): Claim violates a known canon fact.
+                e.g. "Tuor met Elrond in Nevrast" — Elrond isn't born yet.
+                → Returns INVALID.
+
+            ADDITION (pass): Claim introduces something new that is absent from
+                canon but consistent with World Bible rules.
+                e.g. "Tuor found an ancient Elven dagger named Aeglos-minor"
+                → No canon record found, but rule "Elves make named daggers" exists.
+                → Returns PLAUSIBLE: creative addition accepted.
+
+        The key difference from check(): UNKNOWN + no contradicting evidence
+        is promoted to PLAUSIBLE rather than left as uncertain.
+        """
+        result = self.check(claim_text)
+
+        # UNKNOWN with no contradictions = consistent addition
+        if result.status == ValidationStatus.UNKNOWN and not result.contradicting:
+            result.status = ValidationStatus.PLAUSIBLE
+            result.explanation = (
+                "No canon record found — consistent with World Bible rules. "
+                "Creative addition accepted."
+            )
+            result.confidence = max(result.confidence, 0.6)
+
+        # PARTIAL with only supporting evidence = also plausible
+        elif result.status == ValidationStatus.PARTIAL and not result.contradicting:
+            result.status = ValidationStatus.PLAUSIBLE
+            result.explanation = (
+                "Partially consistent with known rules. "
+                "Creative addition accepted."
+            )
+
+        return result
     
     def _check_entity_exists(self, claim: ParsedClaim, result: ValidationResult) -> ValidationResult:
         """Check if an entity exists with claimed properties."""

--- a/tests/test_incubator.py
+++ b/tests/test_incubator.py
@@ -1,0 +1,255 @@
+"""Tests for the Lore Incubator and Trope Dictionary."""
+
+import json
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+# ─── TropeDictionary ─────────────────────────────────────────────────────────
+
+class TestTropeDictionary:
+    def test_has_minimum_tropes(self):
+        from book_graph_analyzer.generate.incubator import TropeDictionary
+        td = TropeDictionary()
+        assert len(td.TROPES) >= 6
+
+    def test_select_returns_a_trope(self):
+        from book_graph_analyzer.generate.incubator import TropeDictionary
+        td = TropeDictionary()
+        trope = td.select_trope()
+        assert "name" in trope
+        assert "description" in trope
+        assert "required_elements" in trope
+
+    def test_avoids_recently_used_tropes(self):
+        from book_graph_analyzer.generate.incubator import TropeDictionary
+        td = TropeDictionary()
+
+        used = []
+        for _ in range(len(td.TROPES)):
+            trope = td.select_trope(used_tropes=used)
+            # Should not repeat as long as pool isn't exhausted
+            if len(used) < len(td.TROPES) - 1:
+                assert trope["name"] not in used, \
+                    f"Trope '{trope['name']}' was reused before pool exhausted"
+            used.append(trope["name"])
+
+    def test_resets_when_all_used(self):
+        """When all tropes have been used, select_trope should still return one."""
+        from book_graph_analyzer.generate.incubator import TropeDictionary
+        td = TropeDictionary()
+        all_names = [t["name"] for t in td.TROPES]
+
+        # All tropes "used" — should still return something
+        result = td.select_trope(used_tropes=all_names)
+        assert result is not None
+        assert "name" in result
+
+    def test_journey_beat_prefers_journey_trope(self):
+        from book_graph_analyzer.generate.incubator import TropeDictionary
+        td = TropeDictionary()
+
+        # Run multiple times and check that journey-hinted tropes appear
+        journey_trope_names = [
+            t["name"] for t in td.TROPES
+            if t.get("scene_type_hint") == "journey"
+        ]
+        if not journey_trope_names:
+            pytest.skip("No journey tropes defined")
+
+        results = [td.select_trope(chapter_beat="Tuor travels through the wilderness on a long road") for _ in range(20)]
+        selected_names = [r["name"] for r in results]
+        assert any(name in selected_names for name in journey_trope_names), \
+            "Journey tropes should appear when beat mentions travel"
+
+    def test_get_all_returns_complete_list(self):
+        from book_graph_analyzer.generate.incubator import TropeDictionary
+        td = TropeDictionary()
+        assert td.get_all() == td.TROPES
+
+
+# ─── LoreIncubator ───────────────────────────────────────────────────────────
+
+def make_mock_shadow_graph():
+    sg = MagicMock()
+    sg.get_invented_entities.return_value = []
+    return sg
+
+
+def make_valid_invention_response() -> str:
+    return json.dumps({
+        "invented_entities": [
+            {
+                "type": "MINOR_CHARACTER",
+                "name": "Cabed Norn",
+                "race": "Elf",
+                "description": "A lone Sindarin scout, last survivor of a ruined garrison.",
+                "tragic_history": "Watched his kin fall to Orcs at the ford of Ringlin.",
+                "role_in_story": "Reluctant guide through the mountain pass.",
+                "trope_connection": "The Reluctant Guide.",
+            },
+            {
+                "type": "RUINED_LOCATION",
+                "name": "Barad-wath",
+                "region": "Western Echoriath",
+                "description": "A shattered watchtower, its stones split by ancient cold.",
+                "former_purpose": "Guarded the hidden western approach to Gondolin.",
+                "how_it_fell": "Destroyed by a Balrog in the Year of Lamentation.",
+                "what_remains": "A broken arch and a descent into darkness.",
+            },
+            {
+                "type": "ARTIFACT",
+                "name": "Mornbrand",
+                "material": "Dark iron with a silver edge",
+                "description": "A short blade of Noldorin make, cold to the touch.",
+                "age_of_origin": "First Age, before the Nirnaeth",
+                "tragic_history": "Carried by a slain captain; abandoned in the dark.",
+                "power_or_property": "Glows faintly cold near hidden passages.",
+                "trope_connection": "Relic in the Dark — found in the ruin's descent.",
+            },
+        ],
+        "narrative_seeds": [
+            "Cabed Norn emerges from shadow at the ford, blocking Tuor's path.",
+            "The shattered arch of Barad-wath is the only landmark visible through the snow.",
+            "In the darkness beneath the tower, Tuor's foot strikes something cold and hard.",
+        ],
+    })
+
+
+class TestLoreIncubator:
+    def test_incubate_returns_result_with_three_entities(self):
+        from book_graph_analyzer.generate.incubator import LoreIncubator
+
+        sg = make_mock_shadow_graph()
+        llm = MagicMock()
+        llm.generate.return_value = make_valid_invention_response()
+
+        incubator = LoreIncubator(shadow_graph=sg, llm_client=llm)
+        result = incubator.incubate(
+            journey_context="Tuor traveling from Nevrast to Gondolin",
+            whitespace_description="400-mile gap of unnamed wilderness",
+        )
+
+        assert len(result.invented_entities) == 3
+        types = {e["type"] for e in result.invented_entities}
+        assert "MINOR_CHARACTER" in types
+        assert "RUINED_LOCATION" in types
+        assert "ARTIFACT" in types
+
+    def test_incubate_populates_narrative_seeds(self):
+        from book_graph_analyzer.generate.incubator import LoreIncubator
+
+        sg = make_mock_shadow_graph()
+        llm = MagicMock()
+        llm.generate.return_value = make_valid_invention_response()
+
+        incubator = LoreIncubator(shadow_graph=sg, llm_client=llm)
+        result = incubator.incubate("context", "whitespace")
+
+        assert len(result.narrative_seeds) == 3
+        assert all(isinstance(s, str) for s in result.narrative_seeds)
+
+    def test_incubate_returns_empty_result_on_llm_failure(self):
+        from book_graph_analyzer.generate.incubator import LoreIncubator
+
+        sg = make_mock_shadow_graph()
+        llm = MagicMock()
+        llm.generate.side_effect = Exception("LLM unavailable")
+
+        incubator = LoreIncubator(shadow_graph=sg, llm_client=llm)
+        result = incubator.incubate("context", "whitespace")
+
+        # Should return graceful empty result, not raise
+        assert result is not None
+        assert result.invented_entities == []
+
+    def test_incubate_returns_empty_result_on_bad_json(self):
+        from book_graph_analyzer.generate.incubator import LoreIncubator
+
+        sg = make_mock_shadow_graph()
+        llm = MagicMock()
+        llm.generate.return_value = "Sorry, I cannot help with that."
+
+        incubator = LoreIncubator(shadow_graph=sg, llm_client=llm)
+        result = incubator.incubate("context", "whitespace")
+
+        assert result.invented_entities == []
+
+    def test_commit_to_shadow_calls_graph_for_each_entity(self):
+        from book_graph_analyzer.generate.incubator import LoreIncubator
+
+        sg = make_mock_shadow_graph()
+        llm = MagicMock()
+        llm.generate.return_value = make_valid_invention_response()
+
+        incubator = LoreIncubator(shadow_graph=sg, llm_client=llm)
+        result = incubator.incubate("context", "whitespace")
+        incubator.commit_to_shadow(result, scene_id="chapter-1-pre")
+
+        assert sg.commit_invented_entity.call_count == 3
+
+    def test_incubate_and_commit_convenience_method(self):
+        from book_graph_analyzer.generate.incubator import LoreIncubator
+
+        sg = make_mock_shadow_graph()
+        llm = MagicMock()
+        llm.generate.return_value = make_valid_invention_response()
+
+        incubator = LoreIncubator(shadow_graph=sg, llm_client=llm)
+        result = incubator.incubate_and_commit(
+            "Tuor's journey",
+            "The wilderness gap",
+            chapter_id="ch-1",
+        )
+
+        assert len(result.invented_entities) == 3
+        assert sg.commit_invented_entity.call_count == 3
+
+    def test_trope_recorded_in_result(self):
+        from book_graph_analyzer.generate.incubator import LoreIncubator
+
+        sg = make_mock_shadow_graph()
+        llm = MagicMock()
+        llm.generate.return_value = make_valid_invention_response()
+
+        incubator = LoreIncubator(shadow_graph=sg, llm_client=llm)
+        result = incubator.incubate("context", "whitespace")
+
+        assert result.trope_used is not None
+        assert "name" in result.trope_used
+
+    def test_used_tropes_tracked_across_calls(self):
+        """Each call to incubate records the trope used."""
+        from book_graph_analyzer.generate.incubator import LoreIncubator
+
+        sg = make_mock_shadow_graph()
+        llm = MagicMock()
+        llm.generate.return_value = make_valid_invention_response()
+
+        incubator = LoreIncubator(shadow_graph=sg, llm_client=llm)
+
+        incubator.incubate("context", "whitespace 1")
+        incubator.incubate("context", "whitespace 2")
+
+        assert len(incubator._used_tropes) == 2
+
+
+# ─── IncubationResult: summary ───────────────────────────────────────────────
+
+class TestIncubationResult:
+    def test_summary_includes_entity_names(self):
+        from book_graph_analyzer.generate.incubator import IncubationResult
+
+        result = IncubationResult(
+            invented_entities=[
+                {"type": "MINOR_CHARACTER", "name": "Cabed Norn", "description": "A scout."},
+                {"type": "RUINED_LOCATION", "name": "Barad-wath", "description": "A tower."},
+            ],
+            narrative_seeds=["He appeared at the ford."],
+            trope_used={"name": "The Reluctant Guide"},
+        )
+
+        summary = result.summary()
+        assert "Cabed Norn" in summary
+        assert "Barad-wath" in summary
+        assert "The Reluctant Guide" in summary

--- a/tests/test_lore_checker_addition.py
+++ b/tests/test_lore_checker_addition.py
@@ -1,0 +1,110 @@
+"""Tests for LoreChecker.check_addition() — permissive RAG path."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+class TestLoreCheckerAddition:
+    """
+    check_addition() is the permissive RAG path.
+    UNKNOWN + no contradictions = PLAUSIBLE (creative addition accepted).
+    INVALID = still INVALID (hard canon violation).
+    """
+
+    def _make_checker(self):
+        from book_graph_analyzer.lore.checker import LoreChecker
+        checker = LoreChecker(use_llm=False)
+        return checker
+
+    def test_unknown_with_no_contradictions_becomes_plausible(self):
+        from book_graph_analyzer.lore.checker import LoreChecker, ValidationStatus
+
+        checker = self._make_checker()
+
+        # An entirely invented entity — not in any loaded canon
+        result = checker.check_addition("Tuor found an ancient Elven dagger named Aeglos-minor")
+
+        assert result.status == ValidationStatus.PLAUSIBLE
+        assert "creative addition accepted" in result.explanation.lower()
+
+    def test_plausible_confidence_is_at_least_0_6(self):
+        from book_graph_analyzer.lore.checker import LoreChecker, ValidationStatus
+
+        checker = self._make_checker()
+        result = checker.check_addition("A ruined tower called Barad-wath stood in the mountains")
+
+        assert result.status == ValidationStatus.PLAUSIBLE
+        assert result.confidence >= 0.6
+
+    def test_invalid_claim_stays_invalid(self):
+        """A hard canon violation must not be promoted to PLAUSIBLE."""
+        from book_graph_analyzer.lore.checker import LoreChecker, ValidationStatus
+
+        checker = self._make_checker()
+
+        # Inject a contradicting evidence manually by mocking check()
+        with patch.object(checker, 'check') as mock_check:
+            from book_graph_analyzer.lore.checker import ValidationResult, Evidence
+            from book_graph_analyzer.lore.parser import ParsedClaim, ClaimType
+
+            fake_claim = MagicMock(spec=ParsedClaim)
+            fake_claim.original_text = "Tuor met Elrond in Nevrast"
+
+            mock_result = ValidationResult(
+                claim=fake_claim,
+                status=ValidationStatus.INVALID,
+                confidence=0.9,
+                contradicting=[
+                    Evidence(
+                        text="Elrond was not yet born during Tuor's time in Nevrast",
+                        source="Timeline",
+                        supports=False,
+                    )
+                ],
+                explanation="Elrond is not yet born in this era.",
+            )
+            mock_check.return_value = mock_result
+
+            result = checker.check_addition("Tuor met Elrond in Nevrast")
+
+        # check() returned INVALID — check_addition should NOT override that
+        assert result.status == ValidationStatus.INVALID
+
+    def test_plausible_icon_is_plus(self):
+        """PLAUSIBLE status should show [+] not [~] in summary."""
+        from book_graph_analyzer.lore.checker import LoreChecker, ValidationStatus
+
+        checker = self._make_checker()
+        result = checker.check_addition("A small village of Men named Aldburg stood near the river")
+
+        assert result.status == ValidationStatus.PLAUSIBLE
+        summary = result.summary()
+        assert "[+]" in summary, f"Expected [+] in summary, got: {summary[:50]}"
+        assert "[~]" not in summary
+
+    def test_partial_with_no_contradictions_becomes_plausible(self):
+        """PARTIAL + no contradictions should also be promoted."""
+        from book_graph_analyzer.lore.checker import LoreChecker, ValidationStatus, ValidationResult, Evidence
+        from book_graph_analyzer.lore.parser import ParsedClaim
+
+        checker = self._make_checker()
+
+        with patch.object(checker, 'check') as mock_check:
+            fake_claim = MagicMock(spec=ParsedClaim)
+            fake_claim.original_text = "Elves can craft named swords"
+
+            mock_result = ValidationResult(
+                claim=fake_claim,
+                status=ValidationStatus.PARTIAL,
+                confidence=0.5,
+                supporting=[
+                    Evidence(text="Elves are skilled smiths", source="World Bible", supports=True)
+                ],
+                contradicting=[],  # No contradictions
+                explanation="Some aspects valid",
+            )
+            mock_check.return_value = mock_result
+
+            result = checker.check_addition("Elves can craft named swords")
+
+        assert result.status == ValidationStatus.PLAUSIBLE

--- a/tests/test_shadow_graph.py
+++ b/tests/test_shadow_graph.py
@@ -1,0 +1,260 @@
+"""Tests for Shadow Graph story state tracking."""
+
+import json
+import pytest
+from unittest.mock import MagicMock, patch, call
+
+
+# ─── Fixtures ────────────────────────────────────────────────────────────────
+
+def make_mock_driver(query_results: dict = None):
+    """Build a mock Neo4j driver with configurable query results."""
+    driver = MagicMock()
+    session = MagicMock()
+    driver.session.return_value.__enter__ = MagicMock(return_value=session)
+    driver.session.return_value.__exit__ = MagicMock(return_value=False)
+
+    # Default: all queries return nothing
+    result = MagicMock()
+    result.single.return_value = None
+    result.__iter__ = MagicMock(return_value=iter([]))
+    session.run.return_value = result
+
+    return driver, session
+
+
+# ─── ShadowGraph: commit_state_delta ─────────────────────────────────────────
+
+class TestShadowGraphCommitDelta:
+    def test_commit_basic_location_change(self):
+        from book_graph_analyzer.generate.shadow.graph import ShadowGraph
+        from book_graph_analyzer.generate.shadow.models import StateDelta
+
+        driver, session = make_mock_driver()
+        sg = ShadowGraph(story_id="test-story", driver=driver)
+
+        delta = StateDelta(
+            story_id="test-story",
+            scene_id="scene-001",
+            character_updates={
+                "Tuor": {
+                    "location_change": "Nevrast Shore",
+                    "possessions_gained": ["Sword of Turgon"],
+                    "possessions_lost": [],
+                    "conditions_added": ["weary"],
+                    "conditions_removed": [],
+                }
+            },
+            scene_summary="Tuor arrived at the shore and found the arms.",
+            chapter_num=1,
+            scene_num=1,
+        )
+
+        sg.commit_state_delta(delta)
+
+        # Should have called session.run at least for: MERGE_CHARACTER, SET_LOCATION,
+        # ADD_POSSESSION, ADD_CONDITION, RECORD_SCENE, LINK_CHARACTER_SCENE
+        assert session.run.call_count >= 5
+
+    def test_commit_handles_driver_none_gracefully(self):
+        from book_graph_analyzer.generate.shadow.graph import ShadowGraph
+        from book_graph_analyzer.generate.shadow.models import StateDelta
+
+        # No driver — should not raise
+        sg = ShadowGraph(story_id="test-story", driver=None)
+        delta = StateDelta(story_id="test-story", scene_id="s1")
+
+        sg.commit_state_delta(delta)  # Should not raise
+
+    def test_commit_handles_neo4j_exception_gracefully(self):
+        from book_graph_analyzer.generate.shadow.graph import ShadowGraph
+        from book_graph_analyzer.generate.shadow.models import StateDelta
+
+        driver, session = make_mock_driver()
+        session.run.side_effect = Exception("Neo4j connection lost")
+
+        sg = ShadowGraph(story_id="test-story", driver=driver)
+        delta = StateDelta(
+            story_id="test-story",
+            scene_id="s1",
+            character_updates={"Tuor": {"location_change": "Gondolin"}},
+        )
+
+        # Should NOT raise — non-blocking
+        sg.commit_state_delta(delta)
+
+
+# ─── ShadowGraph: get_character_state ────────────────────────────────────────
+
+class TestShadowGraphGetCharacterState:
+    def test_returns_none_when_no_driver(self):
+        from book_graph_analyzer.generate.shadow.graph import ShadowGraph
+
+        sg = ShadowGraph(story_id="test-story", driver=None)
+        assert sg.get_character_state("Tuor") is None
+
+    def test_returns_none_when_character_not_found(self):
+        from book_graph_analyzer.generate.shadow.graph import ShadowGraph
+
+        driver, session = make_mock_driver()
+        session.run.return_value.single.return_value = None
+
+        sg = ShadowGraph(story_id="test-story", driver=driver)
+        assert sg.get_character_state("Tuor") is None
+
+    def test_returns_character_state_from_graph(self):
+        from book_graph_analyzer.generate.shadow.graph import ShadowGraph
+
+        driver, session = make_mock_driver()
+        mock_record = {
+            "name": "Tuor",
+            "location": "Gondolin",
+            "possessions": ["Sword of Turgon", "Grey Cloak"],
+            "conditions": ["weary"],
+        }
+        session.run.return_value.single.return_value = mock_record
+
+        sg = ShadowGraph(story_id="test-story", driver=driver)
+        state = sg.get_character_state("Tuor")
+
+        assert state is not None
+        assert state.name == "Tuor"
+        assert state.location == "Gondolin"
+        assert "Sword of Turgon" in state.possessions
+        assert "weary" in state.conditions
+
+    def test_story_id_isolation(self):
+        """Two stories don't share character state."""
+        from book_graph_analyzer.generate.shadow.graph import ShadowGraph
+
+        driver, session = make_mock_driver()
+        session.run.return_value.single.return_value = None
+
+        sg1 = ShadowGraph(story_id="story-A", driver=driver)
+        sg2 = ShadowGraph(story_id="story-B", driver=driver)
+
+        sg1.get_character_state("Tuor")
+        sg2.get_character_state("Tuor")
+
+        # Both calls should pass their own story_id
+        calls = session.run.call_args_list
+        story_ids_used = [c.kwargs.get("story_id") or (c.args[1] if len(c.args) > 1 else None)
+                          for c in calls]
+        # At minimum, the two story IDs should both appear
+        assert "story-A" in str(calls)
+        assert "story-B" in str(calls)
+
+
+# ─── ShadowGraph: extract_delta_from_scene ───────────────────────────────────
+
+class TestShadowGraphExtractDelta:
+    def test_extract_returns_empty_delta_on_parse_failure(self):
+        from book_graph_analyzer.generate.shadow.graph import ShadowGraph
+
+        driver, _ = make_mock_driver()
+        sg = ShadowGraph(story_id="test-story", driver=driver)
+
+        # Mock LLM returning garbage
+        sg._llm = MagicMock()
+        sg._llm.generate.return_value = "This is not JSON at all."
+
+        delta = sg.extract_delta_from_scene(
+            scene_text="Tuor walked into the rain.",
+            characters=["Tuor"],
+            scene_id="s-001",
+        )
+
+        # Should return empty delta, not raise
+        assert delta.story_id == "test-story"
+        assert delta.scene_id == "s-001"
+        assert delta.character_updates == {}
+
+    def test_extract_parses_valid_json_response(self):
+        from book_graph_analyzer.generate.shadow.graph import ShadowGraph
+
+        driver, _ = make_mock_driver()
+        sg = ShadowGraph(story_id="test-story", driver=driver)
+
+        mock_response = json.dumps({
+            "characters": {
+                "Tuor": {
+                    "location_change": "Nevrast",
+                    "possessions_gained": ["Turgon's Helm"],
+                    "possessions_lost": [],
+                    "conditions_added": ["determined"],
+                    "conditions_removed": [],
+                }
+            },
+            "new_entities": [],
+            "scene_summary": "Tuor found the arms of Turgon on the shore.",
+        })
+
+        sg._llm = MagicMock()
+        sg._llm.generate.return_value = mock_response
+
+        delta = sg.extract_delta_from_scene(
+            scene_text="He found the helm gleaming on the shore...",
+            characters=["Tuor"],
+            scene_id="s-002",
+        )
+
+        assert "Tuor" in delta.character_updates
+        assert delta.character_updates["Tuor"]["location_change"] == "Nevrast"
+        assert "Turgon's Helm" in delta.character_updates["Tuor"]["possessions_gained"]
+        assert delta.scene_summary == "Tuor found the arms of Turgon on the shore."
+
+
+# ─── SceneState: to_prompt_block ─────────────────────────────────────────────
+
+class TestSceneState:
+    def test_to_prompt_block_under_400_tokens(self):
+        from book_graph_analyzer.generate.shadow.models import (
+            SceneState, CharacterState, InventedEntity
+        )
+
+        state = SceneState(
+            characters=[
+                CharacterState(
+                    name="Tuor",
+                    story_id="s1",
+                    location="Echoriath foothills",
+                    possessions=["Sword of Turgon", "Grey Cloak"],
+                    conditions=["weary", "determined"],
+                ),
+                CharacterState(
+                    name="Voronwë",
+                    story_id="s1",
+                    location="Echoriath foothills",
+                    possessions=[],
+                    conditions=["resolute"],
+                ),
+            ],
+            recent_summaries=[
+                "Tuor and Voronwë fled an Orc ambush near the river.",
+                "They discovered a hidden path marked by Ulmo's sign.",
+            ],
+            invented_entities=[
+                InventedEntity(
+                    type="RUINED_LOCATION",
+                    name="Barad-wath",
+                    description="A ruined watchtower of the First Age, half-buried in ice.",
+                    story_id="s1",
+                    scene_id="pre-draft",
+                ),
+            ],
+        )
+
+        block = state.to_prompt_block()
+        # Rough token estimate: ~0.75 tokens per character
+        estimated_tokens = len(block) * 0.75
+        assert estimated_tokens < 400, f"Prompt block too long: ~{estimated_tokens:.0f} tokens"
+        assert "Tuor" in block
+        assert "Voronwë" in block
+        assert "Barad-wath" in block
+
+    def test_empty_state_returns_empty_string(self):
+        from book_graph_analyzer.generate.shadow.models import SceneState
+        state = SceneState()
+        # Should not crash, should return empty/minimal
+        block = state.to_prompt_block()
+        assert isinstance(block, str)


### PR DESCRIPTION
Implements #19 (Shadow Graph), adds Lore Incubator + TropeDictionary (feeds #21), and introduces Fog of War mode to SceneGenerator.

New:
- generate/shadow/ — ShadowGraph + StateDelta/SceneState models
- generate/incubator.py — LoreIncubator + TropeDictionary

Modified:
- lore/checker.py — check_addition() promotes UNKNOWN→PLAUSIBLE for additions; PLAUSIBLE icon is now [+]
- generate/generator.py — og_of_war flag + alternate prompt

Tests:
- Added unit tests for ShadowGraph, LoreIncubator/Tropes, and LoreChecker.check_addition

Closes #19. Related: #20 #21.