### PR TITLE
feat: Character Emotional Arc + Relationship Sentiment Valence (#8)

### DIFF
--- a/src/book_graph_analyzer/cli.py
+++ b/src/book_graph_analyzer/cli.py
@@ -2692,6 +2692,212 @@ def lore_top_passages(limit: int, min_score: float) -> None:
     console.print(table)
 
 
+@lore.command(name="arc")
+@click.option("--character", "-c", required=True,
+              help="Character name (e.g. 'Frodo', 'Sam', 'Gandalf')")
+@click.option("--year", "-y", default=None, type=int,
+              help="Show expected state at a specific story year")
+def lore_arc(character: str, year: int | None) -> None:
+    """Show a character's canonical emotional arc.
+
+    Displays all arc checkpoints with valid/invalid registers.
+
+    Examples:
+        bga lore arc --character Frodo
+        bga lore arc --character Frodo --year 3019
+        bga lore arc --character Sam
+    """
+    from book_graph_analyzer.lore.emotional_arc import EmotionalArcValidator
+
+    validator = EmotionalArcValidator()
+    arc = validator.get_arc(character)
+
+    if not arc:
+        console.print(f"[red]No canonical arc found for '{character}'.[/red]")
+        console.print(f"\n[bold]Characters with registered arcs:[/bold]")
+        for name in validator.all_characters():
+            console.print(f"  {name}")
+        return
+
+    console.print(f"\n[bold]Emotional Arc:[/bold] [cyan]{arc.character_name}[/cyan]\n")
+
+    if year is not None:
+        cp = validator.expected_state(character, year)
+        if not cp:
+            console.print(f"[yellow]No checkpoint covers TA {year} for {arc.character_name}.[/yellow]")
+        else:
+            console.print(f"[bold]At TA {year} — Checkpoint: '{cp.label}'[/bold]")
+            console.print(f"  {cp.description}")
+            console.print(f"  Register: [cyan]{cp.emotional_state.dominant_register if cp.emotional_state else '?'}[/cyan]")
+            console.print(f"  Valence:  {cp.emotional_state.valence:.2f}  Agency: {cp.emotional_state.agency:.2f}" if cp.emotional_state else "")
+            console.print(f"  Hardness: {'[red]HARD[/red]' if cp.hardness == 'HARD' else '[yellow]SOFT[/yellow]'}")
+            if cp.valid_registers:
+                console.print(f"  Valid: {', '.join(cp.valid_registers)}")
+            if cp.invalid_registers:
+                console.print(f"  [red]Invalid: {', '.join(cp.invalid_registers)}[/red]")
+        return
+
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("Label", style="cyan", width=26)
+    table.add_column("Year(s)", width=12)
+    table.add_column("Register", width=16)
+    table.add_column("Val", justify="right", width=5)
+    table.add_column("Agt", justify="right", width=5)
+    table.add_column("Hard", width=6)
+    table.add_column("Context")
+
+    for cp in arc.checkpoints:
+        yr = str(cp.story_year)
+        if cp.story_year_end:
+            yr += f"-{cp.story_year_end}"
+        reg = cp.emotional_state.dominant_register if cp.emotional_state else "?"
+        val = f"{cp.emotional_state.valence:+.1f}" if cp.emotional_state else "-"
+        agt = f"{cp.emotional_state.agency:+.1f}" if cp.emotional_state else "-"
+        hard = "[red]HARD[/red]" if cp.hardness == "HARD" else "[yellow]SOFT[/yellow]"
+        context = cp.description[:70] + "..." if len(cp.description) > 70 else cp.description
+        table.add_row(cp.label, yr, reg, val, agt, hard, context)
+
+    console.print(table)
+    hard = sum(1 for cp in arc.checkpoints if cp.hardness == "HARD")
+    console.print(f"\n  {len(arc.checkpoints)} checkpoints · {hard} HARD")
+
+
+@lore.command(name="validate-arc")
+@click.option("--character", "-c", required=True,
+              help="Character name (e.g. 'Frodo', 'Sam', 'Gandalf')")
+@click.option("--story-year", "-y", required=True, type=int,
+              help="Story year in Third Age (e.g. 3019)")
+@click.option("--generated-state", "-s", default=None,
+              help="Proposed emotional state (register name or description text)")
+@click.option("--text", "-t", default=None,
+              help="Full passage text to extract state from automatically")
+def lore_validate_arc(
+    character: str,
+    story_year: int,
+    generated_state: str | None,
+    text: str | None,
+) -> None:
+    """Validate a character's emotional state against the canonical arc.
+
+    Checks whether the proposed state is consistent with what is canonically
+    expected at this point in the story.
+
+    Examples:
+        bga lore validate-arc --character Frodo --story-year 3019 --generated-state 'cozy'
+        bga lore validate-arc --character Frodo --story-year 3019 \\
+            --text "Frodo felt hopeful and light-hearted as he walked through Mordor."
+        bga lore validate-arc --character Sam --story-year 3019 --generated-state 'resolute'
+    """
+    from book_graph_analyzer.lore.emotional_arc import (
+        EmotionalArcValidator, extract_emotional_state_from_text
+    )
+
+    validator = EmotionalArcValidator()
+
+    if not generated_state and not text:
+        console.print("[red]Provide --generated-state or --text.[/red]")
+        return
+
+    if text:
+        is_valid, detected_register, explanation = validator.validate_arc_from_text(
+            character=character,
+            story_year=story_year,
+            text=text,
+        )
+        console.print(f"\n[bold]Arc Validation:[/bold] {character} at TA {story_year}\n")
+        console.print(f"  Extracted register: [cyan]{detected_register}[/cyan]")
+        if is_valid:
+            console.print(f"  [bold green]✓ PASS[/bold green]")
+        else:
+            console.print(f"  [bold red]✗ VIOLATION[/bold red]")
+        console.print(f"\n  {explanation}")
+    else:
+        is_valid, explanation = validator.validate_arc(
+            character=character,
+            story_year=story_year,
+            proposed_register=generated_state,
+        )
+        console.print(f"\n[bold]Arc Validation:[/bold] {character} at TA {story_year}\n")
+        console.print(f"  Proposed register: [cyan]{generated_state}[/cyan]")
+        if is_valid:
+            console.print(f"  [bold green]✓ PASS[/bold green]")
+        else:
+            console.print(f"  [bold red]✗ VIOLATION[/bold red]")
+        console.print(f"\n  {explanation}")
+
+    # Show the expected checkpoint
+    cp = validator.expected_state(character, story_year)
+    if cp:
+        console.print(f"\n[dim]Expected checkpoint '{cp.label}':")
+        console.print(f"  Valid: {cp.valid_registers}")
+        if cp.invalid_registers:
+            console.print(f"  [red]Invalid: {cp.invalid_registers}[/red]")
+        console.print(f"[/dim]")
+
+
+@lore.command(name="sentiment")
+@click.option("--from-character", "-f", default=None,
+              help="Filter by source character")
+@click.option("--to-character", "-t", default=None,
+              help="Filter by target character")
+def lore_sentiment(
+    from_character: str | None,
+    to_character: str | None,
+) -> None:
+    """Show canonical relational sentiment between characters.
+
+    Demonstrates the asymmetric nature of relationships (how A feels about B
+    is not the same as how B feels about A).
+
+    Examples:
+        bga lore sentiment
+        bga lore sentiment --from-character samwise_gamgee
+        bga lore sentiment --to-character frodo_baggins
+    """
+    from book_graph_analyzer.lore.emotional_arc import TOLKIEN_RELATIONSHIP_SENTIMENTS
+
+    edges = TOLKIEN_RELATIONSHIP_SENTIMENTS
+    if from_character:
+        edges = [e for e in edges if e.from_character_id == from_character]
+    if to_character:
+        edges = [e for e in edges if e.to_character_id == to_character]
+
+    if not edges:
+        console.print("[yellow]No matching sentiment edges.[/yellow]")
+        return
+
+    console.print(f"\n[bold]Relational Sentiments ({len(edges)})[/bold]\n")
+
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("From", style="cyan", width=20)
+    table.add_column("→ To", style="cyan", width=20)
+    table.add_column("Sentiment", width=12)
+    table.add_column("Valence", justify="right", width=8)
+    table.add_column("Trajectory", width=14)
+
+    for e in edges:
+        val_str = f"{e.valence:+.2f}"
+        traj_color = (
+            "[green]" if e.valence_trajectory == "improving" else
+            "[red]" if e.valence_trajectory == "deteriorating" else
+            "[yellow]" if e.valence_trajectory == "volatile" else ""
+        )
+        traj_end = "[/green]" if "green" in traj_color else (
+            "[/red]" if "red" in traj_color else (
+                "[/yellow]" if "yellow" in traj_color else ""
+            )
+        )
+        table.add_row(
+            e.from_character_id,
+            e.to_character_id,
+            e.sentiment,
+            val_str,
+            f"{traj_color}{e.valence_trajectory}{traj_end}",
+        )
+    console.print(table)
+    console.print("\n[dim]Note: sentiment is asymmetric — each direction is independent.[/dim]")
+
+
 @lore.group(name="conflicts")
 def lore_conflicts() -> None:
     """Track and manage intra/inter-book lore contradictions."""

--- a/src/book_graph_analyzer/lore/emotional_arc.py
+++ b/src/book_graph_analyzer/lore/emotional_arc.py
@@ -1,0 +1,767 @@
+"""Emotional arc system — pre-defined Tolkien arcs, validator, extractor, and Neo4j writer.
+
+Contains:
+  TOLKIEN_CHARACTER_ARCS  — canonical arcs for Frodo, Sam, Gandalf, Aragorn, etc.
+  TOLKIEN_RELATIONSHIP_SENTIMENTS — relational sentiment edges
+  EmotionalArcValidator   — validates proposed states against canonical arcs
+  EmotionalStateExtractor — heuristic extraction from text (no LLM required)
+  EmotionalArcNeo4jWriter — writes EmotionalState nodes + FELT / KNOWS edges
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+from ..models.emotional_arc import (
+    EmotionalState,
+    ArcCheckpoint,
+    CharacterArc,
+    FeltEdge,
+    RelationalSentimentEdge,
+    TolkienRegister,
+    RelationshipSentiment,
+    REGISTER_ANCHORS,
+    SENTIMENT_VALENCE,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers for building arc checkpoints
+# ---------------------------------------------------------------------------
+
+def _state(
+    label: str,
+    valence: float,
+    agency: float,
+    register: str,
+    description: str,
+) -> EmotionalState:
+    return EmotionalState(
+        id=f"state_{label.replace(' ', '_')}",
+        valence=valence,
+        agency=agency,
+        dominant_register=register,
+        description=description,
+    )
+
+
+def _cp(
+    label: str,
+    year: int,
+    valence: float,
+    agency: float,
+    register: str,
+    description: str,
+    valid_registers: list[str],
+    invalid_registers: list[str],
+    hardness: str = "SOFT",
+    year_end: Optional[int] = None,
+) -> ArcCheckpoint:
+    return ArcCheckpoint(
+        label=label,
+        story_year=year,
+        story_year_end=year_end,
+        emotional_state=_state(label, valence, agency, register, description),
+        description=description,
+        hardness=hardness,
+        valid_registers=valid_registers,
+        invalid_registers=invalid_registers,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Frodo Baggins — the most detailed arc
+# ---------------------------------------------------------------------------
+
+_FRODO_ARC = CharacterArc(
+    character_id="frodo_baggins",
+    character_name="Frodo Baggins",
+    checkpoints=[
+        _cp(
+            label="shire_idyll",
+            year=3001, year_end=3018,
+            valence=0.8, agency=0.7,
+            register=TolkienRegister.COZY,
+            description=(
+                "Frodo in the Shire — content, curious, comfortable. "
+                "Slightly melancholy after Bilbo's departure but fundamentally at peace."
+            ),
+            valid_registers=[
+                TolkienRegister.COZY, TolkienRegister.WONDER,
+                TolkienRegister.ELEGIAC, TolkienRegister.HOPE,
+            ],
+            invalid_registers=[
+                TolkienRegister.DREAD, TolkienRegister.RAGE,
+                TolkienRegister.BURDEN,
+            ],
+        ),
+        _cp(
+            label="flight_to_rivendell",
+            year=3018,
+            valence=0.2, agency=0.3,
+            register=TolkienRegister.DREAD,
+            description=(
+                "Fleeing the Shire with the Black Riders on his heels. "
+                "Frightened but pressing on — courage overlaid with fear."
+            ),
+            valid_registers=[
+                TolkienRegister.DREAD, TolkienRegister.RESOLUTE,
+                TolkienRegister.WONDER, TolkienRegister.HOPE,
+            ],
+            invalid_registers=[
+                TolkienRegister.COZY, TolkienRegister.EUCATASTROPHIC,
+            ],
+        ),
+        _cp(
+            label="fellowship_of_the_ring",
+            year=3018, year_end=3019,
+            valence=0.4, agency=0.5,
+            register=TolkienRegister.RESOLUTE,
+            description=(
+                "Frodo bearing the Ring through the Fellowship. "
+                "Wonder at the wider world, growing weight, but still purposeful and hopeful."
+            ),
+            valid_registers=[
+                TolkienRegister.RESOLUTE, TolkienRegister.WONDER,
+                TolkienRegister.HOPE, TolkienRegister.BURDEN,
+            ],
+            invalid_registers=[
+                TolkienRegister.COZY, TolkienRegister.EUCATASTROPHIC,
+                TolkienRegister.RAGE,
+            ],
+        ),
+        _cp(
+            label="emyn_muil_ithilien",
+            year=3019,
+            valence=-0.1, agency=0.2,
+            register=TolkienRegister.BURDEN,
+            description=(
+                "After the breaking of the Fellowship. "
+                "Frodo alone (with Sam) feels the Ring's weight increasing. "
+                "Determined but increasingly burdened, wary of Gollum."
+            ),
+            valid_registers=[
+                TolkienRegister.BURDEN, TolkienRegister.RESOLUTE,
+                TolkienRegister.DREAD, TolkienRegister.GRIEF,
+            ],
+            invalid_registers=[
+                TolkienRegister.COZY, TolkienRegister.WONDER,
+                TolkienRegister.HOPE, TolkienRegister.EUCATASTROPHIC,
+            ],
+            hardness="HARD",
+        ),
+        _cp(
+            label="cirith_ungol_mordor",
+            year=3019,
+            valence=-0.7, agency=-0.6,
+            register=TolkienRegister.BURDEN,
+            description=(
+                "Cirith Ungol and the plains of Mordor. "
+                "Frodo consumed by the Ring's weight — despair, exhaustion, "
+                "near-total loss of agency. Sometimes hostile toward Sam."
+            ),
+            valid_registers=[
+                TolkienRegister.BURDEN, TolkienRegister.DREAD,
+                TolkienRegister.GRIEF,
+            ],
+            invalid_registers=[
+                TolkienRegister.COZY, TolkienRegister.WONDER,
+                TolkienRegister.HOPE, TolkienRegister.EUCATASTROPHIC,
+                TolkienRegister.RESOLUTE, TolkienRegister.RAGE,
+            ],
+            hardness="HARD",
+        ),
+        _cp(
+            label="mount_doom_eucatastrophe",
+            year=3019,
+            valence=0.7, agency=0.1,
+            register=TolkienRegister.TRANSCENDENT,
+            description=(
+                "The eucatastrophe at the Crack of Doom. "
+                "The burden is lifted through Gollum's mercy — overwhelming relief, "
+                "grace, wonder, transcendence beyond ordinary feeling."
+            ),
+            valid_registers=[
+                TolkienRegister.TRANSCENDENT, TolkienRegister.EUCATASTROPHIC,
+                TolkienRegister.GRIEF, TolkienRegister.WONDER,
+            ],
+            invalid_registers=[
+                TolkienRegister.COZY, TolkienRegister.RAGE,
+                TolkienRegister.DREAD,
+            ],
+        ),
+        _cp(
+            label="scouring_of_the_shire",
+            year=3019, year_end=3020,
+            valence=0.1, agency=0.6,
+            register=TolkienRegister.RESOLUTE,
+            description=(
+                "Post-Ring Frodo — not quite himself, touched by Mordor, "
+                "but finding purpose in healing the Shire. Elegiac undertone."
+            ),
+            valid_registers=[
+                TolkienRegister.RESOLUTE, TolkienRegister.ELEGIAC,
+                TolkienRegister.GRIEF, TolkienRegister.PITY,
+            ],
+            invalid_registers=[
+                TolkienRegister.COZY, TolkienRegister.EUCATASTROPHIC,
+                TolkienRegister.WONDER,
+            ],
+        ),
+        _cp(
+            label="grey_havens_departure",
+            year=3021,
+            valence=0.5, agency=0.4,
+            register=TolkienRegister.ELEGIAC,
+            description=(
+                "Frodo's departure at the Grey Havens — bittersweet peace. "
+                "Sadness at leaving, acceptance of what he has become, "
+                "quiet joy at the healing ahead."
+            ),
+            valid_registers=[
+                TolkienRegister.ELEGIAC, TolkienRegister.TRANSCENDENT,
+                TolkienRegister.PITY, TolkienRegister.WONDER,
+            ],
+            invalid_registers=[
+                TolkienRegister.COZY, TolkienRegister.RAGE,
+                TolkienRegister.DREAD, TolkienRegister.BURDEN,
+            ],
+        ),
+    ]
+)
+
+
+# ---------------------------------------------------------------------------
+# Samwise Gamgee
+# ---------------------------------------------------------------------------
+
+_SAM_ARC = CharacterArc(
+    character_id="samwise_gamgee",
+    character_name="Samwise Gamgee",
+    checkpoints=[
+        _cp(
+            label="shire_gardener",
+            year=3001, year_end=3018,
+            valence=0.85, agency=0.7,
+            register=TolkienRegister.COZY,
+            description="Sam in the Shire — simple contentment, loyal service, dreams of Elves.",
+            valid_registers=[TolkienRegister.COZY, TolkienRegister.WONDER, TolkienRegister.HOPE],
+            invalid_registers=[TolkienRegister.DREAD, TolkienRegister.BURDEN],
+        ),
+        _cp(
+            label="on_the_quest",
+            year=3018, year_end=3019,
+            valence=0.5, agency=0.6,
+            register=TolkienRegister.RESOLUTE,
+            description="Sam on the Quest — steadfast, faithful, occasionally homesick but never wavering.",
+            valid_registers=[
+                TolkienRegister.RESOLUTE, TolkienRegister.COZY, TolkienRegister.WONDER,
+                TolkienRegister.GRIEF, TolkienRegister.HOPE,
+            ],
+            invalid_registers=[TolkienRegister.DREAD, TolkienRegister.BURDEN],
+        ),
+        _cp(
+            label="carrying_frodo_mordor",
+            year=3019,
+            valence=0.3, agency=0.7,
+            register=TolkienRegister.RESOLUTE,
+            description=(
+                "Sam carrying Frodo up Mount Doom — utter determination, love, "
+                "personal agency through service. The emotional opposite of Frodo's despair."
+            ),
+            valid_registers=[
+                TolkienRegister.RESOLUTE, TolkienRegister.HOPE,
+                TolkienRegister.GRIEF, TolkienRegister.PITY,
+            ],
+            invalid_registers=[TolkienRegister.DREAD, TolkienRegister.BURDEN, TolkienRegister.COZY],
+            hardness="HARD",
+        ),
+    ]
+)
+
+
+# ---------------------------------------------------------------------------
+# Gandalf
+# ---------------------------------------------------------------------------
+
+_GANDALF_ARC = CharacterArc(
+    character_id="gandalf",
+    character_name="Gandalf",
+    checkpoints=[
+        _cp(
+            label="gandalf_grey",
+            year=3001, year_end=3018,
+            valence=0.5, agency=0.7,
+            register=TolkienRegister.RESOLUTE,
+            description=(
+                "Gandalf the Grey — watchful, purposeful, slightly playful. "
+                "Carries the weight of long knowledge but with wit."
+            ),
+            valid_registers=[
+                TolkienRegister.RESOLUTE, TolkienRegister.WONDER,
+                TolkienRegister.ELEGIAC, TolkienRegister.HOPE,
+            ],
+            invalid_registers=[TolkienRegister.COZY, TolkienRegister.BURDEN],
+        ),
+        _cp(
+            label="gandalf_white",
+            year=3019,
+            valence=0.6, agency=0.9,
+            register=TolkienRegister.RESOLUTE,
+            description=(
+                "Gandalf the White — returned with greater power and purpose. "
+                "More austere, less playful; entirely focused on the final war."
+            ),
+            valid_registers=[
+                TolkienRegister.RESOLUTE, TolkienRegister.HOPE,
+                TolkienRegister.ELEGIAC, TolkienRegister.TRANSCENDENT,
+            ],
+            invalid_registers=[TolkienRegister.COZY, TolkienRegister.DREAD, TolkienRegister.BURDEN],
+            hardness="HARD",
+        ),
+    ]
+)
+
+
+# ---------------------------------------------------------------------------
+# Aragorn
+# ---------------------------------------------------------------------------
+
+_ARAGORN_ARC = CharacterArc(
+    character_id="aragorn",
+    character_name="Aragorn",
+    checkpoints=[
+        _cp(
+            label="strider_incognito",
+            year=3001, year_end=3018,
+            valence=0.3, agency=0.7,
+            register=TolkienRegister.RESOLUTE,
+            description=(
+                "Aragorn as Strider — carrying the burden of his lineage in secret, "
+                "purposeful, a little melancholy, fiercely determined."
+            ),
+            valid_registers=[
+                TolkienRegister.RESOLUTE, TolkienRegister.ELEGIAC,
+                TolkienRegister.HOPE, TolkienRegister.WONDER,
+            ],
+            invalid_registers=[TolkienRegister.COZY, TolkienRegister.DREAD],
+        ),
+        _cp(
+            label="war_of_the_ring",
+            year=3018, year_end=3019,
+            valence=0.5, agency=0.85,
+            register=TolkienRegister.RESOLUTE,
+            description=(
+                "Aragorn assuming his destiny — resolute, kingly, hope-filled but grave. "
+                "The long-waited moment arriving."
+            ),
+            valid_registers=[
+                TolkienRegister.RESOLUTE, TolkienRegister.HOPE,
+                TolkienRegister.GRIEF, TolkienRegister.TRANSCENDENT,
+            ],
+            invalid_registers=[TolkienRegister.DREAD, TolkienRegister.BURDEN, TolkienRegister.COZY],
+        ),
+    ]
+)
+
+
+# ---------------------------------------------------------------------------
+# Gollum / Sméagol
+# ---------------------------------------------------------------------------
+
+_GOLLUM_ARC = CharacterArc(
+    character_id="gollum",
+    character_name="Gollum",
+    checkpoints=[
+        _cp(
+            label="gollum_guiding",
+            year=3019,
+            valence=-0.3, agency=0.3,
+            register=TolkienRegister.DREAD,
+            description=(
+                "Gollum guiding Frodo and Sam — torn between Sméagol's faint hope "
+                "and Gollum's treachery. Dread of Sauron, obsession with the Ring."
+            ),
+            valid_registers=[
+                TolkienRegister.DREAD, TolkienRegister.BURDEN,
+                TolkienRegister.GRIEF, TolkienRegister.PITY,
+            ],
+            invalid_registers=[
+                TolkienRegister.COZY, TolkienRegister.WONDER,
+                TolkienRegister.RESOLUTE, TolkienRegister.EUCATASTROPHIC,
+            ],
+        ),
+    ]
+)
+
+
+# Registry of all canonical character arcs
+TOLKIEN_CHARACTER_ARCS: dict[str, CharacterArc] = {
+    "frodo_baggins": _FRODO_ARC,
+    "samwise_gamgee": _SAM_ARC,
+    "gandalf": _GANDALF_ARC,
+    "aragorn": _ARAGORN_ARC,
+    "gollum": _GOLLUM_ARC,
+}
+
+# Canonical character name aliases
+CHARACTER_NAME_MAP: dict[str, str] = {
+    "frodo": "frodo_baggins",
+    "frodo baggins": "frodo_baggins",
+    "sam": "samwise_gamgee",
+    "samwise": "samwise_gamgee",
+    "samwise gamgee": "samwise_gamgee",
+    "gandalf": "gandalf",
+    "gandalf the grey": "gandalf",
+    "gandalf the white": "gandalf",
+    "aragorn": "aragorn",
+    "strider": "aragorn",
+    "gollum": "gollum",
+    "smeagol": "gollum",
+    "sméagol": "gollum",
+}
+
+
+# ---------------------------------------------------------------------------
+# Pre-defined relational sentiment edges
+# ---------------------------------------------------------------------------
+
+TOLKIEN_RELATIONSHIP_SENTIMENTS: list[RelationalSentimentEdge] = [
+    # Sam → Frodo: devoted loyalty
+    RelationalSentimentEdge(
+        from_character_id="samwise_gamgee",
+        to_character_id="frodo_baggins",
+        sentiment=RelationshipSentiment.LOYAL,
+        valence=0.95,
+        valence_trajectory="stable",
+        era="Third Age",
+    ),
+    # Frodo → Sam: deep trust and love (declining slightly under Ring influence near end)
+    RelationalSentimentEdge(
+        from_character_id="frodo_baggins",
+        to_character_id="samwise_gamgee",
+        sentiment=RelationshipSentiment.LOVE,
+        valence=0.9,
+        valence_trajectory="volatile",  # Ring distorts it near Mordor
+        era="Third Age",
+    ),
+    # Sam → Gollum: wary distrust
+    RelationalSentimentEdge(
+        from_character_id="samwise_gamgee",
+        to_character_id="gollum",
+        sentiment=RelationshipSentiment.WARY,
+        valence=-0.7,
+        valence_trajectory="deteriorating",
+        era="Third Age",
+    ),
+    # Gollum → Sam: fear and hatred
+    RelationalSentimentEdge(
+        from_character_id="gollum",
+        to_character_id="samwise_gamgee",
+        sentiment=RelationshipSentiment.FEAR,
+        valence=-0.8,
+        valence_trajectory="stable",
+        era="Third Age",
+    ),
+    # Gollum → Frodo: pity mixed with obsession
+    RelationalSentimentEdge(
+        from_character_id="gollum",
+        to_character_id="frodo_baggins",
+        sentiment=RelationshipSentiment.PITY,
+        valence=0.1,
+        valence_trajectory="volatile",
+        era="Third Age",
+    ),
+    # Frodo → Gollum: pity
+    RelationalSentimentEdge(
+        from_character_id="frodo_baggins",
+        to_character_id="gollum",
+        sentiment=RelationshipSentiment.PITY,
+        valence=0.2,
+        valence_trajectory="deteriorating",
+        era="Third Age",
+    ),
+    # Aragorn → Gandalf: respect/trust
+    RelationalSentimentEdge(
+        from_character_id="aragorn",
+        to_character_id="gandalf",
+        sentiment=RelationshipSentiment.RESPECT,
+        valence=0.8,
+        valence_trajectory="stable",
+        era="Third Age",
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# EmotionalStateExtractor — heuristic extraction from text (no LLM)
+# ---------------------------------------------------------------------------
+
+# Keyword → register mapping for text-based extraction
+_REGISTER_KEYWORDS: dict[str, list[str]] = {
+    TolkienRegister.ELEGIAC: [
+        "fading", "gone", "lost", "mourned", "wept", "tears", "memory", "lament",
+        "passed", "no more", "ancient", "shadow of what was",
+    ],
+    TolkienRegister.EUCATASTROPHIC: [
+        "suddenly", "joy", "saved", "victory", "hope fulfilled", "against all",
+        "eucatastrophe", "eagles", "light broke",
+    ],
+    TolkienRegister.DREAD: [
+        "dread", "terror", "shadow", "fear", "darkness", "cold", "black",
+        "nazgul", "ringwraith", "horror",
+    ],
+    TolkienRegister.WONDER: [
+        "marvelled", "beautiful", "wondrous", "glory", "radiant", "astonished",
+        "amazed", "magnificent", "breathtaking",
+    ],
+    TolkienRegister.COZY: [
+        "comfortable", "warm", "hearth", "supper", "pipe-weed", "home",
+        "shire", "hobbit-hole", "cozy", "safe",
+    ],
+    TolkienRegister.RESOLUTE: [
+        "determined", "resolved", "must", "duty", "courage", "stood firm",
+        "would not yield", "forward", "endure",
+    ],
+    TolkienRegister.BURDEN: [
+        "burden", "weight", "heavy", "exhausted", "could not go on",
+        "crushing", "overwhelmed", "dragging",
+    ],
+    TolkienRegister.GRIEF: [
+        "grief", "mourning", "sorrow", "loss", "dead", "gone forever",
+        "wept bitterly",
+    ],
+    TolkienRegister.HOPE: [
+        "hope", "dawn", "light", "will endure", "not all is lost",
+        "trust", "faith",
+    ],
+    TolkienRegister.RAGE: [
+        "anger", "fury", "wrath", "raged", "burning anger", "snarled",
+        "fighting fury",
+    ],
+    TolkienRegister.PITY: [
+        "pity", "mercy", "compassion", "could not bring himself", "spare",
+        "gentle", "kind",
+    ],
+    TolkienRegister.TRANSCENDENT: [
+        "beyond", "mystical", "strange peace", "unnatural calm", "otherworldly",
+        "beyond grief", "beyond joy",
+    ],
+}
+
+
+def extract_emotional_state_from_text(
+    text: str,
+    character_name: Optional[str] = None,
+) -> tuple[str, float]:
+    """Heuristically extract the dominant emotional register from passage text.
+
+    Returns:
+        (dominant_register, confidence) — confidence 0.0-1.0
+    """
+    text_lower = text.lower()
+    scores: dict[str, int] = {}
+    for register, keywords in _REGISTER_KEYWORDS.items():
+        score = sum(1 for kw in keywords if kw.lower() in text_lower)
+        if score > 0:
+            scores[register] = score
+
+    if not scores:
+        return TolkienRegister.RESOLUTE, 0.1
+
+    dominant = max(scores, key=scores.__getitem__)
+    total = sum(scores.values())
+    confidence = min(1.0, scores[dominant] / max(1, total) + 0.3)
+    return dominant, round(confidence, 2)
+
+
+def text_to_emotional_state(
+    text: str,
+    state_id: str = "extracted",
+    character_name: Optional[str] = None,
+) -> EmotionalState:
+    """Extract an EmotionalState from text heuristically."""
+    register, confidence = extract_emotional_state_from_text(text, character_name)
+    valence, agency = REGISTER_ANCHORS.get(register, (0.0, 0.0))
+    return EmotionalState(
+        id=state_id,
+        valence=valence,
+        agency=agency,
+        dominant_register=register,
+        description=f"Extracted from text (confidence={confidence:.0%})",
+    )
+
+
+# ---------------------------------------------------------------------------
+# EmotionalArcValidator
+# ---------------------------------------------------------------------------
+
+class EmotionalArcValidator:
+    """Validates proposed character emotional states against canonical arcs."""
+
+    def __init__(
+        self,
+        arcs: Optional[dict[str, CharacterArc]] = None,
+    ) -> None:
+        self._arcs = arcs or TOLKIEN_CHARACTER_ARCS
+
+    def get_arc(self, character_id_or_name: str) -> Optional[CharacterArc]:
+        """Look up arc by ID or name (case-insensitive)."""
+        name_lower = character_id_or_name.lower()
+        # Try direct ID lookup
+        if character_id_or_name in self._arcs:
+            return self._arcs[character_id_or_name]
+        # Try alias map
+        canonical_id = CHARACTER_NAME_MAP.get(name_lower)
+        if canonical_id and canonical_id in self._arcs:
+            return self._arcs[canonical_id]
+        return None
+
+    def validate_arc(
+        self,
+        character: str,
+        story_year: int,
+        proposed_register: str,
+    ) -> tuple[bool, str]:
+        """Validate a proposed emotional register for a character at a story year.
+
+        Args:
+            character: Character name or ID (e.g. 'Frodo', 'frodo_baggins')
+            story_year: Story year in Third Age (e.g. 3019)
+            proposed_register: TolkienRegister value being proposed
+
+        Returns:
+            (is_valid, explanation)
+        """
+        arc = self.get_arc(character)
+        if not arc:
+            return True, f"No canonical arc registered for '{character}'"
+
+        return arc.validate_state(proposed_register, story_year)
+
+    def validate_arc_from_text(
+        self,
+        character: str,
+        story_year: int,
+        text: str,
+    ) -> tuple[bool, str, str]:
+        """Validate emotional state extracted from text.
+
+        Returns:
+            (is_valid, detected_register, explanation)
+        """
+        register, confidence = extract_emotional_state_from_text(text, character)
+        is_valid, explanation = self.validate_arc(character, story_year, register)
+        full_explanation = (
+            f"Detected register: '{register}' (confidence={confidence:.0%})\n"
+            f"{explanation}"
+        )
+        return is_valid, register, full_explanation
+
+    def list_checkpoints(self, character: str) -> list[ArcCheckpoint]:
+        """Return all checkpoints for a character."""
+        arc = self.get_arc(character)
+        if arc is None:
+            return []
+        return arc.checkpoints
+
+    def expected_state(
+        self, character: str, story_year: int
+    ) -> Optional[ArcCheckpoint]:
+        """Return the expected checkpoint for a character at a given year."""
+        arc = self.get_arc(character)
+        if arc is None:
+            return None
+        return arc.get_checkpoint_for_year(story_year)
+
+    def all_characters(self) -> list[str]:
+        """Return all character names with registered arcs."""
+        return [arc.character_name for arc in self._arcs.values()]
+
+
+# ---------------------------------------------------------------------------
+# EmotionalArcNeo4jWriter
+# ---------------------------------------------------------------------------
+
+class EmotionalArcNeo4jWriter:
+    """Write EmotionalState nodes and FELT / KNOWS-sentiment edges to Neo4j."""
+
+    def __init__(self, driver=None) -> None:
+        self._driver = driver
+
+    @property
+    def driver(self):
+        if self._driver is None:
+            from ..graph.connection import get_driver
+            self._driver = get_driver()
+        return self._driver
+
+    def close(self) -> None:
+        if self._driver:
+            self._driver.close()
+            self._driver = None
+
+    def upsert_emotional_state(self, state: EmotionalState) -> None:
+        """Create or update an EmotionalState node."""
+        with self.driver.session() as session:
+            session.run(
+                "MERGE (e:EmotionalState {id: $id}) SET e += $props",
+                id=state.id,
+                props=state.to_neo4j_props(),
+            )
+
+    def upsert_felt_edge(self, edge: FeltEdge) -> None:
+        """Create a FELT edge from Character to EmotionalState."""
+        with self.driver.session() as session:
+            session.run(
+                """
+                MATCH (c:Character {id: $char_id})
+                MATCH (e:EmotionalState {id: $state_id})
+                MERGE (c)-[r:FELT {era: $era}]->(e)
+                SET r += $props
+                """,
+                char_id=edge.character_id,
+                state_id=edge.emotional_state_id,
+                era=edge.era,
+                props=edge.to_neo4j_props(),
+            )
+
+    def upsert_relationship_sentiment(self, edge: RelationalSentimentEdge) -> None:
+        """Extend a KNOWS edge with sentiment data (asymmetric)."""
+        with self.driver.session() as session:
+            session.run(
+                """
+                MATCH (a:Character {id: $from_id})
+                MATCH (b:Character {id: $to_id})
+                MERGE (a)-[r:KNOWS]->(b)
+                SET r += $props
+                """,
+                from_id=edge.from_character_id,
+                to_id=edge.to_character_id,
+                props=edge.to_neo4j_props(),
+            )
+
+    def seed_tolkien_sentiments(self) -> int:
+        """Write all pre-defined Tolkien relationship sentiments to Neo4j."""
+        count = 0
+        for edge in TOLKIEN_RELATIONSHIP_SENTIMENTS:
+            self.upsert_relationship_sentiment(edge)
+            count += 1
+        return count
+
+    def query_character_arc(self, character_id: str) -> list[dict]:
+        """Query all FELT edges for a character from Neo4j, ordered by year."""
+        with self.driver.session() as session:
+            result = session.run(
+                """
+                MATCH (c:Character {id: $cid})-[r:FELT]->(e:EmotionalState)
+                RETURN c.id AS character_id, e.dominant_register AS register,
+                       e.valence AS valence, e.agency AS agency,
+                       e.description AS description,
+                       r.era AS era, r.year AS year, r.passage_id AS passage_id
+                ORDER BY r.year
+                """,
+                cid=character_id,
+            )
+            return [dict(row) for row in result]

--- a/src/book_graph_analyzer/models/emotional_arc.py
+++ b/src/book_graph_analyzer/models/emotional_arc.py
@@ -1,0 +1,298 @@
+"""Emotional arc models — EmotionalState, ArcCheckpoint, CharacterArc, RelationshipSentiment.
+
+Represents the canonical emotional trajectory of characters over story time.
+This is part of the lore contract — generating a character in the wrong
+emotional state at a given story moment is a lore violation.
+
+Node: (:EmotionalState { valence, agency, dominant_register, description })
+Edge: (Character)-[:FELT { era, year, passage_id, toward_entity_id, triggered_by }]->(EmotionalState)
+Edge extension: (Character)-[:KNOWS { sentiment, valence, valence_trajectory, ... }]->(Character)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+from enum import Enum
+
+
+# ---------------------------------------------------------------------------
+# Tolkien emotional registers
+# ---------------------------------------------------------------------------
+
+class TolkienRegister(str, Enum):
+    """Specific emotional/narrative registers found in Tolkien's prose."""
+    ELEGIAC        = "elegiac"        # Sorrowful, lamenting; things passing away
+    EUCATASTROPHIC = "eucatastrophic" # Sudden joyous turn, unexpected salvation
+    DREAD          = "dread"          # Deep fear, terror of the dark
+    WONDER         = "wonder"         # Awe, marveling at beauty or strangeness
+    COZY           = "cozy"           # Domestic comfort, Shire-warmth, safety
+    RESOLUTE       = "resolute"       # Grim determination, stoic endurance
+    BURDEN         = "burden"         # Crushing weight, unwilled duty
+    GRIEF          = "grief"          # Active mourning, loss
+    HOPE           = "hope"           # Forward-looking trust despite adversity
+    RAGE           = "rage"           # Anger, fierce combat-fury
+    PITY           = "pity"           # Compassion, merciful tenderness
+    TRANSCENDENT   = "transcendent"   # Mystical, beyond ordinary feeling
+
+
+# Register valence / agency anchors (for validation heuristics)
+# Tuple: (valence_center, agency_center)
+REGISTER_ANCHORS: dict[str, tuple[float, float]] = {
+    TolkienRegister.ELEGIAC:        (-0.3,  0.0),
+    TolkienRegister.EUCATASTROPHIC: ( 0.9,  0.5),
+    TolkienRegister.DREAD:          (-0.8, -0.5),
+    TolkienRegister.WONDER:         ( 0.7,  0.3),
+    TolkienRegister.COZY:           ( 0.8,  0.6),
+    TolkienRegister.RESOLUTE:       ( 0.1,  0.7),
+    TolkienRegister.BURDEN:         (-0.5, -0.6),
+    TolkienRegister.GRIEF:          (-0.6, -0.2),
+    TolkienRegister.HOPE:           ( 0.7,  0.4),
+    TolkienRegister.RAGE:           (-0.2,  0.8),
+    TolkienRegister.PITY:           ( 0.3,  0.2),
+    TolkienRegister.TRANSCENDENT:   ( 0.6,  0.1),
+}
+
+
+# ---------------------------------------------------------------------------
+# Relationship sentiment values
+# ---------------------------------------------------------------------------
+
+class RelationshipSentiment(str, Enum):
+    """How one character feels about another in a relational edge."""
+    ALLY    = "ally"    # Positive cooperation, shared purpose
+    ENEMY   = "enemy"   # Active opposition, hostility
+    WARY    = "wary"    # Cautious, not trusting, watching
+    LOYAL   = "loyal"   # Deep personal devotion
+    LOVE    = "love"    # Romantic or deep familial/companionate love
+    PITY    = "pity"    # Compassion mixed with sorrow
+    FEAR    = "fear"    # Driven by terror of the other
+    RESPECT = "respect" # Admiration without full trust or alliance
+    GRIEF   = "grief"   # Sorrow centered on the other (loss, mourning)
+
+
+# Sentiment → rough valence
+SENTIMENT_VALENCE: dict[str, float] = {
+    RelationshipSentiment.ALLY:    0.7,
+    RelationshipSentiment.ENEMY:  -0.8,
+    RelationshipSentiment.WARY:   -0.2,
+    RelationshipSentiment.LOYAL:   0.9,
+    RelationshipSentiment.LOVE:    0.95,
+    RelationshipSentiment.PITY:    0.2,
+    RelationshipSentiment.FEAR:   -0.7,
+    RelationshipSentiment.RESPECT: 0.5,
+    RelationshipSentiment.GRIEF:  -0.3,
+}
+
+
+# ---------------------------------------------------------------------------
+# EmotionalState
+# ---------------------------------------------------------------------------
+
+@dataclass
+class EmotionalState:
+    """A snapshot of a character's emotional state at a point in story time.
+
+    Stored as (:EmotionalState) in Neo4j.
+    Connected via (Character)-[:FELT { ... }]->(EmotionalState).
+    """
+    id: str
+    valence: float                         # -1.0 (despair/dread) to 1.0 (joy/hope)
+    agency: float                          # -1.0 (powerless/burdened) to 1.0 (in command/free)
+    dominant_register: str                 # TolkienRegister value
+    description: str = ""                  # Human-readable e.g. "grim determination under crushing burden"
+
+    def to_neo4j_props(self) -> dict:
+        return {
+            "id": self.id,
+            "valence": round(self.valence, 3),
+            "agency": round(self.agency, 3),
+            "dominant_register": self.dominant_register,
+            "description": self.description,
+        }
+
+    def to_dict(self) -> dict:
+        return self.to_neo4j_props()
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "EmotionalState":
+        return cls(
+            id=d.get("id", ""),
+            valence=float(d.get("valence", 0.0)),
+            agency=float(d.get("agency", 0.0)),
+            dominant_register=d.get("dominant_register", TolkienRegister.RESOLUTE),
+            description=d.get("description", ""),
+        )
+
+    def distance_from(self, other: "EmotionalState") -> float:
+        """Euclidean distance in (valence, agency) space."""
+        return ((self.valence - other.valence) ** 2 + (self.agency - other.agency) ** 2) ** 0.5
+
+    def compatible_with(self, other: "EmotionalState", tolerance: float = 0.4) -> bool:
+        """True if this state is within tolerance of another in (valence, agency) space."""
+        return self.distance_from(other) <= tolerance
+
+    def is_violation(self, expected: "EmotionalState", hard_threshold: float = 0.6) -> bool:
+        """True if this state is far enough from expected to constitute a lore violation."""
+        return self.distance_from(expected) > hard_threshold
+
+
+# ---------------------------------------------------------------------------
+# FELT edge (arc entry)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class FeltEdge:
+    """Represents a (Character)-[:FELT { ... }]->(EmotionalState) edge."""
+
+    character_id: str
+    emotional_state_id: str
+    era: str
+    year: Optional[int] = None
+    passage_id: Optional[str] = None
+    toward_entity_id: Optional[str] = None   # How they feel ABOUT a specific entity
+    triggered_by_event_id: Optional[str] = None
+
+    def to_neo4j_props(self) -> dict:
+        props: dict = {"era": self.era}
+        if self.year is not None:
+            props["year"] = self.year
+        if self.passage_id:
+            props["passage_id"] = self.passage_id
+        if self.toward_entity_id:
+            props["toward_entity_id"] = self.toward_entity_id
+        if self.triggered_by_event_id:
+            props["triggered_by_event_id"] = self.triggered_by_event_id
+        return props
+
+
+# ---------------------------------------------------------------------------
+# ArcCheckpoint — a named story moment in a character's arc
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ArcCheckpoint:
+    """A canonical emotional checkpoint in a character's story arc.
+
+    Represents the expected emotional state at a specific narrative moment.
+    Used as a validation target — generated scenes must not violate these.
+    """
+    label: str                             # e.g. 'near_mount_doom'
+    story_year: int                        # Approximate story year (TA)
+    story_year_end: Optional[int] = None   # Inclusive range end (for spans)
+    emotional_state: Optional[EmotionalState] = None
+    description: str = ""                  # Why the character feels this way
+    # How strictly this must be respected
+    hardness: str = "SOFT"                 # 'HARD' | 'SOFT'
+    # Keywords that would describe VALID states at this moment
+    valid_registers: list[str] = field(default_factory=list)
+    # Keywords that would describe INVALID states
+    invalid_registers: list[str] = field(default_factory=list)
+
+    def covers_year(self, year: int) -> bool:
+        """True if this checkpoint applies to the given story year."""
+        if self.story_year_end is not None:
+            return self.story_year <= year <= self.story_year_end
+        # Allow ±15 years tolerance for single-year checkpoints
+        return abs(year - self.story_year) <= 15
+
+    def is_valid_register(self, register: str) -> bool:
+        """True if the given register is valid for this checkpoint."""
+        if self.valid_registers and register not in self.valid_registers:
+            return False
+        if register in self.invalid_registers:
+            return False
+        return True
+
+
+# ---------------------------------------------------------------------------
+# CharacterArc — full emotional arc for one character
+# ---------------------------------------------------------------------------
+
+@dataclass
+class CharacterArc:
+    """The complete canonical emotional arc of a character."""
+
+    character_id: str
+    character_name: str
+    checkpoints: list[ArcCheckpoint] = field(default_factory=list)
+
+    def get_checkpoint_for_year(self, year: int) -> Optional[ArcCheckpoint]:
+        """Return the most specific checkpoint covering the given year."""
+        candidates = [cp for cp in self.checkpoints if cp.covers_year(year)]
+        if not candidates:
+            return None
+        # Prefer checkpoints with narrower year ranges (more specific)
+        candidates.sort(
+            key=lambda cp: (
+                abs(cp.story_year - year),
+                (cp.story_year_end - cp.story_year) if cp.story_year_end else 0,
+            )
+        )
+        return candidates[0]
+
+    def validate_state(
+        self,
+        proposed_register: str,
+        story_year: int,
+    ) -> tuple[bool, str]:
+        """Validate a proposed emotional register against the canonical arc.
+
+        Returns:
+            (is_valid, explanation) — is_valid=False means lore violation.
+        """
+        checkpoint = self.get_checkpoint_for_year(story_year)
+        if not checkpoint:
+            return True, f"No arc constraint for {self.character_name} at TA {story_year}"
+
+        if checkpoint.is_valid_register(proposed_register):
+            return True, (
+                f"{self.character_name} at TA {story_year}: "
+                f"'{proposed_register}' is consistent with '{checkpoint.label}'"
+            )
+
+        explanation = (
+            f"VIOLATION: {self.character_name} at TA {story_year} "
+            f"(checkpoint: '{checkpoint.label}') — "
+            f"'{proposed_register}' is incompatible. "
+            f"Expected: {checkpoint.valid_registers}. "
+            f"Explicitly invalid: {checkpoint.invalid_registers}. "
+            f"Context: {checkpoint.description}"
+        )
+        return False, explanation
+
+
+# ---------------------------------------------------------------------------
+# RelationalSentimentEdge — KNOWS extension
+# ---------------------------------------------------------------------------
+
+@dataclass
+class RelationalSentimentEdge:
+    """Represents sentiment data on a (Character)-[:KNOWS]->(Character) edge.
+
+    Sentiment is asymmetric: how A feels about B ≠ how B feels about A.
+    """
+    from_character_id: str
+    to_character_id: str
+    sentiment: str               # RelationshipSentiment value
+    valence: float               # -1.0 to 1.0
+    valence_trajectory: str      # 'improving' | 'deteriorating' | 'stable' | 'volatile'
+    era: Optional[str] = None
+    year_start: Optional[int] = None
+    year_end: Optional[int] = None
+    source_passage_ids: list[str] = field(default_factory=list)
+
+    def to_neo4j_props(self) -> dict:
+        props: dict = {
+            "sentiment": self.sentiment,
+            "valence": round(self.valence, 3),
+            "valence_trajectory": self.valence_trajectory,
+            "source_passage_ids": self.source_passage_ids,
+        }
+        if self.era:
+            props["era"] = self.era
+        if self.year_start is not None:
+            props["year_start"] = self.year_start
+        if self.year_end is not None:
+            props["year_end"] = self.year_end
+        return props

--- a/tests/test_emotional_arc.py
+++ b/tests/test_emotional_arc.py
@@ -1,0 +1,669 @@
+"""Tests for Character Emotional Arc + Relationship Sentiment Valence (Issue #8).
+
+All tests are pure-Python — no Neo4j or LLM required. Covers:
+  - EmotionalState model
+  - TolkienRegister and RelationshipSentiment enums
+  - ArcCheckpoint and CharacterArc
+  - TOLKIEN_CHARACTER_ARCS baseline (Frodo's arc specifically)
+  - TOLKIEN_RELATIONSHIP_SENTIMENTS (asymmetric relational sentiment)
+  - EmotionalArcValidator
+  - EmotionalStateExtractor (heuristic text extraction)
+  - FeltEdge and RelationalSentimentEdge models
+"""
+
+import pytest
+from book_graph_analyzer.models.emotional_arc import (
+    EmotionalState,
+    ArcCheckpoint,
+    CharacterArc,
+    FeltEdge,
+    RelationalSentimentEdge,
+    TolkienRegister,
+    RelationshipSentiment,
+    REGISTER_ANCHORS,
+    SENTIMENT_VALENCE,
+)
+from book_graph_analyzer.lore.emotional_arc import (
+    EmotionalArcValidator,
+    TOLKIEN_CHARACTER_ARCS,
+    TOLKIEN_RELATIONSHIP_SENTIMENTS,
+    CHARACTER_NAME_MAP,
+    extract_emotional_state_from_text,
+    text_to_emotional_state,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def make_state(
+    state_id: str = "s1",
+    valence: float = 0.0,
+    agency: float = 0.0,
+    register: str = TolkienRegister.RESOLUTE,
+    description: str = "test state",
+) -> EmotionalState:
+    return EmotionalState(
+        id=state_id,
+        valence=valence,
+        agency=agency,
+        dominant_register=register,
+        description=description,
+    )
+
+
+def make_checkpoint(
+    label: str = "test_cp",
+    year: int = 3019,
+    valid_registers: list[str] | None = None,
+    invalid_registers: list[str] | None = None,
+    hardness: str = "SOFT",
+    year_end: int | None = None,
+) -> ArcCheckpoint:
+    return ArcCheckpoint(
+        label=label,
+        story_year=year,
+        story_year_end=year_end,
+        emotional_state=make_state(),
+        description="Test checkpoint",
+        hardness=hardness,
+        valid_registers=(
+            valid_registers if valid_registers is not None
+            else [TolkienRegister.RESOLUTE, TolkienRegister.HOPE]
+        ),
+        invalid_registers=(
+            invalid_registers if invalid_registers is not None
+            else [TolkienRegister.COZY]
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# TolkienRegister
+# ---------------------------------------------------------------------------
+
+class TestTolkienRegister:
+    def test_all_registers_have_anchor(self):
+        for register in TolkienRegister:
+            assert register in REGISTER_ANCHORS, f"Missing anchor for {register}"
+
+    def test_anchors_in_valid_range(self):
+        for register, (valence, agency) in REGISTER_ANCHORS.items():
+            assert -1.0 <= valence <= 1.0, f"Valence out of range for {register}"
+            assert -1.0 <= agency <= 1.0, f"Agency out of range for {register}"
+
+    def test_cozy_is_positive_high_agency(self):
+        v, a = REGISTER_ANCHORS[TolkienRegister.COZY]
+        assert v > 0.5
+        assert a > 0.5
+
+    def test_dread_is_negative_low_agency(self):
+        v, a = REGISTER_ANCHORS[TolkienRegister.DREAD]
+        assert v < -0.5
+        assert a < 0.0
+
+    def test_burden_is_negative_low_agency(self):
+        v, a = REGISTER_ANCHORS[TolkienRegister.BURDEN]
+        assert v < -0.3
+        assert a < -0.4
+
+    def test_eucatastrophic_is_very_positive(self):
+        v, a = REGISTER_ANCHORS[TolkienRegister.EUCATASTROPHIC]
+        assert v > 0.8
+
+
+# ---------------------------------------------------------------------------
+# RelationshipSentiment
+# ---------------------------------------------------------------------------
+
+class TestRelationshipSentiment:
+    def test_all_sentiments_have_valence(self):
+        for sent in RelationshipSentiment:
+            assert sent in SENTIMENT_VALENCE, f"Missing valence for {sent}"
+
+    def test_loyal_is_very_positive(self):
+        assert SENTIMENT_VALENCE[RelationshipSentiment.LOYAL] > 0.8
+
+    def test_enemy_is_very_negative(self):
+        assert SENTIMENT_VALENCE[RelationshipSentiment.ENEMY] < -0.5
+
+    def test_fear_is_negative(self):
+        assert SENTIMENT_VALENCE[RelationshipSentiment.FEAR] < -0.5
+
+    def test_love_is_most_positive(self):
+        assert SENTIMENT_VALENCE[RelationshipSentiment.LOVE] >= 0.9
+
+
+# ---------------------------------------------------------------------------
+# EmotionalState
+# ---------------------------------------------------------------------------
+
+class TestEmotionalState:
+    def test_basic_creation(self):
+        state = make_state(valence=0.7, agency=0.5)
+        assert state.valence == 0.7
+        assert state.agency == 0.5
+
+    def test_to_neo4j_props(self):
+        state = make_state(state_id="s1", valence=0.7)
+        props = state.to_neo4j_props()
+        assert props["id"] == "s1"
+        assert props["valence"] == 0.7
+        assert "dominant_register" in props
+
+    def test_from_dict_roundtrip(self):
+        state = make_state(state_id="s1", valence=0.5, agency=-0.3)
+        d = state.to_dict()
+        state2 = EmotionalState.from_dict(d)
+        assert state2.id == state.id
+        assert abs(state2.valence - state.valence) < 1e-6
+
+    def test_distance_from_same_state(self):
+        s = make_state(valence=0.5, agency=0.3)
+        assert s.distance_from(s) == 0.0
+
+    def test_distance_from_opposite(self):
+        s1 = make_state(valence=1.0, agency=1.0)
+        s2 = make_state(valence=-1.0, agency=-1.0)
+        dist = s1.distance_from(s2)
+        assert dist > 2.0
+
+    def test_compatible_with_close_state(self):
+        s1 = make_state(valence=0.5, agency=0.3)
+        s2 = make_state(valence=0.55, agency=0.35)
+        assert s1.compatible_with(s2)
+
+    def test_not_compatible_with_far_state(self):
+        s1 = make_state(valence=0.9, agency=0.9)   # cozy/joyful
+        s2 = make_state(valence=-0.9, agency=-0.9) # despair/powerless
+        assert not s1.compatible_with(s2)
+
+    def test_is_violation_when_far(self):
+        s_expected = make_state(valence=-0.7, agency=-0.6)  # burden
+        s_proposed = make_state(valence=0.9, agency=0.8)   # cozy joy
+        assert s_proposed.is_violation(s_expected)
+
+    def test_not_violation_when_close(self):
+        s_expected = make_state(valence=0.3, agency=0.5)
+        s_proposed = make_state(valence=0.35, agency=0.45)
+        assert not s_proposed.is_violation(s_expected)
+
+
+# ---------------------------------------------------------------------------
+# ArcCheckpoint
+# ---------------------------------------------------------------------------
+
+class TestArcCheckpoint:
+    def test_covers_year_exact(self):
+        cp = make_checkpoint(year=3019)
+        assert cp.covers_year(3019)
+
+    def test_covers_year_with_range(self):
+        cp = make_checkpoint(year=3018, year_end=3019)
+        assert cp.covers_year(3018)
+        assert cp.covers_year(3019)
+        assert not cp.covers_year(3017)
+        assert not cp.covers_year(3020)
+
+    def test_covers_year_tolerance_window(self):
+        """Single-year checkpoints have ±15 year tolerance."""
+        cp = make_checkpoint(year=3019)
+        assert cp.covers_year(3010)  # within 15 years
+        assert cp.covers_year(3030)  # within 15 years
+        assert not cp.covers_year(2990)  # >15 years away
+
+    def test_is_valid_register_in_valid_list(self):
+        cp = make_checkpoint(valid_registers=[TolkienRegister.RESOLUTE, TolkienRegister.HOPE])
+        assert cp.is_valid_register(TolkienRegister.RESOLUTE)
+        assert cp.is_valid_register(TolkienRegister.HOPE)
+
+    def test_is_invalid_register_not_in_valid_list(self):
+        cp = make_checkpoint(
+            valid_registers=[TolkienRegister.RESOLUTE],
+            invalid_registers=[],
+        )
+        assert not cp.is_valid_register(TolkienRegister.COZY)
+
+    def test_is_invalid_register_explicitly_excluded(self):
+        cp = make_checkpoint(
+            valid_registers=[],  # No specific valid set
+            invalid_registers=[TolkienRegister.COZY],
+        )
+        assert not cp.is_valid_register(TolkienRegister.COZY)
+
+    def test_any_register_valid_when_no_constraints(self):
+        cp = make_checkpoint(valid_registers=[], invalid_registers=[])
+        assert cp.is_valid_register(TolkienRegister.COZY)
+        assert cp.is_valid_register(TolkienRegister.DREAD)
+
+
+# ---------------------------------------------------------------------------
+# CharacterArc
+# ---------------------------------------------------------------------------
+
+class TestCharacterArc:
+    def test_get_checkpoint_for_covered_year(self):
+        arc = CharacterArc(
+            character_id="test",
+            character_name="Test Character",
+            checkpoints=[make_checkpoint(year=3019, year_end=3019)],
+        )
+        cp = arc.get_checkpoint_for_year(3019)
+        assert cp is not None
+
+    def test_get_checkpoint_returns_none_for_uncovered_year(self):
+        arc = CharacterArc(
+            character_id="test",
+            character_name="Test",
+            checkpoints=[make_checkpoint(year=3019, year_end=3019)],
+        )
+        cp = arc.get_checkpoint_for_year(2500)
+        assert cp is None
+
+    def test_validate_state_valid(self):
+        cp = make_checkpoint(
+            year=3019, year_end=3019,
+            valid_registers=[TolkienRegister.RESOLUTE],
+            invalid_registers=[TolkienRegister.COZY],
+        )
+        arc = CharacterArc("test", "Test", [cp])
+        is_valid, explanation = arc.validate_state(TolkienRegister.RESOLUTE, 3019)
+        assert is_valid is True
+
+    def test_validate_state_violation(self):
+        cp = make_checkpoint(
+            year=3019, year_end=3019,
+            valid_registers=[TolkienRegister.RESOLUTE],
+            invalid_registers=[TolkienRegister.COZY],
+        )
+        arc = CharacterArc("test", "Test", [cp])
+        is_valid, explanation = arc.validate_state(TolkienRegister.COZY, 3019)
+        assert is_valid is False
+        assert "VIOLATION" in explanation
+
+    def test_validate_state_no_checkpoint_passes(self):
+        arc = CharacterArc("test", "Test", [])
+        is_valid, _ = arc.validate_state(TolkienRegister.COZY, 9999)
+        assert is_valid is True
+
+
+# ---------------------------------------------------------------------------
+# TOLKIEN_CHARACTER_ARCS — Frodo's arc in detail
+# ---------------------------------------------------------------------------
+
+class TestFrodoArc:
+    def setup_method(self):
+        self.arc = TOLKIEN_CHARACTER_ARCS["frodo_baggins"]
+
+    def test_arc_exists(self):
+        assert self.arc is not None
+        assert self.arc.character_name == "Frodo Baggins"
+
+    def test_multiple_checkpoints(self):
+        assert len(self.arc.checkpoints) >= 5
+
+    def test_shire_is_cozy(self):
+        # Use 3005 — clearly closer to shire_idyll (3001) than flight_to_rivendell (3018)
+        cp = self.arc.get_checkpoint_for_year(3005)
+        assert cp is not None
+        assert TolkienRegister.COZY in cp.valid_registers
+
+    def test_shire_rejects_dread(self):
+        cp = self.arc.get_checkpoint_for_year(3005)
+        assert cp is not None
+        assert TolkienRegister.DREAD in cp.invalid_registers
+
+    def test_mordor_rejects_cozy(self):
+        """Frodo near Mordor (TA 3019) — cozy is a hard violation."""
+        cp = self.arc.get_checkpoint_for_year(3019)
+        assert cp is not None
+        assert TolkienRegister.COZY in cp.invalid_registers
+
+    def test_mordor_rejects_hope(self):
+        """Frodo near Mordor — hopeful and energetic is a violation."""
+        cp = self.arc.get_checkpoint_for_year(3019)
+        assert TolkienRegister.HOPE in cp.invalid_registers or \
+               TolkienRegister.EUCATASTROPHIC in cp.invalid_registers
+
+    def test_mordor_allows_burden(self):
+        cp = self.arc.get_checkpoint_for_year(3019)
+        assert TolkienRegister.BURDEN in cp.valid_registers
+
+    def test_mordor_checkpoint_is_hard(self):
+        # The Cirith Ungol / Mordor checkpoint should be HARD
+        hard_cps = [cp for cp in self.arc.checkpoints if cp.hardness == "HARD"]
+        hard_years = [cp.story_year for cp in hard_cps]
+        assert 3019 in hard_years
+
+    def test_validates_violation_cozy_at_mordor(self):
+        """Spec example: 'hopeful, energetic' at Cirith Ungol → violation."""
+        is_valid, explanation = self.arc.validate_state(TolkienRegister.COZY, 3019)
+        assert is_valid is False
+
+    def test_validates_valid_burden_at_mordor(self):
+        is_valid, _ = self.arc.validate_state(TolkienRegister.BURDEN, 3019)
+        assert is_valid is True
+
+    def test_arc_progression_valence_decreases_toward_mordor(self):
+        """Frodo's valence should be lower near Mordor than in the Shire."""
+        shire_cp = self.arc.get_checkpoint_for_year(3010)
+        mordor_cp = self.arc.get_checkpoint_for_year(3019)
+        if shire_cp and mordor_cp and shire_cp.emotional_state and mordor_cp.emotional_state:
+            assert mordor_cp.emotional_state.valence < shire_cp.emotional_state.valence
+
+
+# ---------------------------------------------------------------------------
+# Other characters
+# ---------------------------------------------------------------------------
+
+class TestSamArc:
+    def setup_method(self):
+        self.arc = TOLKIEN_CHARACTER_ARCS["samwise_gamgee"]
+
+    def test_arc_exists(self):
+        assert self.arc is not None
+
+    def test_mordor_sam_is_resolute(self):
+        cp = self.arc.get_checkpoint_for_year(3019)
+        assert cp is not None
+        assert TolkienRegister.RESOLUTE in cp.valid_registers
+
+    def test_mordor_sam_is_hard(self):
+        hard_cps = [cp for cp in self.arc.checkpoints if cp.hardness == "HARD"]
+        assert len(hard_cps) >= 1
+
+
+class TestGandalfArc:
+    def test_gandalf_white_is_hard(self):
+        arc = TOLKIEN_CHARACTER_ARCS["gandalf"]
+        hard_cps = [cp for cp in arc.checkpoints if cp.hardness == "HARD"]
+        assert any(cp.label == "gandalf_white" for cp in hard_cps)
+
+    def test_gandalf_white_rejects_burden(self):
+        arc = TOLKIEN_CHARACTER_ARCS["gandalf"]
+        cp = arc.get_checkpoint_for_year(3019)
+        if cp:
+            assert TolkienRegister.BURDEN in cp.invalid_registers
+
+
+# ---------------------------------------------------------------------------
+# EmotionalArcValidator
+# ---------------------------------------------------------------------------
+
+class TestEmotionalArcValidator:
+    def setup_method(self):
+        self.validator = EmotionalArcValidator()
+
+    def test_get_arc_by_canonical_id(self):
+        arc = self.validator.get_arc("frodo_baggins")
+        assert arc is not None
+
+    def test_get_arc_by_common_name(self):
+        arc = self.validator.get_arc("Frodo")
+        assert arc is not None
+        assert arc.character_id == "frodo_baggins"
+
+    def test_get_arc_by_alias_sam(self):
+        arc = self.validator.get_arc("Sam")
+        assert arc is not None
+        assert arc.character_id == "samwise_gamgee"
+
+    def test_get_arc_by_alias_strider(self):
+        arc = self.validator.get_arc("Strider")
+        assert arc is not None
+        assert arc.character_id == "aragorn"
+
+    def test_get_arc_unknown_returns_none(self):
+        arc = self.validator.get_arc("Tom Sawyer")
+        assert arc is None
+
+    def test_validate_arc_violation_frodo_mordor_cozy(self):
+        """Spec case: Frodo at TA 3019 feeling 'cozy' = violation."""
+        is_valid, explanation = self.validator.validate_arc(
+            character="Frodo",
+            story_year=3019,
+            proposed_register=TolkienRegister.COZY,
+        )
+        assert is_valid is False
+        assert "VIOLATION" in explanation
+
+    def test_validate_arc_valid_frodo_mordor_burden(self):
+        is_valid, explanation = self.validator.validate_arc(
+            character="Frodo",
+            story_year=3019,
+            proposed_register=TolkienRegister.BURDEN,
+        )
+        assert is_valid is True
+
+    def test_validate_arc_valid_sam_mordor_resolute(self):
+        is_valid, _ = self.validator.validate_arc(
+            character="Sam",
+            story_year=3019,
+            proposed_register=TolkienRegister.RESOLUTE,
+        )
+        assert is_valid is True
+
+    def test_validate_arc_unknown_character_passes(self):
+        """Unknown character has no constraints — always passes."""
+        is_valid, explanation = self.validator.validate_arc(
+            character="Tom Bombadil",
+            story_year=3019,
+            proposed_register=TolkienRegister.COZY,
+        )
+        assert is_valid is True
+
+    def test_validate_arc_from_text_detects_cozy(self):
+        text = "Frodo felt warm and comfortable by the hearth in the cozy hobbit-hole."
+        is_valid, register, explanation = self.validator.validate_arc_from_text(
+            character="Frodo", story_year=3019, text=text
+        )
+        assert register == TolkienRegister.COZY
+        assert is_valid is False
+
+    def test_validate_arc_from_text_burden_passes(self):
+        text = "The weight was crushing, the burden unbearable, he could barely drag himself forward."
+        is_valid, register, explanation = self.validator.validate_arc_from_text(
+            character="Frodo", story_year=3019, text=text
+        )
+        assert register == TolkienRegister.BURDEN
+        assert is_valid is True
+
+    def test_expected_state_returns_checkpoint(self):
+        cp = self.validator.expected_state("Frodo", 3019)
+        assert cp is not None
+
+    def test_expected_state_none_for_unknown_year(self):
+        cp = self.validator.expected_state("Frodo", 1000)
+        assert cp is None
+
+    def test_all_characters_returns_list(self):
+        chars = self.validator.all_characters()
+        assert "Frodo Baggins" in chars
+        assert "Samwise Gamgee" in chars
+
+    def test_list_checkpoints_returns_all(self):
+        cps = self.validator.list_checkpoints("Frodo")
+        assert len(cps) >= 5
+
+
+# ---------------------------------------------------------------------------
+# Heuristic text extraction
+# ---------------------------------------------------------------------------
+
+class TestEmotionalStateExtractor:
+    def test_extract_cozy_from_shire_text(self):
+        text = "Bilbo sat by the warm hearth in his comfortable hobbit-hole and had supper."
+        register, confidence = extract_emotional_state_from_text(text)
+        assert register == TolkienRegister.COZY
+        assert confidence > 0.0
+
+    def test_extract_dread_from_mordor_text(self):
+        text = "The dread darkness pressed upon them; shadow and terror lay on every side."
+        register, confidence = extract_emotional_state_from_text(text)
+        assert register == TolkienRegister.DREAD
+        assert confidence > 0.0
+
+    def test_extract_burden_from_ring_bearer_text(self):
+        text = "The weight was crushing and unbearable; dragging him down, exhausted beyond words."
+        register, confidence = extract_emotional_state_from_text(text)
+        assert register == TolkienRegister.BURDEN
+        assert confidence > 0.0
+
+    def test_extract_wonder_from_elves_text(self):
+        text = "He marvelled at the beautiful radiant elves, wondrous and magnificent beyond words."
+        register, confidence = extract_emotional_state_from_text(text)
+        assert register == TolkienRegister.WONDER
+        assert confidence > 0.0
+
+    def test_extract_resolute_from_determination_text(self):
+        text = "He was determined and resolved; his duty was clear; he stood firm and would not yield."
+        register, confidence = extract_emotional_state_from_text(text)
+        assert register == TolkienRegister.RESOLUTE
+        assert confidence > 0.0
+
+    def test_returns_default_for_neutral_text(self):
+        text = "He walked along the path."
+        register, confidence = extract_emotional_state_from_text(text)
+        assert isinstance(register, str)
+        assert 0.0 <= confidence <= 1.0
+
+    def test_text_to_emotional_state_returns_object(self):
+        text = "He sat by the fire, warm and safe."
+        state = text_to_emotional_state(text, state_id="test")
+        assert isinstance(state, EmotionalState)
+        assert state.id == "test"
+        assert state.dominant_register == TolkienRegister.COZY
+
+
+# ---------------------------------------------------------------------------
+# TOLKIEN_RELATIONSHIP_SENTIMENTS — asymmetric relational sentiment
+# ---------------------------------------------------------------------------
+
+class TestRelationalSentiments:
+    def test_at_least_five_edges(self):
+        assert len(TOLKIEN_RELATIONSHIP_SENTIMENTS) >= 5
+
+    def test_sam_frodo_is_loyal(self):
+        sam_frodo = next(
+            e for e in TOLKIEN_RELATIONSHIP_SENTIMENTS
+            if e.from_character_id == "samwise_gamgee"
+            and e.to_character_id == "frodo_baggins"
+        )
+        assert sam_frodo.sentiment == RelationshipSentiment.LOYAL
+        assert sam_frodo.valence > 0.8
+
+    def test_sam_gollum_is_wary_negative(self):
+        sam_gollum = next(
+            e for e in TOLKIEN_RELATIONSHIP_SENTIMENTS
+            if e.from_character_id == "samwise_gamgee"
+            and e.to_character_id == "gollum"
+        )
+        assert sam_gollum.sentiment == RelationshipSentiment.WARY
+        assert sam_gollum.valence < 0.0
+
+    def test_gollum_sam_is_fear(self):
+        gollum_sam = next(
+            e for e in TOLKIEN_RELATIONSHIP_SENTIMENTS
+            if e.from_character_id == "gollum"
+            and e.to_character_id == "samwise_gamgee"
+        )
+        assert gollum_sam.sentiment == RelationshipSentiment.FEAR
+
+    def test_asymmetry_sam_gollum_vs_gollum_sam(self):
+        """Sam → Gollum ≠ Gollum → Sam — demonstrates asymmetric sentiment."""
+        sam_gollum = next(
+            e for e in TOLKIEN_RELATIONSHIP_SENTIMENTS
+            if e.from_character_id == "samwise_gamgee"
+            and e.to_character_id == "gollum"
+        )
+        gollum_sam = next(
+            e for e in TOLKIEN_RELATIONSHIP_SENTIMENTS
+            if e.from_character_id == "gollum"
+            and e.to_character_id == "samwise_gamgee"
+        )
+        # Different sentiments, both negative
+        assert sam_gollum.sentiment != gollum_sam.sentiment
+
+    def test_frodo_gollum_is_pity(self):
+        frodo_gollum = next(
+            (e for e in TOLKIEN_RELATIONSHIP_SENTIMENTS
+             if e.from_character_id == "frodo_baggins"
+             and e.to_character_id == "gollum"),
+            None
+        )
+        if frodo_gollum:
+            assert frodo_gollum.sentiment == RelationshipSentiment.PITY
+
+    def test_to_neo4j_props_has_required_fields(self):
+        edge = TOLKIEN_RELATIONSHIP_SENTIMENTS[0]
+        props = edge.to_neo4j_props()
+        assert "sentiment" in props
+        assert "valence" in props
+        assert "valence_trajectory" in props
+
+    def test_valence_trajectories_valid(self):
+        valid_trajectories = {"improving", "deteriorating", "stable", "volatile"}
+        for e in TOLKIEN_RELATIONSHIP_SENTIMENTS:
+            assert e.valence_trajectory in valid_trajectories, \
+                f"Invalid trajectory '{e.valence_trajectory}' for {e.from_character_id}"
+
+
+# ---------------------------------------------------------------------------
+# FeltEdge and RelationalSentimentEdge models
+# ---------------------------------------------------------------------------
+
+class TestFeltEdge:
+    def test_basic_creation(self):
+        edge = FeltEdge(
+            character_id="frodo",
+            emotional_state_id="state_mordor",
+            era="Third Age",
+            year=3019,
+            passage_id="p_001",
+        )
+        assert edge.character_id == "frodo"
+        assert edge.year == 3019
+
+    def test_to_neo4j_props_includes_era(self):
+        edge = FeltEdge(
+            character_id="frodo",
+            emotional_state_id="state_mordor",
+            era="Third Age",
+        )
+        props = edge.to_neo4j_props()
+        assert props["era"] == "Third Age"
+
+    def test_to_neo4j_props_omits_none_values(self):
+        edge = FeltEdge(
+            character_id="frodo",
+            emotional_state_id="s1",
+            era="Third Age",
+        )
+        props = edge.to_neo4j_props()
+        assert "year" not in props
+        assert "passage_id" not in props
+        assert "toward_entity_id" not in props
+
+
+class TestRelationalSentimentEdge:
+    def test_basic_creation(self):
+        edge = RelationalSentimentEdge(
+            from_character_id="sam",
+            to_character_id="frodo",
+            sentiment=RelationshipSentiment.LOYAL,
+            valence=0.95,
+            valence_trajectory="stable",
+        )
+        assert edge.sentiment == RelationshipSentiment.LOYAL
+        assert edge.valence == 0.95
+
+    def test_source_passage_ids_default_empty(self):
+        edge = RelationalSentimentEdge(
+            from_character_id="sam",
+            to_character_id="frodo",
+            sentiment=RelationshipSentiment.LOYAL,
+            valence=0.9,
+            valence_trajectory="stable",
+        )
+        assert edge.source_passage_ids == []


### PR DESCRIPTION
## Summary

Implements Issue #8 — Character Emotional Arc + Relationship Sentiment Valence.

## What's Built

### 1. EmotionalState model (models/emotional_arc.py)
- alence (-1.0 despair → 1.0 joy), gency (-1.0 powerless → 1.0 in command)
- dominant_register (TolkienRegister), description
- distance_from(), compatible_with(), is_violation() — spatial comparison in (valence, agency) space
- 	o_neo4j_props() / rom_dict()

### 2. TolkienRegister enum — 12 registers
elegiac, eucatastrophic, dread, wonder, cozy, resolute, burden, grief, hope, rage, pity, transcendent
Each has REGISTER_ANCHORS (valence, agency) for heuristic validation.

### 3. RelationshipSentiment enum — 9 values
ally, enemy, wary, loyal, love, pity, fear, respect, grief
Each has SENTIMENT_VALENCE mapping.

### 4. ArcCheckpoint and CharacterArc
- ArcCheckpoint: label, story_year, year_end (range), valid/invalid registers, hardness (HARD/SOFT)
- covers_year() with ±15 year tolerance for single-point checkpoints
- CharacterArc.validate_state() — returns (is_valid, explanation)

### 5. Pre-defined Tolkien Arcs (lore/emotional_arc.py)
Detailed arcs for **5 characters**:
- **Frodo**: 8 checkpoints (Shire → Grey Havens), 2 HARD checkpoints at Mordor stages
- **Sam**: 3 checkpoints with HARD 'carrying Frodo' milestone
- **Gandalf**: 2 checkpoints (Grey → White), HARD Gandalf White
- **Aragorn**: 2 checkpoints
- **Gollum**: 1 checkpoint

Key validation: Frodo at TA 3019 (Cirith Ungol/Mordor) — cozy, wonder, hope, eucatastrophic → hard violations. Only urden, dread, grief are valid.

### 6. TOLKIEN_RELATIONSHIP_SENTIMENTS — 7 asymmetric edges
- Sam→Frodo: loyal (+0.95)
- Frodo→Sam: love (+0.90, volatile near Mordor)
- Sam→Gollum: wary (-0.70, deteriorating)
- Gollum→Sam: fear (-0.80, stable)
- Gollum→Frodo: pity (+0.10, volatile)
- Frodo→Gollum: pity (+0.20, deteriorating)
- Aragorn→Gandalf: respect (+0.80)

### 7. EmotionalArcValidator
- get_arc() — by canonical ID or name alias (Frodo, Sam, Strider, etc.)
- alidate_arc(character, story_year, proposed_register) → (is_valid, explanation)
- alidate_arc_from_text(character, story_year, text) — heuristic extraction then validation
- expected_state(), list_checkpoints(), ll_characters()

### 8. Heuristic EmotionalStateExtractor (no LLM)
Keyword-based register detection: ~100 keywords across 12 registers.

### 9. EmotionalArcNeo4jWriter
- upsert_emotional_state(), upsert_felt_edge() — write EmotionalState + FELT edges
- upsert_relationship_sentiment() — extend KNOWS edge with sentiment data
- seed_tolkien_sentiments(), query_character_arc()

### 10. CLI Commands
`
bga lore arc --character Frodo
bga lore arc --character Frodo --year 3019
bga lore validate-arc --character Frodo --story-year 3019 --generated-state cozy
bga lore validate-arc --character Frodo --story-year 3019 --text '...'
bga lore sentiment
bga lore sentiment --from-character samwise_gamgee
`

### 11. Tests — 83 passing (	ests/test_emotional_arc.py)
