### PR TITLE
feat: Conflict Tracking — Intra/Inter-Book Lore Contradictions (#7)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,12 @@
+# pytest conftest -- ensure workspace src/ takes precedence over installed package.
+#
+# The editable install may point to a different clone (C:/Temp/bga-invention-engine/src).
+# This conftest inserts the workspace src/ at the front of sys.path so that
+# new modules written in this session are importable during test runs.
+import sys
+import os
+
+# Insert workspace src at position 0 so it shadows the installed editable package
+_workspace_src = os.path.join(os.path.dirname(__file__), "src")
+if _workspace_src not in sys.path:
+    sys.path.insert(0, _workspace_src)

--- a/src/book_graph_analyzer/cli.py
+++ b/src/book_graph_analyzer/cli.py
@@ -2692,6 +2692,236 @@ def lore_top_passages(limit: int, min_score: float) -> None:
     console.print(table)
 
 
+@lore.group(name="conflicts")
+def lore_conflicts() -> None:
+    """Track and manage intra/inter-book lore contradictions."""
+    pass
+
+
+@lore_conflicts.command(name="list")
+@click.option("--conflict-type", "-t", default=None,
+              help="Filter by type: direct_contradiction, retcon, ambiguity, interpretation")
+@click.option("--resolved", is_flag=True, default=False, help="Show only resolved conflicts")
+@click.option("--unresolved", is_flag=True, default=False, help="Show only unresolved conflicts")
+@click.option("--neo4j", is_flag=True, help="Read from Neo4j instead of built-in conflicts")
+def lore_conflicts_list(
+    conflict_type: str | None, resolved: bool, unresolved: bool, neo4j: bool
+) -> None:
+    """List all tracked lore conflicts.
+
+    Examples:
+        bga lore conflicts list
+        bga lore conflicts list --unresolved
+        bga lore conflicts list --conflict-type retcon
+        bga lore conflicts list --neo4j
+    """
+    from book_graph_analyzer.lore.conflicts import ConflictRegistry, LoreConflictNeo4jWriter
+    from book_graph_analyzer.graph.connection import check_neo4j_connection
+
+    if neo4j:
+        if not check_neo4j_connection():
+            console.print("[red]Cannot connect to Neo4j.[/red]")
+            return
+        writer = LoreConflictNeo4jWriter()
+        conflicts_raw = writer.query_conflicts(
+            conflict_type=conflict_type,
+            resolved=True if resolved else (False if unresolved else None),
+            needs_human=False,
+        )
+        writer.close()
+        if not conflicts_raw:
+            console.print("[yellow]No conflicts found in Neo4j. Run 'bga lore conflicts init' first.[/yellow]")
+            return
+        console.print(f"\n[bold]LoreConflicts in Neo4j ({len(conflicts_raw)})[/bold]\n")
+        for c in conflicts_raw:
+            status = "[green]✓[/green]" if c.get("resolved") else "[yellow]?[/yellow]"
+            console.print(f"  {status} [{c.get('conflict_type', '?')}] [cyan]{c.get('id')}[/cyan]")
+            console.print(f"    {c.get('summary', '')[:80]}")
+            console.print(f"    Policy: {c.get('resolution_policy', '?')}")
+            console.print()
+        return
+
+    # Built-in registry
+    registry = ConflictRegistry.from_tolkien_defaults()
+    conflicts = registry.all()
+    if conflict_type:
+        conflicts = [c for c in conflicts if c.conflict_type == conflict_type]
+    if resolved:
+        conflicts = [c for c in conflicts if c.is_resolved]
+    elif unresolved:
+        conflicts = [c for c in conflicts if not c.is_resolved]
+
+    console.print(f"\n[bold]Known Tolkien Lore Conflicts ({len(conflicts)})[/bold]\n")
+
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("ID", style="cyan", width=28)
+    table.add_column("Type", width=20)
+    table.add_column("Policy", width=22)
+    table.add_column("✓", width=3)
+    table.add_column("Summary")
+
+    for conflict in sorted(conflicts, key=lambda c: c.id):
+        status = "[green]✓[/green]" if conflict.is_resolved else "[yellow]?[/yellow]"
+        table.add_row(
+            conflict.id,
+            conflict.conflict_type,
+            conflict.resolution_policy,
+            status,
+            conflict.summary[:60] + "..." if len(conflict.summary) > 60 else conflict.summary,
+        )
+    console.print(table)
+
+    res = sum(1 for c in conflicts if c.is_resolved)
+    unres = len(conflicts) - res
+    console.print(f"\n  {res} resolved · {unres} unresolved")
+
+
+@lore_conflicts.command(name="show")
+@click.argument("conflict_id")
+def lore_conflicts_show(conflict_id: str) -> None:
+    """Show full detail for a single LoreConflict.
+
+    Example:
+        bga lore conflicts show glorfindel_identity
+    """
+    from book_graph_analyzer.lore.conflicts import ConflictRegistry
+
+    registry = ConflictRegistry.from_tolkien_defaults()
+    conflict = registry.get(conflict_id)
+
+    if not conflict:
+        console.print(f"[red]Conflict '{conflict_id}' not found.[/red]")
+        console.print("\nAvailable conflict IDs:")
+        for c in registry.all():
+            console.print(f"  {c.id}")
+        return
+
+    console.print(f"\n{conflict.detail()}")
+
+
+@lore_conflicts.command(name="unresolved")
+def lore_conflicts_unresolved() -> None:
+    """Show conflicts needing human attention (flag_for_human or irresolvable).
+
+    Example:
+        bga lore conflicts unresolved
+    """
+    from book_graph_analyzer.lore.conflicts import ConflictRegistry
+
+    registry = ConflictRegistry.from_tolkien_defaults()
+    human_needed = registry.needing_human_review()
+
+    if not human_needed:
+        console.print("[green]No conflicts need human review.[/green]")
+        return
+
+    console.print(f"\n[bold yellow]Conflicts requiring human review ({len(human_needed)}):[/bold yellow]\n")
+    for conflict in human_needed:
+        console.print(f"  [yellow]⚠[/yellow] [cyan]{conflict.id}[/cyan]  [{conflict.conflict_type}]")
+        console.print(f"    {conflict.summary[:100]}")
+        if conflict.claims:
+            for i, claim in enumerate(conflict.claims, 1):
+                console.print(f"      [{i}] ({claim.author_period} / {claim.source_book}) {claim.statement[:80]}")
+        console.print()
+
+
+@lore_conflicts.command(name="resolve")
+@click.option("--id", "conflict_id", required=True, help="Conflict ID to resolve")
+@click.option("--policy", required=True,
+              type=click.Choice([
+                  "use_later_text", "use_earlier_text", "both_valid_in_universe",
+                  "flag_for_human", "use_most_cited", "irresolvable"
+              ]),
+              help="Resolution policy to apply")
+@click.option("--notes", default="", help="Notes explaining the resolution")
+@click.option("--neo4j", is_flag=True, help="Also persist resolution to Neo4j")
+def lore_conflicts_resolve(
+    conflict_id: str, policy: str, notes: str, neo4j: bool
+) -> None:
+    """Apply a resolution policy to a conflict.
+
+    Examples:
+        bga lore conflicts resolve --id orc_origin --policy use_later_text
+        bga lore conflicts resolve --id bombadil_nature --policy irresolvable --notes "Tolkien's intent"
+        bga lore conflicts resolve --id glorfindel_identity --policy use_later_text --neo4j
+    """
+    from book_graph_analyzer.lore.conflicts import ConflictRegistry, LoreConflictNeo4jWriter
+    from book_graph_analyzer.graph.connection import check_neo4j_connection
+
+    registry = ConflictRegistry.from_tolkien_defaults()
+    success = registry.resolve(conflict_id, policy, notes)
+
+    if not success:
+        console.print(f"[red]Conflict '{conflict_id}' not found in built-in registry.[/red]")
+        return
+
+    conflict = registry.get(conflict_id)
+    status = "[green]✓ Resolved[/green]" if conflict.resolved else "[yellow]Flagged[/yellow]"
+    console.print(f"\n{status}: [{conflict_id}] → {policy}")
+
+    winner = conflict.winning_claim()
+    if winner:
+        console.print(f"  Active claim: ({winner.author_period} / {winner.source_book}) {winner.statement[:80]}")
+
+    if neo4j:
+        if not check_neo4j_connection():
+            console.print("[red]Cannot connect to Neo4j.[/red]")
+            return
+        writer = LoreConflictNeo4jWriter()
+        writer.resolve_conflict(conflict_id, policy, notes)
+        writer.close()
+        console.print("[green]OK[/green] Neo4j updated.")
+
+
+@lore_conflicts.command(name="init")
+@click.option("--dry-run", is_flag=True, help="Show what would be written without writing")
+def lore_conflicts_init(dry_run: bool) -> None:
+    """Write all known Tolkien conflicts to Neo4j.
+
+    This seeds the conflict database. Safe to run multiple times (idempotent MERGE).
+
+    Example:
+        bga lore conflicts init
+        bga lore conflicts init --dry-run
+    """
+    from book_graph_analyzer.lore.conflicts import ConflictRegistry, LoreConflictNeo4jWriter
+    from book_graph_analyzer.graph.connection import check_neo4j_connection
+
+    registry = ConflictRegistry.from_tolkien_defaults()
+    conflicts = registry.all()
+
+    console.print(f"[bold]Initialising {len(conflicts)} known Tolkien conflicts[/bold]")
+
+    if dry_run:
+        console.print("\n[yellow][DRY RUN] Would write:[/yellow]")
+        for c in conflicts:
+            status = "✓" if c.is_resolved else "?"
+            console.print(f"  [{status}] {c.id}: {c.summary[:70]}")
+        return
+
+    if not check_neo4j_connection():
+        console.print("[red]Cannot connect to Neo4j.[/red]")
+        return
+
+    writer = LoreConflictNeo4jWriter()
+    writer.ensure_schema()
+    count = writer.upsert_many(conflicts)
+
+    # Create CONFLICTS_WITH edges for rule-linked conflicts
+    for c in conflicts:
+        if len(c.rule_ids) >= 2:
+            for i in range(len(c.rule_ids) - 1):
+                try:
+                    writer.create_conflicts_with_edge(
+                        c.rule_ids[i], c.rule_ids[i + 1], c.id
+                    )
+                except Exception:
+                    pass  # Rules may not exist yet
+
+    writer.close()
+    console.print(f"[green]OK[/green] {count} LoreConflict nodes written to Neo4j")
+
+
 @lore.group(name="rules")
 def lore_rules() -> None:
     """Manage LoreRule nodes — lore laws as executable Cypher contracts."""

--- a/src/book_graph_analyzer/lore/__init__.py
+++ b/src/book_graph_analyzer/lore/__init__.py
@@ -22,6 +22,13 @@ from .rules import (
     SceneContext,
     TOLKIEN_LORE_RULES,
 )
+from .conflicts import (
+    ConflictRegistry,
+    ConflictDetector,
+    ConflictAwareValidator,
+    LoreConflictNeo4jWriter,
+    KNOWN_TOLKIEN_CONFLICTS,
+)
 
 __all__ = [
     "LoreChecker",
@@ -44,4 +51,9 @@ __all__ = [
     "LoreRuleNeo4jWriter",
     "SceneContext",
     "TOLKIEN_LORE_RULES",
+    "ConflictRegistry",
+    "ConflictDetector",
+    "ConflictAwareValidator",
+    "LoreConflictNeo4jWriter",
+    "KNOWN_TOLKIEN_CONFLICTS",
 ]

--- a/src/book_graph_analyzer/lore/conflicts.py
+++ b/src/book_graph_analyzer/lore/conflicts.py
@@ -1,0 +1,713 @@
+"""Conflict tracking for Tolkien lore contradictions.
+
+Contains:
+  KNOWN_TOLKIEN_CONFLICTS — pre-seeded baseline of major contradictions
+  ConflictRegistry        — in-memory + Neo4j registry of LoreConflict objects
+  ConflictDetector        — detects new conflicts when extracting facts
+  ConflictAwareValidator  — wraps LoreRuleValidator; suppresses known-conflict false positives
+  LoreConflictNeo4jWriter — writes (:LoreConflict) nodes and [:CONFLICTS_WITH] edges
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from ..models.lore_conflict import (
+    LoreConflict,
+    ConflictClaim,
+    ConflictType,
+    ResolutionPolicy,
+    AuthorPeriod,
+)
+from ..models.lore_rule import LoreValidationResult, LoreViolation
+
+
+# ---------------------------------------------------------------------------
+# Pre-seeded baseline: known major Tolkien contradictions
+# ---------------------------------------------------------------------------
+
+KNOWN_TOLKIEN_CONFLICTS: list[LoreConflict] = [
+
+    # ---- Blue Wizards (Alatar/Pallando vs. Morinehtar/Rómestámo) -----------
+
+    LoreConflict(
+        id="blue_wizards_names",
+        summary=(
+            "The Blue Wizards are named 'Alatar and Pallando' in Unfinished Tales "
+            "but renamed 'Morinehtar and Rómestámo' in late notes (Peoples of Middle-earth)."
+        ),
+        conflict_type=ConflictType.RETCON,
+        entity_ids=["blue_wizards", "alatar", "pallando", "morinehtar", "romestamo"],
+        rule_ids=[],
+        claims=[
+            ConflictClaim(
+                statement="The Blue Wizards are named Alatar and Pallando.",
+                source_book="Unfinished Tales",
+                author_period=AuthorPeriod.MIDDLE,
+                confidence=0.95,
+            ),
+            ConflictClaim(
+                statement="The Blue Wizards are named Morinehtar and Rómestámo.",
+                source_book="The Peoples of Middle-earth",
+                author_period=AuthorPeriod.LATE,
+                confidence=0.90,
+            ),
+        ],
+        resolution_policy=ResolutionPolicy.BOTH_VALID_IN_UNIVERSE,
+        resolution_notes=(
+            "Both names are accepted in different scholarly traditions. "
+            "The late names reflect Tolkien's final intent; UT names are more familiar. "
+            "Both can coexist as names in different Elvish traditions."
+        ),
+        resolved=True,
+    ),
+
+    # ---- Glorfindel identity (First Age / Third Age same elf?) --------------
+
+    LoreConflict(
+        id="glorfindel_identity",
+        summary=(
+            "Is Glorfindel of Rivendell (LotR) the same Elf who died killing a Balrog "
+            "in the First Age? Tolkien changed his mind multiple times."
+        ),
+        conflict_type=ConflictType.RETCON,
+        entity_ids=["glorfindel"],
+        rule_ids=["race_elf_immortal"],  # Glorfindel died but returned — exception to immortality rule
+        claims=[
+            ConflictClaim(
+                statement=(
+                    "Glorfindel of Rivendell is a different Elf from the Glorfindel "
+                    "who died in the Fall of Gondolin. The name is a coincidence."
+                ),
+                source_book="The Lord of the Rings (early conception)",
+                author_period=AuthorPeriod.MIDDLE,
+                confidence=0.6,
+            ),
+            ConflictClaim(
+                statement=(
+                    "Glorfindel of Rivendell IS the Glorfindel of Gondolin, reincarnated "
+                    "and returned from Valinor by the Valar as a reward for his sacrifice."
+                ),
+                source_book="Unfinished Tales / late notes",
+                author_period=AuthorPeriod.LATE,
+                confidence=0.9,
+            ),
+        ],
+        resolution_policy=ResolutionPolicy.USE_LATER_TEXT,
+        resolution_notes=(
+            "Tolkien's late writing (circa 1972) firmly identifies them as the same Elf. "
+            "This is now the accepted canonical reading. The earlier ambiguity is moot."
+        ),
+        resolved=True,
+    ),
+
+    # ---- Tom Bombadil's nature -----------------------------------------------
+
+    LoreConflict(
+        id="bombadil_nature",
+        summary=(
+            "Tom Bombadil's nature and origin are deliberately left unexplained in LotR. "
+            "Tolkien gave contradictory hints in letters: a 'spirit of the (vanishing) Oxford "
+            "and Berkshire countryside', or the oldest living thing, unaffected by the Ring."
+        ),
+        conflict_type=ConflictType.AMBIGUITY,
+        entity_ids=["tom_bombadil"],
+        rule_ids=["magic_ring_corruption"],  # Bombadil is immune to Ring corruption
+        claims=[
+            ConflictClaim(
+                statement="Tom Bombadil is a nature spirit — the spirit of the Oxford countryside personified.",
+                source_book="Letters of J.R.R. Tolkien",
+                author_period=AuthorPeriod.MIDDLE,
+                confidence=0.7,
+            ),
+            ConflictClaim(
+                statement="Tom Bombadil is 'the oldest' and represents a deliberately enigmatic mystery meant to remain unsolved.",
+                source_book="Letters of J.R.R. Tolkien",
+                author_period=AuthorPeriod.LATE,
+                confidence=0.8,
+            ),
+            ConflictClaim(
+                statement="Tom Bombadil may be a Maia of Yavanna (scholarly interpretation).",
+                source_book="Various scholarly analyses",
+                author_period=AuthorPeriod.LATE,
+                confidence=0.4,
+            ),
+        ],
+        resolution_policy=ResolutionPolicy.IRRESOLVABLE,
+        resolution_notes=(
+            "Tolkien explicitly stated Bombadil was meant to remain enigmatic. "
+            "The Ring's inability to corrupt him is consistent regardless of his nature. "
+            "Mark as irresolvable — any depiction of Bombadil should preserve the mystery."
+        ),
+        resolved=False,
+    ),
+
+    # ---- Elvish mortality (early vs. late Tolkien) ---------------------------
+
+    LoreConflict(
+        id="elvish_mortality",
+        summary=(
+            "Early Tolkien had Elves who could 'die of grief' or 'fade' into nothing. "
+            "Later Tolkien refined this: Elves are bound to Arda until its end; "
+            "death means their spirit goes to Mandos, not annihilation."
+        ),
+        conflict_type=ConflictType.RETCON,
+        entity_ids=[],  # Applies to all Elves
+        rule_ids=["race_elf_immortal"],
+        claims=[
+            ConflictClaim(
+                statement="Elves can 'die' of grief, fading from the world into nothing — a true death.",
+                source_book="The Book of Lost Tales",
+                author_period=AuthorPeriod.EARLY,
+                confidence=0.7,
+            ),
+            ConflictClaim(
+                statement=(
+                    "Elves cannot truly die; their fëa goes to Mandos. 'Death' for Elves means "
+                    "temporary separation of body and spirit — they can be reincarnated."
+                ),
+                source_book="Laws and Customs of the Eldar / Morgoth's Ring",
+                author_period=AuthorPeriod.LATE,
+                confidence=0.95,
+            ),
+        ],
+        resolution_policy=ResolutionPolicy.USE_LATER_TEXT,
+        resolution_notes=(
+            "The later theology is explicit and detailed (Laws and Customs). "
+            "The LoreRule 'race_elf_immortal' reflects the late canonical view. "
+            "Early BoLT material should be treated as superseded."
+        ),
+        resolved=True,
+    ),
+
+    # ---- Balrogs: how many? wings? -------------------------------------------
+
+    LoreConflict(
+        id="balrog_count_and_wings",
+        summary=(
+            "Early Tolkien had Balrogs in the hundreds. Late Tolkien reduced them to 'at most seven'. "
+            "Additionally, whether Balrogs have physical wings (can fly) is debated from the text."
+        ),
+        conflict_type=ConflictType.RETCON,
+        entity_ids=["balrog"],
+        rule_ids=[],
+        claims=[
+            ConflictClaim(
+                statement="Balrogs existed in large numbers — possibly hundreds — in the early legendarium.",
+                source_book="The Book of Lost Tales",
+                author_period=AuthorPeriod.EARLY,
+                confidence=0.8,
+            ),
+            ConflictClaim(
+                statement="There were at most seven Balrogs remaining in Middle-earth in the later Ages.",
+                source_book="Letters of J.R.R. Tolkien / late notes",
+                author_period=AuthorPeriod.LATE,
+                confidence=0.85,
+            ),
+            ConflictClaim(
+                statement="The Balrog's 'wings' in Moria are metaphorical shadow-wings, not physical.",
+                source_book="The Lord of the Rings (textual analysis)",
+                author_period=AuthorPeriod.MIDDLE,
+                confidence=0.6,
+            ),
+        ],
+        resolution_policy=ResolutionPolicy.USE_LATER_TEXT,
+        resolution_notes=(
+            "The 'at most seven' figure is Tolkien's considered late position. "
+            "The wing question remains genuinely ambiguous — flag depictions either way."
+        ),
+        resolved=True,
+    ),
+
+    # ---- Orcs: origin (Elves vs. Men) ---------------------------------------
+
+    LoreConflict(
+        id="orc_origin",
+        summary=(
+            "Tolkien was troubled by Orc origin throughout his life. "
+            "Early: Orcs = corrupted Elves. Later: also possibly Men, or 'soulless' automatons. "
+            "The corrupted-Elves theory creates theological problems Tolkien never resolved."
+        ),
+        conflict_type=ConflictType.RETCON,
+        entity_ids=["orc"],
+        rule_ids=[],
+        claims=[
+            ConflictClaim(
+                statement="Orcs were created by Morgoth from captured Elves, corrupted and twisted.",
+                source_book="The Silmarillion",
+                author_period=AuthorPeriod.MIDDLE,
+                confidence=0.9,
+            ),
+            ConflictClaim(
+                statement="Orcs may be corrupted Men, not Elves — Tolkien considered this in late writings.",
+                source_book="Morgoth's Ring / late notes",
+                author_period=AuthorPeriod.LATE,
+                confidence=0.7,
+            ),
+            ConflictClaim(
+                statement="Orcs may be 'soulless' automata operated by Morgoth's will, with no independent fëa.",
+                source_book="Morgoth's Ring / late notes",
+                author_period=AuthorPeriod.LATE,
+                confidence=0.6,
+            ),
+        ],
+        resolution_policy=ResolutionPolicy.FLAG_FOR_HUMAN,
+        resolution_notes=(
+            "Tolkien never resolved this. The Silmarillion version is most widely known "
+            "and accepted. Generation should default to corrupted-Elves unless specifically "
+            "targeting late-period themes."
+        ),
+        resolved=False,
+    ),
+
+    # ---- Finwë's second marriage (Elvish remarriage) ------------------------
+
+    LoreConflict(
+        id="elvish_remarriage",
+        summary=(
+            "Whether Elves can remarry after the death of a spouse was debated by Tolkien. "
+            "Finwë's marriage to Indis after Míriel's death creates theological tension."
+        ),
+        conflict_type=ConflictType.AMBIGUITY,
+        entity_ids=["finwe", "miriel", "indis"],
+        rule_ids=[],
+        claims=[
+            ConflictClaim(
+                statement="Elves cannot remarry — each fëa is bound to one spouse for eternity.",
+                source_book="Laws and Customs of the Eldar (early draft)",
+                author_period=AuthorPeriod.MIDDLE,
+                confidence=0.7,
+            ),
+            ConflictClaim(
+                statement=(
+                    "Finwë was granted special dispensation to remarry because Míriel's "
+                    "self-willed death was unprecedented. Remarriage is normally forbidden."
+                ),
+                source_book="Morgoth's Ring (Laws and Customs of the Eldar, final)",
+                author_period=AuthorPeriod.LATE,
+                confidence=0.85,
+            ),
+        ],
+        resolution_policy=ResolutionPolicy.USE_LATER_TEXT,
+        resolution_notes=(
+            "The final Laws and Customs text is the most developed. "
+            "Finwë's case is an exception, not the rule."
+        ),
+        resolved=True,
+    ),
+
+    # ---- Númenórean lifespan -------------------------------------------------
+
+    LoreConflict(
+        id="numenorean_lifespan",
+        summary=(
+            "The exact lifespan of Númenóreans varies across texts. "
+            "Early texts suggest 200-300 years; later texts imply multiple centuries "
+            "for kings, with the lifespan decreasing as they approached the Downfall."
+        ),
+        conflict_type=ConflictType.AMBIGUITY,
+        entity_ids=["numenorean"],
+        rule_ids=[],
+        claims=[
+            ConflictClaim(
+                statement="Númenóreans lived approximately three times the lifespan of normal Men.",
+                source_book="Appendices to The Lord of the Rings",
+                author_period=AuthorPeriod.MIDDLE,
+                confidence=0.8,
+            ),
+            ConflictClaim(
+                statement="The greatest Númenórean kings lived 400-500 years; the lifespan decreased near the Downfall.",
+                source_book="Unfinished Tales / late texts",
+                author_period=AuthorPeriod.LATE,
+                confidence=0.85,
+            ),
+        ],
+        resolution_policy=ResolutionPolicy.BOTH_VALID_IN_UNIVERSE,
+        resolution_notes="Both figures are consistent — the later number is more specific.",
+        resolved=True,
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# ConflictRegistry
+# ---------------------------------------------------------------------------
+
+class ConflictRegistry:
+    """In-memory registry of LoreConflict objects.
+
+    Can be seeded from KNOWN_TOLKIEN_CONFLICTS, loaded from Neo4j, or built manually.
+    """
+
+    def __init__(self) -> None:
+        self._conflicts: dict[str, LoreConflict] = {}
+
+    def add(self, conflict: LoreConflict) -> None:
+        self._conflicts[conflict.id] = conflict
+
+    def add_many(self, conflicts: list[LoreConflict]) -> None:
+        for c in conflicts:
+            self.add(c)
+
+    def get(self, conflict_id: str) -> Optional[LoreConflict]:
+        return self._conflicts.get(conflict_id)
+
+    def all(self) -> list[LoreConflict]:
+        return list(self._conflicts.values())
+
+    def resolved(self) -> list[LoreConflict]:
+        return [c for c in self._conflicts.values() if c.is_resolved]
+
+    def unresolved(self) -> list[LoreConflict]:
+        return [c for c in self._conflicts.values() if not c.is_resolved]
+
+    def needing_human_review(self) -> list[LoreConflict]:
+        return [c for c in self._conflicts.values() if c.needs_human_review]
+
+    def by_entity(self, entity_id: str) -> list[LoreConflict]:
+        return [c for c in self._conflicts.values() if entity_id in c.entity_ids]
+
+    def by_rule(self, rule_id: str) -> list[LoreConflict]:
+        return [c for c in self._conflicts.values() if rule_id in c.rule_ids]
+
+    def by_type(self, conflict_type: str) -> list[LoreConflict]:
+        return [c for c in self._conflicts.values() if c.conflict_type == conflict_type]
+
+    def resolve(
+        self,
+        conflict_id: str,
+        policy: str,
+        notes: str = "",
+    ) -> bool:
+        """Apply a resolution policy to an existing conflict. Returns True if found."""
+        conflict = self._conflicts.get(conflict_id)
+        if not conflict:
+            return False
+        conflict.resolution_policy = policy
+        conflict.resolution_notes = notes or conflict.resolution_notes
+        conflict.resolved = policy not in (
+            ResolutionPolicy.FLAG_FOR_HUMAN,
+            ResolutionPolicy.IRRESOLVABLE,
+        )
+        return True
+
+    @classmethod
+    def from_tolkien_defaults(cls) -> "ConflictRegistry":
+        """Create a registry pre-loaded with all known Tolkien conflicts."""
+        registry = cls()
+        registry.add_many(KNOWN_TOLKIEN_CONFLICTS)
+        return registry
+
+    def __len__(self) -> int:
+        return len(self._conflicts)
+
+    def suppresses_violation(self, rule_id: str, entity_id: str) -> bool:
+        """Check if any conflict suppresses a lore violation for rule + entity."""
+        return any(
+            c.suppresses_lore_violation(rule_id, entity_id)
+            for c in self._conflicts.values()
+        )
+
+    def downgrades_to_soft(self, rule_id: str, entity_id: str) -> bool:
+        """Check if any conflict downgrades a HARD violation to SOFT."""
+        return any(
+            c.downgrades_to_soft(rule_id, entity_id)
+            for c in self._conflicts.values()
+        )
+
+
+# ---------------------------------------------------------------------------
+# ConflictDetector — detects conflicts when new facts are extracted
+# ---------------------------------------------------------------------------
+
+class ConflictDetector:
+    """Detects potential conflicts when a new fact is being added.
+
+    Compares incoming claims against existing registry entries and
+    flags possible contradictions for review.
+    """
+
+    def __init__(self, registry: Optional[ConflictRegistry] = None) -> None:
+        self._registry = registry or ConflictRegistry.from_tolkien_defaults()
+
+    @property
+    def registry(self) -> ConflictRegistry:
+        return self._registry
+
+    def check_entity(
+        self, entity_id: str, new_statement: str
+    ) -> list[LoreConflict]:
+        """Return any existing conflicts that involve the given entity."""
+        return self._registry.by_entity(entity_id)
+
+    def check_rule(
+        self, rule_id: str
+    ) -> list[LoreConflict]:
+        """Return any existing conflicts involving the given lore rule."""
+        return self._registry.by_rule(rule_id)
+
+    def detect_new_conflict(
+        self,
+        entity_ids: list[str],
+        rule_ids: list[str],
+        new_statement: str,
+        source_book: str,
+        author_period: str,
+        existing_statement: str,
+        existing_source: str,
+        existing_period: str,
+    ) -> LoreConflict:
+        """Create a new LoreConflict from a detected contradiction.
+
+        The conflict is returned (not auto-added to registry) so the caller
+        can decide whether to add it.
+
+        Args:
+            entity_ids: Entities involved in the contradiction.
+            rule_ids: LoreRules affected.
+            new_statement: The new incoming claim.
+            source_book: Source book for the new claim.
+            author_period: AuthorPeriod of the new claim.
+            existing_statement: The existing claim being contradicted.
+            existing_source: Source of the existing claim.
+            existing_period: AuthorPeriod of the existing claim.
+
+        Returns:
+            A new LoreConflict (not yet in registry).
+        """
+        import hashlib
+        import time
+        id_src = f"{','.join(sorted(entity_ids))}__{new_statement[:30]}"
+        conflict_id = "auto_" + hashlib.md5(id_src.encode()).hexdigest()[:8]
+
+        # Classify type: if periods differ, it's a retcon; otherwise direct contradiction
+        if author_period != existing_period:
+            conflict_type = ConflictType.RETCON
+        else:
+            conflict_type = ConflictType.DIRECT_CONTRADICTION
+
+        return LoreConflict(
+            id=conflict_id,
+            summary=f"Auto-detected conflict for entity/rule: {entity_ids or rule_ids}",
+            conflict_type=conflict_type,
+            entity_ids=entity_ids,
+            rule_ids=rule_ids,
+            claims=[
+                ConflictClaim(
+                    statement=existing_statement,
+                    source_book=existing_source,
+                    author_period=existing_period,
+                ),
+                ConflictClaim(
+                    statement=new_statement,
+                    source_book=source_book,
+                    author_period=author_period,
+                ),
+            ],
+            resolution_policy=(
+                ResolutionPolicy.USE_LATER_TEXT
+                if conflict_type == ConflictType.RETCON
+                else ResolutionPolicy.FLAG_FOR_HUMAN
+            ),
+            resolved=False,
+        )
+
+
+# ---------------------------------------------------------------------------
+# ConflictAwareValidator
+# ---------------------------------------------------------------------------
+
+class ConflictAwareValidator:
+    """Wraps LoreRuleValidator to suppress false positives from known conflicts.
+
+    Per spec:
+      - If resolution_policy = 'both_valid_in_universe' → suppress the violation entirely
+      - If resolution_policy = 'flag_for_human' → downgrade HARD to SOFT warning
+    """
+
+    def __init__(
+        self,
+        rule_validator=None,
+        conflict_registry: Optional[ConflictRegistry] = None,
+    ) -> None:
+        if rule_validator is None:
+            from .rules import LoreRuleValidator, LoreRuleRegistry
+            rule_validator = LoreRuleValidator(LoreRuleRegistry.from_tolkien_defaults())
+        self._validator = rule_validator
+        self._registry = conflict_registry or ConflictRegistry.from_tolkien_defaults()
+
+    def validate_scene_context(self, context) -> LoreValidationResult:
+        """Validate a scene context with conflict-aware suppression."""
+        from ..models.lore_rule import LoreValidationResult, LoreViolation
+
+        raw_result = self._validator.validate_scene_context(context)
+
+        filtered_hard: list[LoreViolation] = []
+        filtered_soft: list[LoreViolation] = list(raw_result.soft_warnings)
+
+        for violation in raw_result.hard_violations:
+            # Check all entities in the scene for suppression
+            entity_ids = context.character_names or ["*"]
+            suppressed = any(
+                self._registry.suppresses_violation(violation.rule_id, eid)
+                for eid in entity_ids
+            )
+            downgraded = any(
+                self._registry.downgrades_to_soft(violation.rule_id, eid)
+                for eid in entity_ids
+            )
+
+            if suppressed:
+                continue  # Drop the violation entirely
+            elif downgraded:
+                # Downgrade to soft warning
+                filtered_soft.append(LoreViolation(
+                    rule_id=violation.rule_id,
+                    rule_statement=violation.rule_statement,
+                    hardness="SOFT",
+                    description=f"[Downgraded — known conflict] {violation.description}",
+                    blocking=False,
+                ))
+            else:
+                filtered_hard.append(violation)
+
+        passed = len(filtered_hard) == 0
+        return LoreValidationResult(
+            scene_id=raw_result.scene_id,
+            passed=passed,
+            hard_violations=filtered_hard,
+            soft_warnings=filtered_soft,
+            rules_checked=raw_result.rules_checked,
+        )
+
+    def validate_text(
+        self, text: str, scene_id: str = "inline", story_era: Optional[str] = None
+    ) -> LoreValidationResult:
+        """Validate raw text with conflict suppression."""
+        from .rules import _extract_context_from_text
+        context = _extract_context_from_text(text, scene_id, story_era)
+        return self.validate_scene_context(context)
+
+
+# ---------------------------------------------------------------------------
+# LoreConflictNeo4jWriter
+# ---------------------------------------------------------------------------
+
+class LoreConflictNeo4jWriter:
+    """Write LoreConflict nodes and CONFLICTS_WITH edges to Neo4j."""
+
+    def __init__(self, driver=None) -> None:
+        self._driver = driver
+
+    @property
+    def driver(self):
+        if self._driver is None:
+            from ..graph.connection import get_driver
+            self._driver = get_driver()
+        return self._driver
+
+    def close(self) -> None:
+        if self._driver:
+            self._driver.close()
+            self._driver = None
+
+    def ensure_schema(self) -> None:
+        """Create constraint on LoreConflict.id. Idempotent."""
+        with self.driver.session() as session:
+            try:
+                session.run(
+                    "CREATE CONSTRAINT lore_conflict_id IF NOT EXISTS "
+                    "FOR (c:LoreConflict) REQUIRE c.id IS UNIQUE"
+                )
+            except Exception:
+                pass
+
+    def upsert_conflict(self, conflict: LoreConflict) -> None:
+        """Create or update a LoreConflict node (idempotent MERGE)."""
+        with self.driver.session() as session:
+            session.run(
+                "MERGE (c:LoreConflict {id: $id}) SET c += $props",
+                id=conflict.id,
+                props=conflict.to_neo4j_props(),
+            )
+
+    def upsert_many(self, conflicts: list[LoreConflict]) -> int:
+        """Write many conflicts. Returns count written."""
+        count = 0
+        with self.driver.session() as session:
+            for conflict in conflicts:
+                session.run(
+                    "MERGE (c:LoreConflict {id: $id}) SET c += $props",
+                    id=conflict.id,
+                    props=conflict.to_neo4j_props(),
+                )
+                count += 1
+        return count
+
+    def create_conflicts_with_edge(
+        self, rule_id_a: str, rule_id_b: str, conflict_id: str
+    ) -> None:
+        """Create (LoreRule)-[:CONFLICTS_WITH {conflict_id}]->(LoreRule) edge."""
+        with self.driver.session() as session:
+            session.run(
+                """
+                MATCH (a:LoreRule {id: $a})
+                MATCH (b:LoreRule {id: $b})
+                MERGE (a)-[r:CONFLICTS_WITH {conflict_id: $cid}]->(b)
+                """,
+                a=rule_id_a,
+                b=rule_id_b,
+                cid=conflict_id,
+            )
+
+    def resolve_conflict(
+        self,
+        conflict_id: str,
+        policy: str,
+        notes: str = "",
+    ) -> None:
+        """Update a LoreConflict node's resolution policy in Neo4j."""
+        resolved = policy not in (
+            ResolutionPolicy.FLAG_FOR_HUMAN,
+            ResolutionPolicy.IRRESOLVABLE,
+        )
+        with self.driver.session() as session:
+            session.run(
+                """
+                MATCH (c:LoreConflict {id: $id})
+                SET c.resolution_policy = $policy,
+                    c.resolution_notes = $notes,
+                    c.resolved = $resolved
+                """,
+                id=conflict_id,
+                policy=policy,
+                notes=notes,
+                resolved=resolved,
+            )
+
+    def query_conflicts(
+        self,
+        conflict_type: Optional[str] = None,
+        resolved: Optional[bool] = None,
+        needs_human: bool = False,
+    ) -> list[dict]:
+        """Query LoreConflict nodes from Neo4j with optional filters."""
+        where_parts = []
+        params: dict = {}
+        if conflict_type:
+            where_parts.append("c.conflict_type = $conflict_type")
+            params["conflict_type"] = conflict_type
+        if resolved is not None:
+            where_parts.append("c.resolved = $resolved")
+            params["resolved"] = resolved
+        if needs_human:
+            where_parts.append("c.resolution_policy = 'flag_for_human'")
+            where_parts.append("c.resolved = false")
+
+        where = "WHERE " + " AND ".join(where_parts) if where_parts else ""
+        with self.driver.session() as session:
+            result = session.run(
+                f"MATCH (c:LoreConflict) {where} RETURN c ORDER BY c.resolved, c.id",
+                **params,
+            )
+            return [dict(row["c"]) for row in result]

--- a/src/book_graph_analyzer/models/lore_conflict.py
+++ b/src/book_graph_analyzer/models/lore_conflict.py
@@ -1,0 +1,270 @@
+"""LoreConflict model — tracks intra/inter-book contradictions in the Tolkien corpus.
+
+Tolkien revised his legendarium constantly; contradictions are canon, not errors.
+LoreConflict nodes record these contradictions, their sources, and how to resolve
+them so the lore checker avoids false positives and false negatives.
+
+Node stored in Neo4j as (:LoreConflict { ... }).
+
+Author revision periods follow Tolkien scholarship conventions:
+  early  (~1910s-1930s): Book of Lost Tales, pre-Silmarillion
+  middle (~1940s-1960s): LotR era, first Silmarillion drafts
+  late   (~1960s-1973): The finished legendarium, Unfinished Tales manuscripts
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+from enum import Enum
+
+
+# ---------------------------------------------------------------------------
+# Enums
+# ---------------------------------------------------------------------------
+
+class ConflictType(str, Enum):
+    DIRECT_CONTRADICTION = "direct_contradiction"  # Two claims flatly contradict
+    RETCON               = "retcon"                # Later revision supersedes earlier
+    AMBIGUITY            = "ambiguity"             # Tolkien was deliberately vague
+    INTERPRETATION       = "interpretation"        # Scholars disagree, not Tolkien himself
+
+
+class ResolutionPolicy(str, Enum):
+    USE_LATER_TEXT        = "use_later_text"         # Default for retcons
+    USE_EARLIER_TEXT      = "use_earlier_text"       # Occasionally earlier is more reliable
+    BOTH_VALID_IN_UNIVERSE = "both_valid_in_universe" # In-universe narrators differ
+    FLAG_FOR_HUMAN        = "flag_for_human"          # Genuinely ambiguous
+    USE_MOST_CITED        = "use_most_cited"          # Most referenced version wins
+    IRRESOLVABLE          = "irresolvable"            # Tolkien died before resolving
+
+
+class AuthorPeriod(str, Enum):
+    EARLY  = "early"   # ~1910s-1930s: Book of Lost Tales, pre-Silmarillion
+    MIDDLE = "middle"  # ~1940s-1960s: LotR era, first Silmarillion drafts
+    LATE   = "late"    # ~1960s-1973: finished legendarium, Unfinished Tales
+
+
+# Author period ordering (earlier = smaller number)
+AUTHOR_PERIOD_ORDER: dict[str, int] = {
+    AuthorPeriod.EARLY:  0,
+    AuthorPeriod.MIDDLE: 1,
+    AuthorPeriod.LATE:   2,
+}
+
+
+# ---------------------------------------------------------------------------
+# ConflictClaim — one side of a contradiction
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ConflictClaim:
+    """A single contradictory claim within a LoreConflict.
+
+    Represents one 'side' of the conflict — a specific statement from a
+    specific source with a known author period.
+    """
+
+    statement: str                            # The conflicting claim
+    source_book: str                          # Book the claim comes from
+    author_period: str                        # AuthorPeriod value
+    confidence: float = 1.0
+    source_passage_id: Optional[str] = None   # Passage node ID if available
+
+    def to_dict(self) -> dict:
+        d = {
+            "statement": self.statement,
+            "source_book": self.source_book,
+            "author_period": self.author_period,
+            "confidence": self.confidence,
+        }
+        if self.source_passage_id:
+            d["source_passage_id"] = self.source_passage_id
+        return d
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "ConflictClaim":
+        return cls(
+            statement=d["statement"],
+            source_book=d.get("source_book", "Unknown"),
+            author_period=d.get("author_period", AuthorPeriod.MIDDLE),
+            confidence=float(d.get("confidence", 1.0)),
+            source_passage_id=d.get("source_passage_id"),
+        )
+
+    def period_order(self) -> int:
+        """Return the chronological order of this claim's author period."""
+        return AUTHOR_PERIOD_ORDER.get(self.author_period, 99)
+
+
+# ---------------------------------------------------------------------------
+# LoreConflict
+# ---------------------------------------------------------------------------
+
+@dataclass
+class LoreConflict:
+    """A tracked contradiction between two or more lore claims.
+
+    Stored as (:LoreConflict { ... }) in Neo4j.
+    Connected to LoreRules via (LoreRule)-[:CONFLICTS_WITH {conflict_id}]->(LoreRule).
+    """
+
+    id: str
+    summary: str                              # Human-readable description
+    conflict_type: str                        # ConflictType value
+    claims: list[ConflictClaim] = field(default_factory=list)
+    entity_ids: list[str] = field(default_factory=list)
+    rule_ids: list[str] = field(default_factory=list)
+    resolution_policy: str = ResolutionPolicy.FLAG_FOR_HUMAN
+    resolution_notes: str = ""
+    resolved: bool = False
+
+    @property
+    def is_resolved(self) -> bool:
+        return self.resolved
+
+    @property
+    def needs_human_review(self) -> bool:
+        return self.resolution_policy == ResolutionPolicy.FLAG_FOR_HUMAN and not self.resolved
+
+    def winning_claim(self) -> Optional[ConflictClaim]:
+        """Return the 'winning' claim per the resolution policy.
+
+        Returns None if the conflict is unresolved or both claims are valid.
+        """
+        if not self.claims:
+            return None
+
+        policy = self.resolution_policy
+
+        if policy == ResolutionPolicy.USE_LATER_TEXT:
+            # Highest author_period order wins
+            return max(self.claims, key=lambda c: c.period_order())
+
+        elif policy == ResolutionPolicy.USE_EARLIER_TEXT:
+            return min(self.claims, key=lambda c: c.period_order())
+
+        elif policy == ResolutionPolicy.USE_MOST_CITED:
+            # Highest confidence wins as a proxy for citation frequency
+            return max(self.claims, key=lambda c: c.confidence)
+
+        elif policy in (
+            ResolutionPolicy.BOTH_VALID_IN_UNIVERSE,
+            ResolutionPolicy.FLAG_FOR_HUMAN,
+            ResolutionPolicy.IRRESOLVABLE,
+        ):
+            return None  # No single winner
+
+        return None
+
+    def suppresses_lore_violation(self, rule_id: str, entity_id: str) -> bool:
+        """Should this conflict suppress a lore violation for the given rule + entity?
+
+        Returns True when the conflict covers this rule/entity and the resolution
+        policy indicates the 'violation' is actually a known ambiguity.
+        """
+        covers_rule = rule_id in self.rule_ids
+        covers_entity = not self.entity_ids or entity_id in self.entity_ids
+
+        if not (covers_rule and covers_entity):
+            return False
+
+        # both_valid_in_universe fully suppresses the violation
+        if self.resolution_policy == ResolutionPolicy.BOTH_VALID_IN_UNIVERSE:
+            return True
+
+        return False
+
+    def downgrades_to_soft(self, rule_id: str, entity_id: str) -> bool:
+        """Should a HARD violation be downgraded to SOFT due to this conflict?
+
+        Per spec: if resolution_policy = 'flag_for_human', downgrade HARD → SOFT.
+        """
+        covers_rule = rule_id in self.rule_ids
+        covers_entity = not self.entity_ids or entity_id in self.entity_ids
+
+        if not (covers_rule and covers_entity):
+            return False
+
+        return self.resolution_policy == ResolutionPolicy.FLAG_FOR_HUMAN
+
+    def to_neo4j_props(self) -> dict:
+        """Serialise to a flat Neo4j property dict (claims stored as JSON strings)."""
+        import json
+        return {
+            "id": self.id,
+            "summary": self.summary,
+            "conflict_type": self.conflict_type,
+            "entity_ids": self.entity_ids,
+            "rule_ids": self.rule_ids,
+            "claims": json.dumps([c.to_dict() for c in self.claims]),
+            "resolution_policy": self.resolution_policy,
+            "resolution_notes": self.resolution_notes,
+            "resolved": self.resolved,
+        }
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "summary": self.summary,
+            "conflict_type": self.conflict_type,
+            "claims": [c.to_dict() for c in self.claims],
+            "entity_ids": self.entity_ids,
+            "rule_ids": self.rule_ids,
+            "resolution_policy": self.resolution_policy,
+            "resolution_notes": self.resolution_notes,
+            "resolved": self.resolved,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "LoreConflict":
+        claims_raw = d.get("claims", [])
+        # Handle both JSON string (from Neo4j) and list (from Python)
+        if isinstance(claims_raw, str):
+            import json
+            claims_raw = json.loads(claims_raw)
+        return cls(
+            id=d["id"],
+            summary=d.get("summary", ""),
+            conflict_type=d.get("conflict_type", ConflictType.AMBIGUITY),
+            claims=[ConflictClaim.from_dict(c) for c in claims_raw],
+            entity_ids=list(d.get("entity_ids", [])),
+            rule_ids=list(d.get("rule_ids", [])),
+            resolution_policy=d.get("resolution_policy", ResolutionPolicy.FLAG_FOR_HUMAN),
+            resolution_notes=d.get("resolution_notes", ""),
+            resolved=bool(d.get("resolved", False)),
+        )
+
+    def brief(self) -> str:
+        """One-line summary for display."""
+        status = "✓" if self.resolved else "?"
+        return (
+            f"[{status}] {self.id}  [{self.conflict_type}]  "
+            f"({self.resolution_policy})  {self.summary[:80]}"
+        )
+
+    def detail(self) -> str:
+        """Multi-line detail for display."""
+        lines = [
+            f"Conflict: {self.id}",
+            f"  Type: {self.conflict_type}",
+            f"  Resolution: {self.resolution_policy}",
+            f"  Resolved: {'Yes' if self.resolved else 'No'}",
+            f"  Summary: {self.summary}",
+        ]
+        if self.resolution_notes:
+            lines.append(f"  Notes: {self.resolution_notes}")
+        if self.entity_ids:
+            lines.append(f"  Entities: {', '.join(self.entity_ids)}")
+        if self.rule_ids:
+            lines.append(f"  Rules: {', '.join(self.rule_ids)}")
+        lines.append(f"  Claims ({len(self.claims)}):")
+        for i, claim in enumerate(self.claims, 1):
+            lines.append(
+                f"    [{i}] ({claim.author_period} / {claim.source_book}) "
+                f"conf={claim.confidence:.0%}: {claim.statement}"
+            )
+        winner = self.winning_claim()
+        if winner:
+            lines.append(f"  → Active claim: [{winner.author_period}] {winner.statement}")
+        return "\n".join(lines)

--- a/src/book_graph_analyzer/models/passage.py
+++ b/src/book_graph_analyzer/models/passage.py
@@ -21,6 +21,13 @@ class Passage(BaseModel):
     scene_type: str | None = None  # dialogue, action, description
 
     # -----------------------------------------------------------------------
+    # Author period — when Tolkien wrote/revised this text
+    # Used for conflict resolution (later texts supersede earlier for retcons)
+    # -----------------------------------------------------------------------
+    author_period: Optional[str] = None  # 'early' | 'middle' | 'late' (AuthorPeriod)
+    source_compilation: Optional[str] = None  # e.g. 'Unfinished Tales', 'HoME Vol. 5'
+
+    # -----------------------------------------------------------------------
     # Story-time frame (when this passage *occurs* in the narrative)
     # -----------------------------------------------------------------------
     story_era: Optional[str] = None    # e.g. 'Third Age'

--- a/tests/test_conflict_tracking.py
+++ b/tests/test_conflict_tracking.py
@@ -1,0 +1,692 @@
+"""Tests for LoreConflict tracking system (Issue #7).
+
+All tests are pure-Python — no Neo4j required. Covers:
+  - LoreConflict model and ConflictClaim
+  - ConflictType, ResolutionPolicy, AuthorPeriod enums
+  - KNOWN_TOLKIEN_CONFLICTS baseline
+  - ConflictRegistry (CRUD, filters, resolution)
+  - ConflictDetector
+  - ConflictAwareValidator (suppression and downgrade logic)
+  - author_period field on Passage model
+"""
+
+import pytest
+from book_graph_analyzer.models.lore_conflict import (
+    LoreConflict,
+    ConflictClaim,
+    ConflictType,
+    ResolutionPolicy,
+    AuthorPeriod,
+    AUTHOR_PERIOD_ORDER,
+)
+from book_graph_analyzer.lore.conflicts import (
+    ConflictRegistry,
+    ConflictDetector,
+    ConflictAwareValidator,
+    KNOWN_TOLKIEN_CONFLICTS,
+)
+from book_graph_analyzer.models.passage import Passage
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def make_claim(**overrides) -> ConflictClaim:
+    defaults = dict(
+        statement="Elves cannot remarry",
+        source_book="Laws and Customs",
+        author_period=AuthorPeriod.LATE,
+        confidence=0.9,
+    )
+    defaults.update(overrides)
+    return ConflictClaim(**defaults)
+
+
+def make_conflict(**overrides) -> LoreConflict:
+    defaults = dict(
+        id="test_conflict",
+        summary="Test contradiction",
+        conflict_type=ConflictType.RETCON,
+        claims=[
+            make_claim(
+                statement="Early claim",
+                author_period=AuthorPeriod.EARLY,
+                confidence=0.7,
+            ),
+            make_claim(
+                statement="Late claim",
+                author_period=AuthorPeriod.LATE,
+                confidence=0.9,
+            ),
+        ],
+        entity_ids=["some_elf"],
+        rule_ids=["race_elf_immortal"],
+        resolution_policy=ResolutionPolicy.USE_LATER_TEXT,
+        resolved=True,
+    )
+    defaults.update(overrides)
+    return LoreConflict(**defaults)
+
+
+def make_passage(**overrides) -> Passage:
+    defaults = dict(
+        id="p_test",
+        text="Gandalf spoke.",
+        book="LOTR",
+        chapter="Ch1",
+        chapter_num=1,
+        paragraph_num=1,
+        sentence_num=1,
+        char_offset=0,
+    )
+    defaults.update(overrides)
+    return Passage(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# AuthorPeriod and ordering
+# ---------------------------------------------------------------------------
+
+class TestAuthorPeriod:
+    def test_early_before_middle(self):
+        assert AUTHOR_PERIOD_ORDER[AuthorPeriod.EARLY] < AUTHOR_PERIOD_ORDER[AuthorPeriod.MIDDLE]
+
+    def test_middle_before_late(self):
+        assert AUTHOR_PERIOD_ORDER[AuthorPeriod.MIDDLE] < AUTHOR_PERIOD_ORDER[AuthorPeriod.LATE]
+
+    def test_early_before_late(self):
+        assert AUTHOR_PERIOD_ORDER[AuthorPeriod.EARLY] < AUTHOR_PERIOD_ORDER[AuthorPeriod.LATE]
+
+    def test_all_periods_covered(self):
+        for period in (AuthorPeriod.EARLY, AuthorPeriod.MIDDLE, AuthorPeriod.LATE):
+            assert period in AUTHOR_PERIOD_ORDER
+
+
+# ---------------------------------------------------------------------------
+# ConflictClaim
+# ---------------------------------------------------------------------------
+
+class TestConflictClaim:
+    def test_basic_creation(self):
+        claim = make_claim()
+        assert claim.statement == "Elves cannot remarry"
+        assert claim.author_period == AuthorPeriod.LATE
+
+    def test_period_order_late_is_highest(self):
+        early = make_claim(author_period=AuthorPeriod.EARLY)
+        late = make_claim(author_period=AuthorPeriod.LATE)
+        assert late.period_order() > early.period_order()
+
+    def test_source_passage_id_optional(self):
+        claim = make_claim()
+        assert claim.source_passage_id is None
+
+    def test_to_dict_roundtrip(self):
+        claim = make_claim(source_passage_id="p_001")
+        d = claim.to_dict()
+        claim2 = ConflictClaim.from_dict(d)
+        assert claim2.statement == claim.statement
+        assert claim2.author_period == claim.author_period
+        assert claim2.source_passage_id == "p_001"
+
+    def test_to_dict_omits_none_passage_id(self):
+        claim = make_claim()
+        d = claim.to_dict()
+        assert "source_passage_id" not in d
+
+
+# ---------------------------------------------------------------------------
+# LoreConflict model
+# ---------------------------------------------------------------------------
+
+class TestLoreConflict:
+    def test_basic_creation(self):
+        c = make_conflict()
+        assert c.id == "test_conflict"
+        assert c.conflict_type == ConflictType.RETCON
+
+    def test_is_resolved_property(self):
+        c = make_conflict(resolved=True)
+        assert c.is_resolved is True
+
+        c2 = make_conflict(resolved=False)
+        assert c2.is_resolved is False
+
+    def test_needs_human_review_false_when_resolved(self):
+        c = make_conflict(
+            resolution_policy=ResolutionPolicy.FLAG_FOR_HUMAN,
+            resolved=True,
+        )
+        assert c.needs_human_review is False
+
+    def test_needs_human_review_true_when_flagged_and_unresolved(self):
+        c = make_conflict(
+            resolution_policy=ResolutionPolicy.FLAG_FOR_HUMAN,
+            resolved=False,
+        )
+        assert c.needs_human_review is True
+
+    def test_winning_claim_use_later_text(self):
+        c = make_conflict(resolution_policy=ResolutionPolicy.USE_LATER_TEXT)
+        winner = c.winning_claim()
+        assert winner is not None
+        assert winner.author_period == AuthorPeriod.LATE
+
+    def test_winning_claim_use_earlier_text(self):
+        c = make_conflict(resolution_policy=ResolutionPolicy.USE_EARLIER_TEXT)
+        winner = c.winning_claim()
+        assert winner is not None
+        assert winner.author_period == AuthorPeriod.EARLY
+
+    def test_winning_claim_both_valid_returns_none(self):
+        c = make_conflict(resolution_policy=ResolutionPolicy.BOTH_VALID_IN_UNIVERSE)
+        assert c.winning_claim() is None
+
+    def test_winning_claim_flag_for_human_returns_none(self):
+        c = make_conflict(resolution_policy=ResolutionPolicy.FLAG_FOR_HUMAN)
+        assert c.winning_claim() is None
+
+    def test_winning_claim_irresolvable_returns_none(self):
+        c = make_conflict(resolution_policy=ResolutionPolicy.IRRESOLVABLE)
+        assert c.winning_claim() is None
+
+    def test_winning_claim_use_most_cited(self):
+        c = make_conflict(
+            resolution_policy=ResolutionPolicy.USE_MOST_CITED,
+            claims=[
+                make_claim(statement="Low conf", confidence=0.5),
+                make_claim(statement="High conf", confidence=0.95),
+            ],
+        )
+        winner = c.winning_claim()
+        assert winner is not None
+        assert winner.confidence == 0.95
+
+    def test_suppresses_lore_violation_both_valid(self):
+        c = make_conflict(
+            rule_ids=["race_elf_immortal"],
+            entity_ids=["glorfindel"],
+            resolution_policy=ResolutionPolicy.BOTH_VALID_IN_UNIVERSE,
+        )
+        assert c.suppresses_lore_violation("race_elf_immortal", "glorfindel") is True
+
+    def test_suppresses_lore_violation_other_policy(self):
+        c = make_conflict(
+            rule_ids=["race_elf_immortal"],
+            entity_ids=["glorfindel"],
+            resolution_policy=ResolutionPolicy.USE_LATER_TEXT,
+        )
+        assert c.suppresses_lore_violation("race_elf_immortal", "glorfindel") is False
+
+    def test_suppresses_lore_violation_wrong_rule(self):
+        c = make_conflict(
+            rule_ids=["race_elf_immortal"],
+            entity_ids=[],
+            resolution_policy=ResolutionPolicy.BOTH_VALID_IN_UNIVERSE,
+        )
+        assert c.suppresses_lore_violation("magic_ring_corruption", "sauron") is False
+
+    def test_downgrades_to_soft_flag_for_human(self):
+        c = make_conflict(
+            rule_ids=["race_elf_immortal"],
+            entity_ids=["glorfindel"],
+            resolution_policy=ResolutionPolicy.FLAG_FOR_HUMAN,
+        )
+        assert c.downgrades_to_soft("race_elf_immortal", "glorfindel") is True
+
+    def test_downgrades_to_soft_other_policy(self):
+        c = make_conflict(
+            rule_ids=["race_elf_immortal"],
+            entity_ids=[],
+            resolution_policy=ResolutionPolicy.USE_LATER_TEXT,
+        )
+        assert c.downgrades_to_soft("race_elf_immortal", "anyone") is False
+
+    def test_to_dict_roundtrip(self):
+        c = make_conflict()
+        d = c.to_dict()
+        c2 = LoreConflict.from_dict(d)
+        assert c2.id == c.id
+        assert c2.summary == c.summary
+        assert c2.conflict_type == c.conflict_type
+        assert len(c2.claims) == len(c.claims)
+
+    def test_from_dict_claims_as_json_string(self):
+        """from_dict should handle claims stored as JSON string (Neo4j format)."""
+        import json
+        c = make_conflict()
+        d = c.to_neo4j_props()
+        # to_neo4j_props stores claims as JSON string
+        d2 = dict(d)
+        c2 = LoreConflict.from_dict(d2)
+        assert len(c2.claims) == 2
+
+    def test_brief_contains_id(self):
+        c = make_conflict()
+        brief = c.brief()
+        assert c.id in brief
+
+    def test_detail_contains_claims(self):
+        c = make_conflict()
+        detail = c.detail()
+        assert "Early claim" in detail
+        assert "Late claim" in detail
+
+    def test_detail_shows_winning_claim(self):
+        c = make_conflict(resolution_policy=ResolutionPolicy.USE_LATER_TEXT)
+        detail = c.detail()
+        assert "Active claim" in detail
+
+
+# ---------------------------------------------------------------------------
+# KNOWN_TOLKIEN_CONFLICTS baseline
+# ---------------------------------------------------------------------------
+
+class TestKnownTolkienConflicts:
+    def test_at_least_five_conflicts(self):
+        assert len(KNOWN_TOLKIEN_CONFLICTS) >= 5
+
+    def test_blue_wizards_conflict_exists(self):
+        ids = {c.id for c in KNOWN_TOLKIEN_CONFLICTS}
+        assert "blue_wizards_names" in ids
+
+    def test_glorfindel_conflict_exists(self):
+        ids = {c.id for c in KNOWN_TOLKIEN_CONFLICTS}
+        assert "glorfindel_identity" in ids
+
+    def test_bombadil_conflict_exists(self):
+        ids = {c.id for c in KNOWN_TOLKIEN_CONFLICTS}
+        assert "bombadil_nature" in ids
+
+    def test_elvish_mortality_conflict_exists(self):
+        ids = {c.id for c in KNOWN_TOLKIEN_CONFLICTS}
+        assert "elvish_mortality" in ids
+
+    def test_all_conflict_types_represented(self):
+        types = {c.conflict_type for c in KNOWN_TOLKIEN_CONFLICTS}
+        assert ConflictType.RETCON in types
+        assert ConflictType.AMBIGUITY in types
+
+    def test_all_author_periods_used(self):
+        periods = set()
+        for c in KNOWN_TOLKIEN_CONFLICTS:
+            for claim in c.claims:
+                periods.add(claim.author_period)
+        assert AuthorPeriod.EARLY in periods
+        assert AuthorPeriod.MIDDLE in periods
+        assert AuthorPeriod.LATE in periods
+
+    def test_all_conflicts_have_claims(self):
+        for c in KNOWN_TOLKIEN_CONFLICTS:
+            assert len(c.claims) >= 2, f"{c.id} should have at least 2 claims"
+
+    def test_all_conflicts_have_summaries(self):
+        for c in KNOWN_TOLKIEN_CONFLICTS:
+            assert len(c.summary) > 20, f"{c.id} summary too short"
+
+    def test_bombadil_is_irresolvable(self):
+        bombadil = next(c for c in KNOWN_TOLKIEN_CONFLICTS if c.id == "bombadil_nature")
+        assert bombadil.resolution_policy == ResolutionPolicy.IRRESOLVABLE
+        assert bombadil.resolved is False
+
+    def test_glorfindel_is_resolved_with_later_text(self):
+        glorfindel = next(c for c in KNOWN_TOLKIEN_CONFLICTS if c.id == "glorfindel_identity")
+        assert glorfindel.resolution_policy == ResolutionPolicy.USE_LATER_TEXT
+        assert glorfindel.resolved is True
+
+    def test_glorfindel_covers_elf_rule(self):
+        glorfindel = next(c for c in KNOWN_TOLKIEN_CONFLICTS if c.id == "glorfindel_identity")
+        assert "race_elf_immortal" in glorfindel.rule_ids
+
+    def test_blue_wizards_is_both_valid(self):
+        bw = next(c for c in KNOWN_TOLKIEN_CONFLICTS if c.id == "blue_wizards_names")
+        assert bw.resolution_policy == ResolutionPolicy.BOTH_VALID_IN_UNIVERSE
+
+
+# ---------------------------------------------------------------------------
+# ConflictRegistry
+# ---------------------------------------------------------------------------
+
+class TestConflictRegistry:
+    def test_empty_registry(self):
+        reg = ConflictRegistry()
+        assert len(reg) == 0
+
+    def test_add_and_get(self):
+        reg = ConflictRegistry()
+        c = make_conflict(id="my_conflict")
+        reg.add(c)
+        assert reg.get("my_conflict") is c
+
+    def test_get_missing_returns_none(self):
+        reg = ConflictRegistry()
+        assert reg.get("nonexistent") is None
+
+    def test_add_many(self):
+        reg = ConflictRegistry()
+        reg.add_many([make_conflict(id=f"c{i}") for i in range(5)])
+        assert len(reg) == 5
+
+    def test_all_returns_all(self):
+        reg = ConflictRegistry()
+        reg.add_many([make_conflict(id=f"c{i}") for i in range(3)])
+        assert len(reg.all()) == 3
+
+    def test_resolved_filter(self):
+        reg = ConflictRegistry()
+        reg.add(make_conflict(id="res", resolved=True))
+        reg.add(make_conflict(id="unres", resolved=False))
+        assert len(reg.resolved()) == 1
+        assert reg.resolved()[0].id == "res"
+
+    def test_unresolved_filter(self):
+        reg = ConflictRegistry()
+        reg.add(make_conflict(id="res", resolved=True))
+        reg.add(make_conflict(id="unres", resolved=False))
+        assert len(reg.unresolved()) == 1
+        assert reg.unresolved()[0].id == "unres"
+
+    def test_needing_human_review(self):
+        reg = ConflictRegistry()
+        reg.add(make_conflict(
+            id="human",
+            resolution_policy=ResolutionPolicy.FLAG_FOR_HUMAN,
+            resolved=False,
+        ))
+        reg.add(make_conflict(id="auto", resolved=True))
+        reviews = reg.needing_human_review()
+        assert len(reviews) == 1
+        assert reviews[0].id == "human"
+
+    def test_by_entity_filter(self):
+        reg = ConflictRegistry()
+        reg.add(make_conflict(id="c1", entity_ids=["glorfindel"]))
+        reg.add(make_conflict(id="c2", entity_ids=["sauron"]))
+        results = reg.by_entity("glorfindel")
+        assert len(results) == 1
+        assert results[0].id == "c1"
+
+    def test_by_rule_filter(self):
+        reg = ConflictRegistry()
+        reg.add(make_conflict(id="c1", rule_ids=["race_elf_immortal"]))
+        reg.add(make_conflict(id="c2", rule_ids=["magic_ring_corruption"]))
+        results = reg.by_rule("race_elf_immortal")
+        assert len(results) == 1
+
+    def test_by_type_filter(self):
+        reg = ConflictRegistry()
+        reg.add(make_conflict(id="retcon", conflict_type=ConflictType.RETCON))
+        reg.add(make_conflict(id="ambi", conflict_type=ConflictType.AMBIGUITY))
+        assert len(reg.by_type(ConflictType.RETCON)) == 1
+
+    def test_resolve_applies_policy(self):
+        reg = ConflictRegistry()
+        reg.add(make_conflict(
+            id="my_conflict",
+            resolution_policy=ResolutionPolicy.FLAG_FOR_HUMAN,
+            resolved=False,
+        ))
+        success = reg.resolve("my_conflict", ResolutionPolicy.USE_LATER_TEXT, "test")
+        assert success is True
+        c = reg.get("my_conflict")
+        assert c.resolution_policy == ResolutionPolicy.USE_LATER_TEXT
+        assert c.resolved is True
+
+    def test_resolve_returns_false_for_missing(self):
+        reg = ConflictRegistry()
+        assert reg.resolve("nonexistent", ResolutionPolicy.USE_LATER_TEXT) is False
+
+    def test_suppresses_violation(self):
+        reg = ConflictRegistry()
+        reg.add(make_conflict(
+            id="c1",
+            rule_ids=["race_elf_immortal"],
+            entity_ids=["glorfindel"],
+            resolution_policy=ResolutionPolicy.BOTH_VALID_IN_UNIVERSE,
+        ))
+        assert reg.suppresses_violation("race_elf_immortal", "glorfindel") is True
+        assert reg.suppresses_violation("race_elf_immortal", "legolas") is False
+
+    def test_downgrades_to_soft(self):
+        reg = ConflictRegistry()
+        reg.add(make_conflict(
+            id="c1",
+            rule_ids=["race_elf_immortal"],
+            entity_ids=["glorfindel"],
+            resolution_policy=ResolutionPolicy.FLAG_FOR_HUMAN,
+        ))
+        assert reg.downgrades_to_soft("race_elf_immortal", "glorfindel") is True
+        assert reg.downgrades_to_soft("magic_ring_corruption", "glorfindel") is False
+
+    def test_from_tolkien_defaults_has_known_conflicts(self):
+        reg = ConflictRegistry.from_tolkien_defaults()
+        assert len(reg) >= 5
+        assert reg.get("glorfindel_identity") is not None
+        assert reg.get("bombadil_nature") is not None
+        assert reg.get("blue_wizards_names") is not None
+
+
+# ---------------------------------------------------------------------------
+# ConflictDetector
+# ---------------------------------------------------------------------------
+
+class TestConflictDetector:
+    def setup_method(self):
+        self.detector = ConflictDetector()
+
+    def test_check_entity_returns_conflicts(self):
+        conflicts = self.detector.check_entity("glorfindel", "new statement")
+        ids = [c.id for c in conflicts]
+        assert "glorfindel_identity" in ids
+
+    def test_check_entity_empty_for_unknown(self):
+        conflicts = self.detector.check_entity("unknown_entity_xyz", "statement")
+        assert conflicts == []
+
+    def test_check_rule_returns_conflicts(self):
+        conflicts = self.detector.check_rule("race_elf_immortal")
+        # glorfindel_identity and elvish_mortality both reference this rule
+        assert len(conflicts) >= 1
+
+    def test_detect_new_conflict_retcon(self):
+        conflict = self.detector.detect_new_conflict(
+            entity_ids=["some_elf"],
+            rule_ids=["race_elf_immortal"],
+            new_statement="Elves can die from despair",
+            source_book="Early Tales",
+            author_period=AuthorPeriod.EARLY,
+            existing_statement="Elves cannot die of age or disease",
+            existing_source="Laws and Customs",
+            existing_period=AuthorPeriod.LATE,
+        )
+        assert conflict.conflict_type == ConflictType.RETCON
+        assert "some_elf" in conflict.entity_ids
+        assert len(conflict.claims) == 2
+
+    def test_detect_new_conflict_same_period_is_direct(self):
+        conflict = self.detector.detect_new_conflict(
+            entity_ids=["aragorn"],
+            rule_ids=[],
+            new_statement="Aragorn is mortal",
+            source_book="Book A",
+            author_period=AuthorPeriod.MIDDLE,
+            existing_statement="Aragorn is immortal",
+            existing_source="Book B",
+            existing_period=AuthorPeriod.MIDDLE,
+        )
+        assert conflict.conflict_type == ConflictType.DIRECT_CONTRADICTION
+
+    def test_detect_new_conflict_retcon_uses_later_text_policy(self):
+        conflict = self.detector.detect_new_conflict(
+            entity_ids=["elf"],
+            rule_ids=[],
+            new_statement="New fact",
+            source_book="Late Book",
+            author_period=AuthorPeriod.LATE,
+            existing_statement="Old fact",
+            existing_source="Early Book",
+            existing_period=AuthorPeriod.EARLY,
+        )
+        assert conflict.resolution_policy == ResolutionPolicy.USE_LATER_TEXT
+
+    def test_detect_new_conflict_direct_flags_for_human(self):
+        conflict = self.detector.detect_new_conflict(
+            entity_ids=[],
+            rule_ids=["some_rule"],
+            new_statement="X",
+            source_book="A",
+            author_period=AuthorPeriod.MIDDLE,
+            existing_statement="Y",
+            existing_source="B",
+            existing_period=AuthorPeriod.MIDDLE,
+        )
+        assert conflict.resolution_policy == ResolutionPolicy.FLAG_FOR_HUMAN
+
+    def test_auto_generated_id_starts_with_auto(self):
+        conflict = self.detector.detect_new_conflict(
+            entity_ids=["entity"],
+            rule_ids=[],
+            new_statement="new",
+            source_book="book",
+            author_period=AuthorPeriod.MIDDLE,
+            existing_statement="old",
+            existing_source="book2",
+            existing_period=AuthorPeriod.MIDDLE,
+        )
+        assert conflict.id.startswith("auto_")
+
+
+# ---------------------------------------------------------------------------
+# ConflictAwareValidator — suppression and downgrade
+# ---------------------------------------------------------------------------
+
+class TestConflictAwareValidator:
+    def setup_method(self):
+        self.validator = ConflictAwareValidator()
+
+    def test_clean_text_passes(self):
+        result = self.validator.validate_text("Frodo sat by the fire.")
+        assert result.passed is True
+
+    def test_bombadil_ring_suppressed(self):
+        """Tom Bombadil's Ring immunity is covered by bombadil_nature conflict.
+
+        However, since bombadil_nature's policy is IRRESOLVABLE (not both_valid),
+        violations are not suppressed — they're preserved. This tests that logic.
+        """
+        # Bombadil conflict policy is IRRESOLVABLE — does not suppress violations
+        from book_graph_analyzer.lore.conflicts import ConflictRegistry
+        reg = ConflictRegistry.from_tolkien_defaults()
+        bombadil = reg.get("bombadil_nature")
+        # IRRESOLVABLE does not suppress — suppression only happens for BOTH_VALID_IN_UNIVERSE
+        assert not bombadil.suppresses_lore_violation("magic_ring_corruption", "tom_bombadil")
+
+    def test_both_valid_universe_suppresses_violation(self):
+        """A conflict with BOTH_VALID_IN_UNIVERSE should suppress violations."""
+        from book_graph_analyzer.lore.rules import LoreRuleRegistry, LoreRuleValidator, SceneContext
+        from book_graph_analyzer.lore.conflicts import ConflictRegistry, ConflictAwareValidator
+
+        # Set up a conflict that suppresses race_elf_immortal for glorfindel
+        conflict_reg = ConflictRegistry()
+        from book_graph_analyzer.models.lore_conflict import LoreConflict, ConflictClaim
+        conflict_reg.add(LoreConflict(
+            id="test_suppressor",
+            summary="Test suppression",
+            conflict_type=ConflictType.AMBIGUITY,
+            rule_ids=["race_elf_immortal"],
+            entity_ids=["glorfindel"],  # entity name as used in scene context
+            resolution_policy=ResolutionPolicy.BOTH_VALID_IN_UNIVERSE,
+            claims=[make_claim(), make_claim()],
+        ))
+
+        rule_reg = LoreRuleRegistry.from_tolkien_defaults()
+        rule_validator = LoreRuleValidator(rule_reg)
+        validator = ConflictAwareValidator(rule_validator, conflict_reg)
+
+        # Create a scene with Glorfindel and a death_by_age event
+        ctx = SceneContext(
+            scene_id="s1",
+            character_names=["glorfindel"],
+            character_races={"glorfindel": "Elf"},
+            place_names=[],
+            object_names=[],
+            event_types=["death_by_age"],
+            story_era="Third Age",
+        )
+
+        result = validator.validate_scene_context(ctx)
+        # Violation for race_elf_immortal should be suppressed
+        hard_ids = {v.rule_id for v in result.hard_violations}
+        assert "race_elf_immortal" not in hard_ids
+
+    def test_flag_for_human_downgrades_hard_to_soft(self):
+        """A conflict with FLAG_FOR_HUMAN should downgrade HARD → SOFT."""
+        from book_graph_analyzer.lore.rules import LoreRuleRegistry, LoreRuleValidator, SceneContext
+        from book_graph_analyzer.lore.conflicts import ConflictRegistry, ConflictAwareValidator
+
+        conflict_reg = ConflictRegistry()
+        from book_graph_analyzer.models.lore_conflict import LoreConflict, ConflictClaim
+        conflict_reg.add(LoreConflict(
+            id="test_downgrader",
+            summary="Test downgrade",
+            conflict_type=ConflictType.AMBIGUITY,
+            rule_ids=["race_elf_immortal"],
+            entity_ids=["legolas"],
+            resolution_policy=ResolutionPolicy.FLAG_FOR_HUMAN,
+            claims=[make_claim(), make_claim()],
+        ))
+
+        rule_reg = LoreRuleRegistry.from_tolkien_defaults()
+        rule_validator = LoreRuleValidator(rule_reg)
+        validator = ConflictAwareValidator(rule_validator, conflict_reg)
+
+        ctx = SceneContext(
+            scene_id="s1",
+            character_names=["legolas"],
+            character_races={"legolas": "Elf"},
+            place_names=[],
+            object_names=[],
+            event_types=["death_by_age"],
+            story_era="Third Age",
+        )
+
+        result = validator.validate_scene_context(ctx)
+        # Should be moved from hard to soft
+        hard_ids = {v.rule_id for v in result.hard_violations}
+        soft_ids = {v.rule_id for v in result.soft_warnings}
+        assert "race_elf_immortal" not in hard_ids
+        assert "race_elf_immortal" in soft_ids
+
+
+# ---------------------------------------------------------------------------
+# author_period on Passage model
+# ---------------------------------------------------------------------------
+
+class TestPassageAuthorPeriod:
+    def test_author_period_default_none(self):
+        p = make_passage()
+        assert p.author_period is None
+
+    def test_author_period_can_be_set(self):
+        p = make_passage(author_period=AuthorPeriod.LATE)
+        assert p.author_period == AuthorPeriod.LATE
+
+    def test_source_compilation_default_none(self):
+        p = make_passage()
+        assert p.source_compilation is None
+
+    def test_source_compilation_can_be_set(self):
+        p = make_passage(source_compilation="Unfinished Tales")
+        assert p.source_compilation == "Unfinished Tales"
+
+    def test_passage_still_works_without_new_fields(self):
+        """Existing Passage code still works — new fields are optional."""
+        p = make_passage()
+        assert p.text == "Gandalf spoke."
+        assert p.book == "LOTR"
+
+    def test_all_periods_valid_strings(self):
+        for period in (AuthorPeriod.EARLY, AuthorPeriod.MIDDLE, AuthorPeriod.LATE):
+            p = make_passage(author_period=period)
+            assert p.author_period == period


### PR DESCRIPTION
## Summary

Implements Issue #7 — Conflict Tracking for intra/inter-book Tolkien contradictions.

## What's Built

### 1. LoreConflict model (models/lore_conflict.py)
Full spec implementation:
- id, summary, conflict_type (direct_contradiction/retcon/ambiguity/interpretation)
- claims: [ConflictClaim] — each claim has statement, source_book, uthor_period, confidence, source_passage_id
- entity_ids, ule_ids — what the conflict involves
- esolution_policy (use_later_text/use_earlier_text/both_valid_in_universe/flag_for_human/use_most_cited/irresolvable)
- esolution_notes, esolved

Key methods:
- winning_claim() — returns active claim per policy
- suppresses_lore_violation(rule_id, entity_id) — returns True for BOTH_VALID_IN_UNIVERSE
- downgrades_to_soft(rule_id, entity_id) — returns True for FLAG_FOR_HUMAN
- 	o_neo4j_props() / 	o_dict() / rom_dict() (handles JSON-string claims from Neo4j)

### 2. Author Period Tracking (AuthorPeriod enum)
- early (~1910s-1930s), middle (~1940s-1960s), late (~1960s-1973)
- AUTHOR_PERIOD_ORDER for USE_LATER_TEXT / USE_EARLIER_TEXT resolution
- Added uthor_period + source_compilation fields to Passage model

### 3. Pre-seeded Tolkien Conflicts (8 baseline conflicts)
All major known contradictions from the issue + more:
| ID | Type | Policy |
|---|---|---|
| lue_wizards_names | retcon | both_valid_in_universe |
| glorfindel_identity | retcon | use_later_text ✓ |
| ombadil_nature | ambiguity | irresolvable |
| elvish_mortality | retcon | use_later_text ✓ |
| alrog_count_and_wings | retcon | use_later_text ✓ |
| orc_origin | retcon | flag_for_human |
| elvish_remarriage | ambiguity | use_later_text ✓ |
| 
umenorean_lifespan | ambiguity | both_valid_in_universe |

### 4. ConflictRegistry
In-memory registry with filters: esolved(), unresolved(), 
eeding_human_review(), y_entity(), y_rule(), y_type(), esolve(), suppresses_violation(), downgrades_to_soft().

### 5. ConflictDetector
Detects new conflicts during extraction:
- check_entity() / check_rule() — find existing related conflicts
- detect_new_conflict() — auto-creates a LoreConflict from contradicting claims
  - Retcon (different periods) → USE_LATER_TEXT policy
  - Direct contradiction (same period) → FLAG_FOR_HUMAN policy

### 6. ConflictAwareValidator
Wraps LoreRuleValidator with conflict suppression:
- BOTH_VALID_IN_UNIVERSE → suppress violation entirely
- FLAG_FOR_HUMAN → downgrade HARD → SOFT warning
- All other policies → violation passes through unchanged

### 7. LoreConflictNeo4jWriter
- upsert_conflict() / upsert_many() — write (:LoreConflict) nodes (idempotent MERGE)
- create_conflicts_with_edge() — (LoreRule)-[:CONFLICTS_WITH {conflict_id}]->(LoreRule)
- esolve_conflict() — update resolution policy in Neo4j
- query_conflicts() with type/resolved/needs_human filters

### 8. CLI Commands
`
bga lore conflicts list [--conflict-type retcon] [--resolved] [--unresolved] [--neo4j]
bga lore conflicts show glorfindel_identity
bga lore conflicts unresolved
bga lore conflicts resolve --id orc_origin --policy use_later_text --notes '...'
bga lore conflicts init [--dry-run]
`

### 9. Infrastructure: conftest.py
Added conftest.py to ensure workspace src/ takes precedence over the editable install pointing to a different clone.

### 10. Tests — 76 passing (	ests/test_conflict_tracking.py)
All pure-Python, no Neo4j required.
