### PR TITLE
feat: VoiceProfile + audience-variant character voice

### DIFF
--- a/src/book_graph_analyzer/cli.py
+++ b/src/book_graph_analyzer/cli.py
@@ -1265,6 +1265,126 @@ def voice_quotes(results_path: str, character: str, limit: int) -> None:
     console.print(f"\n[dim]Total lines: {profile.total_lines}[/dim]")
 
 
+@voice.command(name="identify")
+@click.option("--text", "-t", required=True, help="Raw text snippet to identify speaker for")
+@click.option("--top", "-n", default=3, help="Number of top matches to return")
+def voice_identify(text: str, top: int) -> None:
+    """Identify likely speaker from a text snippet using stored VoiceProfiles.
+
+    Compares the snippet's voice metrics against all VoiceProfile nodes
+    in Neo4j and returns the top N matches with confidence scores.
+
+    Example:
+        bga voice identify --text "You shall not pass!"
+    """
+    from book_graph_analyzer.graph.voice_writer import VoiceProfileWriter
+    from book_graph_analyzer.graph.connection import check_neo4j_connection
+
+    if not check_neo4j_connection():
+        console.print("[red]Cannot connect to Neo4j.[/red]")
+        console.print("[dim]Run 'bga status' to diagnose the connection.[/dim]")
+        return
+
+    writer = VoiceProfileWriter()
+    try:
+        matches = writer.identify_speaker(text, top_n=top)
+    finally:
+        writer.close()
+
+    if not matches:
+        console.print("[yellow]No VoiceProfile nodes found in Neo4j.[/yellow]")
+        console.print("[dim]Run 'bga voice build-profiles' first.[/dim]")
+        return
+
+    console.print(f"\n[bold]Speaker Identification Results[/bold]")
+    console.print(f"[dim]Text: \"{text[:80]}{'...' if len(text) > 80 else ''}\"[/dim]\n")
+
+    # Also compute the query metrics for display
+    from book_graph_analyzer.graph.voice_writer import _extract_text_metrics
+    metrics = _extract_text_metrics(text)
+
+    for i, (character_id, confidence) in enumerate(matches, 1):
+        bar = "█" * int(confidence * 20)
+        console.print(
+            f"  {i}. [cyan]{character_id}[/cyan] "
+            f"(confidence: [bold]{confidence:.2f}[/bold])  [{bar:<20}]"
+        )
+        console.print(
+            f"     formality_score: {metrics['formality_score']:.3f} | "
+            f"archaism_rate: {metrics['archaism_rate']:.3f} | "
+            f"imperative_ratio: {metrics['imperative_ratio']:.3f}"
+        )
+    console.print()
+
+
+@voice.command(name="build-profiles")
+@click.option("--results", "-r", type=click.Path(exists=True),
+              help="JSON voice results file (from 'bga voice analyze')")
+@click.option("--min-utterances", "-m", default=10,
+              help="Minimum utterances required to build a profile (default: 10)")
+def voice_build_profiles(results: str | None, min_utterances: int) -> None:
+    """Build and persist VoiceProfile nodes in Neo4j from a voice analysis results file.
+
+    Reads character voice profiles from a JSON results file (produced by
+    'bga voice analyze') and upserts them into Neo4j as VoiceProfile nodes.
+    Only characters with >= min_utterances lines are stored.
+
+    Example:
+        bga voice build-profiles -r hobbit_voices.json
+        bga voice build-profiles -r hobbit_voices.json --min-utterances 5
+    """
+    from book_graph_analyzer.voice import VoiceAnalyzer
+    from book_graph_analyzer.graph.voice_writer import VoiceProfileWriter
+    from book_graph_analyzer.graph.connection import check_neo4j_connection
+
+    if not check_neo4j_connection():
+        console.print("[red]Cannot connect to Neo4j.[/red]")
+        console.print("[dim]Run 'bga status' to diagnose the connection.[/dim]")
+        return
+
+    if not results:
+        console.print("[red]No results file specified.[/red]")
+        console.print("[dim]Run 'bga voice analyze <path> -o results.json' first, "
+                      "then pass -r results.json here.[/dim]")
+        return
+
+    analyzer = VoiceAnalyzer()
+    result = analyzer.load_results(results)
+
+    # Filter to characters with enough utterances
+    eligible = {
+        name: profile
+        for name, profile in result.profiles.items()
+        if profile.total_lines >= min_utterances
+    }
+
+    if not eligible:
+        console.print(
+            f"[yellow]No characters with >= {min_utterances} utterances found.[/yellow]"
+        )
+        return
+
+    console.print(
+        f"[bold]Building VoiceProfiles[/bold] — {len(eligible)} characters "
+        f"(min utterances: {min_utterances})"
+    )
+
+    writer = VoiceProfileWriter()
+    stored = 0
+    try:
+        for name, profile in eligible.items():
+            writer.upsert_voice_profile(profile)
+            stored += 1
+            console.print(f"  [green]✓[/green] {name} ({profile.total_lines} utterances, "
+                          f"formality: {profile.formality_score:.3f})")
+    finally:
+        writer.close()
+
+    console.print(
+        f"\n[green]Done.[/green] Stored {stored} VoiceProfile node(s) in Neo4j."
+    )
+
+
 # ============================================================================
 # Pipeline Commands - Unified Analysis
 # ============================================================================

--- a/src/book_graph_analyzer/graph/voice_writer.py
+++ b/src/book_graph_analyzer/graph/voice_writer.py
@@ -1,0 +1,300 @@
+"""Neo4j VoiceProfile writer and speaker-identification helper.
+
+Follows the same patterns as passage_writer.py:
+- get_driver() from .connection
+- Session context managers
+- MERGE queries for idempotency
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+import statistics
+from typing import Optional
+
+from .connection import get_driver
+from ..voice.profile import (
+    CharacterVoiceProfile,
+    MODERN_ANACHRONISMS,
+    _is_imperative,
+    _is_rhetorical,
+    _compute_formality_score,
+)
+
+
+class VoiceProfileWriter:
+    """Write and query VoiceProfile data in Neo4j."""
+
+    def __init__(self, driver=None):
+        self._driver = driver
+
+    @property
+    def driver(self):
+        if self._driver is None:
+            self._driver = get_driver()
+            if self._driver is None:
+                raise ConnectionError("Cannot connect to Neo4j")
+        return self._driver
+
+    def close(self) -> None:
+        if self._driver:
+            self._driver.close()
+            self._driver = None
+
+    # ------------------------------------------------------------------
+    # Write helpers
+    # ------------------------------------------------------------------
+
+    def upsert_voice_profile(self, profile: CharacterVoiceProfile) -> None:
+        """Create or update a VoiceProfile node in Neo4j.
+
+        The node is keyed on character_id (falls back to character_name slug).
+        Calling this multiple times is idempotent.
+        """
+        profile_id = _make_profile_id(profile)
+
+        props: dict = {
+            "id": profile_id,
+            "character_id": profile.character_id or _slugify(profile.character_name),
+            "character_name": profile.character_name,
+            # Corpus stats
+            "total_utterances": profile.total_lines,
+            "total_words": profile.total_words,
+            "vocabulary_size": profile.unique_words,
+            "avg_utterance_length": profile.avg_utterance_length,
+            # Speech pattern ratios
+            "question_ratio": profile.question_ratio,
+            "exclamation_ratio": profile.exclamation_ratio,
+            "statement_ratio": profile.statement_ratio,
+            # Formality metrics
+            "formality_score": profile.formality_score,
+            "archaism_rate": profile.archaism_rate,
+            "contraction_usage": profile.contraction_ratio,
+            "first_person_ratio": profile.first_person_ratio,
+            "imperative_ratio": profile.imperative_ratio,
+            "rhetorical_density": profile.rhetorical_density,
+            # Audience variants (stored as JSON strings)
+            "formality_by_audience": json.dumps(profile.formality_by_audience),
+            "length_by_audience": json.dumps(profile.length_by_audience),
+            "register_by_audience": json.dumps(profile.register_by_audience),
+            # Fingerprint lists (stored as Neo4j lists)
+            "distinctive_words": profile.distinctive_words,
+            "signature_phrases": profile.signature_phrases,
+            "never_says": profile.never_says,
+            # Topic distribution (JSON string)
+            "topic_distribution": json.dumps(profile.topic_distribution),
+        }
+
+        with self.driver.session() as session:
+            session.run(
+                "MERGE (vp:VoiceProfile {id: $id}) SET vp += $props",
+                id=profile_id,
+                props=props,
+            )
+
+    def link_passage_to_profile(
+        self,
+        passage_id: str,
+        profile_id: str,
+        speaker_id: str,
+        audience_type: str,
+        context_type: str,
+    ) -> None:
+        """Create (Passage)-[:VOICED_IN {…}]->(VoiceProfile) edge."""
+        edge_props = {
+            "speaker_id": speaker_id,
+            "audience_type": audience_type,
+            "context_type": context_type,
+        }
+
+        with self.driver.session() as session:
+            session.run(
+                """
+                MATCH (p:Passage {id: $passage_id})
+                MATCH (vp:VoiceProfile {id: $profile_id})
+                MERGE (p)-[r:VOICED_IN {speaker_id: $speaker_id}]->(vp)
+                SET r += $props
+                """,
+                passage_id=passage_id,
+                profile_id=profile_id,
+                speaker_id=speaker_id,
+                props=edge_props,
+            )
+
+    def get_voice_profile(self, character_id: str) -> dict | None:
+        """Fetch a VoiceProfile node from Neo4j by character_id.
+
+        Returns the node properties as a dict, or None if not found.
+        """
+        with self.driver.session() as session:
+            result = session.run(
+                "MATCH (vp:VoiceProfile {character_id: $cid}) RETURN vp",
+                cid=character_id,
+            )
+            row = result.single()
+            if not row:
+                return None
+            return dict(row["vp"])
+
+    def identify_speaker(self, text: str, top_n: int = 3) -> list[tuple[str, float]]:
+        """Given raw text, return top N (character_id, confidence) matches.
+
+        Extracts surface metrics from *text* and compares them against all
+        stored VoiceProfile nodes.  Returns a sorted list (highest confidence
+        first), with confidence values in [0.0, 1.0].
+        """
+        # -- Extract metrics from the query text --
+        query_metrics = _extract_text_metrics(text)
+
+        # -- Fetch all profiles --
+        with self.driver.session() as session:
+            result = session.run(
+                """
+                MATCH (vp:VoiceProfile)
+                RETURN vp.character_id AS cid,
+                       vp.formality_score AS formality_score,
+                       vp.archaism_rate AS archaism_rate,
+                       vp.question_ratio AS question_ratio,
+                       vp.exclamation_ratio AS exclamation_ratio,
+                       vp.imperative_ratio AS imperative_ratio,
+                       vp.rhetorical_density AS rhetorical_density,
+                       vp.contraction_usage AS contraction_usage,
+                       vp.avg_utterance_length AS avg_utterance_length
+                """
+            )
+            profiles = [dict(row) for row in result]
+
+        if not profiles:
+            return []
+
+        # -- Score each profile --
+        scored: list[tuple[str, float]] = []
+        for prof in profiles:
+            cid = prof.get("cid", "unknown")
+            confidence = _compute_similarity(query_metrics, prof)
+            scored.append((cid, round(confidence, 4)))
+
+        # Sort descending by confidence
+        scored.sort(key=lambda x: -x[1])
+        return scored[:top_n]
+
+
+# ---------------------------------------------------------------------------
+# Pure-python text metric extraction (no Neo4j, used by identify_speaker)
+# ---------------------------------------------------------------------------
+
+def _extract_text_metrics(text: str) -> dict:
+    """Extract the same metrics we store on VoiceProfile, from raw text."""
+    archaisms_set = {
+        "thee", "thou", "thy", "thine", "ye", "hath", "doth", "art", "wast",
+        "wherefore", "hither", "thither", "whither", "hence", "thence",
+        "ere", "nay", "aye", "yea", "behold", "lo", "alas", "forsooth",
+        "methinks", "mayhap", "perchance", "betwixt", "amongst", "whilst",
+        "verily", "hark", "hearken", "tarry", "prithee",
+    }
+    contraction_patterns = ["n't", "'s", "'re", "'ve", "'ll", "'d", "'m"]
+    fp_words = {'i', 'me', 'my', 'mine', 'myself', "i'm", "i've", "i'll", "i'd"}
+
+    # Split into sentences/utterances (simple split on . ! ?)
+    utterances = [u.strip() for u in re.split(r'[.!?]+', text) if u.strip()]
+    if not utterances:
+        utterances = [text]
+
+    total_utter = len(utterances)
+    questions = sum(1 for u in utterances if text.find(u) >= 0 and u.endswith("?"))
+    exclamations = sum(1 for u in utterances if u.endswith("!"))
+    # Recount from original text
+    questions = text.count("?")
+    exclamations = text.count("!")
+    question_ratio = questions / total_utter if total_utter else 0.0
+    exclamation_ratio = exclamations / total_utter if total_utter else 0.0
+
+    words = text.lower().split()
+    total_words = len(words) or 1
+
+    arch_count = sum(1 for w in words if w.strip('.,!?"\'') in archaisms_set)
+    contr_count = sum(1 for w in words if any(p in w for p in contraction_patterns))
+    fp_count = sum(1 for w in words if w.strip('.,!?"\'') in fp_words)
+    word_lengths = [len(w.strip('.,!?"\'')) for w in words if w.strip('.,!?"\'')]
+    avg_wl = statistics.mean(word_lengths) if word_lengths else 4.0
+
+    archaism_rate = arch_count / total_words
+    contraction_usage = contr_count / total_words
+    first_person_ratio = fp_count / total_words
+
+    # Imperative / rhetorical
+    imperative_count = sum(1 for u in re.split(r'[.!?]+', text) if _is_imperative(u.strip()))
+    rhetorical_count = sum(1 for u in re.split(r'[.!?]+', text) if _is_rhetorical(u.strip() + "?"))
+    imperative_ratio = imperative_count / total_utter if total_utter else 0.0
+    rhetorical_density = rhetorical_count / total_utter if total_utter else 0.0
+
+    formality_score = _compute_formality_score(
+        archaism_rate, contraction_usage, avg_wl, first_person_ratio
+    )
+
+    avg_utterance_length = total_words / total_utter if total_utter else total_words
+
+    return {
+        "formality_score": formality_score,
+        "archaism_rate": archaism_rate,
+        "question_ratio": question_ratio,
+        "exclamation_ratio": exclamation_ratio,
+        "imperative_ratio": imperative_ratio,
+        "rhetorical_density": rhetorical_density,
+        "contraction_usage": contraction_usage,
+        "avg_utterance_length": avg_utterance_length,
+    }
+
+
+def _compute_similarity(query: dict, profile: dict) -> float:
+    """Cosine-distance-inspired similarity in [0, 1] between query and profile metrics."""
+    # Metric weights (must sum to 1.0)
+    weights = {
+        "formality_score": 0.30,
+        "archaism_rate": 0.20,
+        "question_ratio": 0.10,
+        "exclamation_ratio": 0.05,
+        "imperative_ratio": 0.15,
+        "rhetorical_density": 0.10,
+        "contraction_usage": 0.05,
+        "avg_utterance_length": 0.05,
+    }
+
+    total_weight = 0.0
+    weighted_sim = 0.0
+
+    for metric, weight in weights.items():
+        q_val = float(query.get(metric) or 0.0)
+        p_val = float(profile.get(metric) or 0.0)
+
+        if metric == "avg_utterance_length":
+            # Normalise: typical range 0–30 words
+            q_val = min(1.0, q_val / 30.0)
+            p_val = min(1.0, p_val / 30.0)
+
+        # Similarity = 1 - absolute difference (both values in [0,1])
+        diff = abs(q_val - p_val)
+        sim = max(0.0, 1.0 - diff)
+        weighted_sim += weight * sim
+        total_weight += weight
+
+    if total_weight == 0:
+        return 0.0
+
+    return weighted_sim / total_weight
+
+
+# ---------------------------------------------------------------------------
+# Utility
+# ---------------------------------------------------------------------------
+
+def _slugify(name: str) -> str:
+    return re.sub(r"[^a-z0-9_]", "_", name.lower()).strip("_")
+
+
+def _make_profile_id(profile: CharacterVoiceProfile) -> str:
+    if profile.character_id:
+        return f"voice_{profile.character_id}"
+    return f"voice_{_slugify(profile.character_name)}"

--- a/src/book_graph_analyzer/voice/audience.py
+++ b/src/book_graph_analyzer/voice/audience.py
@@ -1,0 +1,233 @@
+"""
+Audience Classification
+
+Heuristic classifier for audience type and conversational context
+of a dialogue line.  No LLM required — keyword/pattern based.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .dialogue import DialogueLine
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+AUDIENCE_TYPES = [
+    "hobbit",
+    "elf",
+    "man",
+    "dwarf",
+    "enemy",
+    "neutral",
+    "self",
+    "prayer",
+]
+
+CONTEXT_TYPES = [
+    "crisis",
+    "explanation",
+    "command",
+    "comfort",
+    "warning",
+    "farewell",
+]
+
+# Keywords / names strongly associated with each audience type
+_AUDIENCE_KEYWORDS: dict[str, list[str]] = {
+    "hobbit": [
+        "bilbo", "frodo", "sam", "samwise", "merry", "pippin", "peregrin",
+        "hobbit", "hobbits", "halfling", "halflings", "shire", "baggins",
+        "gamgee", "took", "brandybuck",
+    ],
+    "elf": [
+        "gandalf",  # Gandalf is Maia but often classed with elves in address
+        "legolas", "elrond", "galadriel", "arwen", "glorfindel", "celeborn",
+        "elf", "elves", "elvish", "eldar", "firstborn", "rivendell", "lothlórien",
+        "lothlórien", "lorien",
+    ],
+    "man": [
+        "aragorn", "boromir", "faramir", "theoden", "eomer", "eowyn",
+        "man", "men", "dunedain", "gondor", "rohan", "mortal", "mortals",
+        "king", "captain", "lord", "ranger",
+    ],
+    "dwarf": [
+        "gimli", "gloin", "balin", "oin", "dwalin", "thorin", "dori", "nori",
+        "dwarf", "dwarves", "dwarfs", "khazad", "erebor", "moria",
+    ],
+    "enemy": [
+        "sauron", "saruman", "morgoth", "balrog", "nazgul", "orc", "orcs",
+        "wraith", "dark lord", "enemy", "foe", "villain", "traitor",
+    ],
+    "self": [
+        "myself", "mine own", "i ask myself", "i wonder", "i know not",
+    ],
+    "prayer": [
+        "elbereth", "varda", "iluvatar", "eru", "manwe", "the valar",
+        "bless", "grant me", "hear my", "o lord", "o ancient",
+    ],
+}
+
+# Compiled lower-case keyword lookup per audience type
+_AUDIENCE_RE: dict[str, re.Pattern] = {
+    aud: re.compile(
+        r"\b(" + "|".join(re.escape(kw) for kw in kws) + r")\b",
+        re.IGNORECASE,
+    )
+    for aud, kws in _AUDIENCE_KEYWORDS.items()
+}
+
+# ---------------------------------------------------------------------------
+# Context classification patterns
+# ---------------------------------------------------------------------------
+
+_IMPERATIVE_STARTS = [
+    "go", "come", "run", "stop", "listen", "look", "wait", "stand",
+    "do not", "don't", "never", "beware", "fly", "flee", "seek", "find",
+    "follow", "stay", "leave", "hold", "keep", "turn", "move", "speak",
+    "tell", "say", "fear", "trust", "grant", "forgive", "remember",
+    "bring", "take", "give", "get", "make", "let", "help", "save",
+    "throw", "cast", "pass", "hear", "heed", "see", "read", "open",
+    "close", "guard", "protect", "hide", "rise", "fall", "walk", "halt",
+]
+
+_FAREWELL_PATTERNS = re.compile(
+    r"\b(farewell|goodbye|good-bye|till we meet|safe travels?|may (your|the|your) "
+    r"|namarie|namarié|go well|ride well|god speed|godspeed|adieu|until we meet)\b",
+    re.IGNORECASE,
+)
+
+_COMFORT_PATTERNS = re.compile(
+    r"\b(fear not|do not grieve|all will be well|there there|take heart|"
+    r"courage|hope|you are safe|rest now|do not weep|be at peace|"
+    r"worry not|peace|calm|be comforted)\b",
+    re.IGNORECASE,
+)
+
+_WARNING_PATTERNS = re.compile(
+    r"\b(beware|danger|watch out|take care|be wary|peril|threat|"
+    r"do not go|do not trust|flee the|run from|escape)\b",
+    re.IGNORECASE,
+)
+
+_CRISIS_PATTERNS = re.compile(
+    r"\b(attack|they are upon|surrounded|no time|hurry|quickly|retreat|"
+    r"help|emergency|fire|break|now or never|too late|fallen|lost|"
+    r"we are lost|we shall not)\b",
+    re.IGNORECASE,
+)
+
+_EXPLANATION_PATTERNS = re.compile(
+    r"\b(because|therefore|thus|hence|in other words|that is to say|"
+    r"you see|let me explain|the reason|it means|what this means|"
+    r"understand|know that|be aware that|hear me)\b",
+    re.IGNORECASE,
+)
+
+
+def _classify_context(text: str, is_question: bool, is_exclamation: bool) -> str:
+    """Return a CONTEXT_TYPE label for a dialogue line.
+
+    Priority order (highest to lowest):
+        farewell → comfort → warning → crisis → command → explanation
+    Comfort and warning are checked before command so that patterns like
+    "Fear not" and "Beware" are correctly labelled rather than falling
+    through to a generic imperative match.
+    """
+    lowered = text.lower().strip()
+
+    # 1. Farewell — easiest wins
+    if _FAREWELL_PATTERNS.search(lowered):
+        return "farewell"
+
+    # 2. Comfort — reassurance language ("fear not", "all will be well", …)
+    #    Must come before command so "Fear not" isn't caught as imperative.
+    if _COMFORT_PATTERNS.search(lowered):
+        return "comfort"
+
+    # 3. Warning — danger language ("beware", "peril", …)
+    #    Must come before command so "Beware" isn't caught as imperative.
+    if _WARNING_PATTERNS.search(lowered):
+        return "warning"
+
+    # 4. Crisis — urgent, exclamatory, panic
+    if _CRISIS_PATTERNS.search(lowered) and (is_exclamation or is_question):
+        return "crisis"
+
+    # 5. Command — imperative structure (verbs not already caught above)
+    for imp in _IMPERATIVE_STARTS:
+        if (
+            lowered.startswith(imp + " ")
+            or lowered.startswith(imp + ",")
+            or lowered.startswith(imp + "!")
+            or lowered == imp
+        ):
+            return "command"
+
+    # 6. Explanation — because / therefore / you see
+    if _EXPLANATION_PATTERNS.search(lowered):
+        return "explanation"
+
+    # Fallback
+    return "explanation"
+
+
+def _classify_audience_from_text(
+    text: str,
+    addressee: str | None,
+    passage_context: str,
+) -> str:
+    """Return an AUDIENCE_TYPE label."""
+    # If we already have a named addressee, try to match it
+    if addressee:
+        addr_lower = addressee.lower()
+        for aud_type, kws in _AUDIENCE_KEYWORDS.items():
+            for kw in kws:
+                if kw in addr_lower:
+                    return aud_type
+
+    # Scan passage context + text for known names
+    combined = (text + " " + passage_context).lower()
+    scores: dict[str, int] = {}
+    for aud_type, pattern in _AUDIENCE_RE.items():
+        hits = pattern.findall(combined)
+        if hits:
+            scores[aud_type] = len(hits)
+
+    if scores:
+        return max(scores, key=lambda k: scores[k])
+
+    return "neutral"
+
+
+def classify_audience(
+    dialogue_line: "DialogueLine",
+    passage_context: str = "",
+) -> tuple[str, str]:
+    """
+    Classify the audience type and conversational context for a dialogue line.
+
+    Args:
+        dialogue_line: A DialogueLine object (must have .text, .is_question,
+                       .is_exclamation; optionally .addressee).
+        passage_context: Surrounding passage text for additional context.
+
+    Returns:
+        (audience_type, context_type) — both are strings from AUDIENCE_TYPES
+        and CONTEXT_TYPES respectively.
+    """
+    addressee = getattr(dialogue_line, "addressee", None)
+    text = dialogue_line.text
+
+    audience_type = _classify_audience_from_text(text, addressee, passage_context)
+    context_type = _classify_context(
+        text,
+        is_question=dialogue_line.is_question,
+        is_exclamation=dialogue_line.is_exclamation,
+    )
+
+    return audience_type, context_type

--- a/src/book_graph_analyzer/voice/profile.py
+++ b/src/book_graph_analyzer/voice/profile.py
@@ -7,106 +7,267 @@ Captures the distinctive speech patterns of a character.
 from dataclasses import dataclass, field, asdict
 from typing import Optional
 import json
+import re
 import statistics
 from collections import Counter
+
+
+# ---------------------------------------------------------------------------
+# Topic keyword clusters for topic_distribution
+# ---------------------------------------------------------------------------
+
+TOPIC_KEYWORDS: dict[str, list[str]] = {
+    "history": [
+        "age", "era", "ancient", "old", "years", "kingdom", "legend", "tale",
+        "past", "long ago", "remember", "history", "lore", "tradition", "ages",
+        "days of", "yore", "elder", "forebear", "ancestor",
+    ],
+    "war": [
+        "battle", "fight", "sword", "enemy", "army", "war", "warrior", "shield",
+        "blade", "weapon", "attack", "defeat", "victory", "conquer", "siege",
+        "foe", "host", "orc", "darkness", "evil", "sauron", "ring",
+    ],
+    "practical": [
+        "food", "water", "road", "path", "camp", "fire", "rest", "sleep",
+        "eat", "drink", "walk", "journey", "carry", "pack", "need", "get",
+        "go", "come", "here", "there", "do", "make", "take",
+    ],
+    "wisdom": [
+        "wisdom", "counsel", "hope", "fate", "doom", "purpose", "must",
+        "ought", "understand", "know", "think", "believe", "truth", "power",
+        "choice", "decide", "heart", "courage", "will", "destiny",
+    ],
+    "nature": [
+        "forest", "river", "mountain", "sea", "tree", "stone", "sky", "land",
+        "earth", "water", "wind", "star", "sun", "moon", "light", "shadow",
+        "dark", "night", "day", "vale", "plain",
+    ],
+    "friendship": [
+        "friend", "companion", "fellowship", "trust", "together", "loyal",
+        "love", "care", "kin", "folk", "people", "home", "family", "master",
+        "sir", "dear", "good",
+    ],
+}
+
+# Words that would be anachronistic in a medieval/high-fantasy register
+MODERN_ANACHRONISMS: list[str] = [
+    "okay", "ok", "yeah", "yep", "nope", "cool", "awesome", "guys",
+    "basically", "literally", "actually", "totally", "like", "whatever",
+    "seriously", "definitely", "absolutely", "random", "stressed", "vibe",
+    "chill", "dude", "bro", "hello", "hi", "bye", "thanks", "alright",
+    "sure", "fine", "wanna", "gonna", "gotta", "kinda", "sorta",
+]
+
+# Common imperative verb starts (infinitive / base form)
+IMPERATIVE_STARTS: list[str] = [
+    "go", "come", "run", "stop", "listen", "look", "wait", "stand",
+    "do not", "don't", "never", "beware", "fly", "flee", "seek", "find",
+    "follow", "stay", "leave", "hold", "keep", "turn", "move", "speak",
+    "tell", "say", "fear", "trust", "grant", "forgive", "remember",
+    "bring", "take", "give", "get", "make", "let", "help", "save",
+    "throw", "cast", "pass", "hear", "heed", "see", "read", "open",
+    "close", "guard", "protect", "hide", "rise", "fall", "walk", "halt",
+]
+
+# Rhetorical question markers
+RHETORICAL_PATTERNS: list[str] = [
+    r"^why\s+(would|should|must|do|does|did|shall|will)\b",
+    r"^how\s+(dare|could|can|shall|would|should)\b",
+    r"\bis it not\b.*\?",
+    r"\bare (?:we|you|they) not\b.*\?",
+    r"\bwas (?:it|he|she|there) not\b.*\?",
+    r"^what\s+(good|use|point|purpose)\b",
+    r"^who\s+(among|would|could|shall|dares|dare)\b",
+    r"^do you not\b",
+    r"^does (?:he|she|it|one) not\b",
+]
+
+_RHETORICAL_RE = [re.compile(p, re.IGNORECASE) for p in RHETORICAL_PATTERNS]
+
+
+def _is_rhetorical(text: str) -> bool:
+    """Heuristically decide if a question is rhetorical."""
+    stripped = text.strip()
+    if not stripped.endswith("?"):
+        return False
+    for pattern in _RHETORICAL_RE:
+        if pattern.search(stripped):
+            return True
+    return False
+
+
+def _is_imperative(text: str) -> bool:
+    """Heuristically decide if a line is imperative."""
+    lowered = text.lower().strip()
+    for imp in IMPERATIVE_STARTS:
+        if (
+            lowered.startswith(imp + " ")
+            or lowered.startswith(imp + ",")
+            or lowered.startswith(imp + "!")
+            or lowered.startswith(imp + "?")
+            or lowered == imp
+        ):
+            return True
+    return False
+
+
+def _compute_topic_distribution(all_words: list[str]) -> dict[str, float]:
+    """Assign a word-overlap topic distribution. Returns proportions summing to 1."""
+    word_set = set(all_words)
+    scores: dict[str, float] = {}
+    for topic, keywords in TOPIC_KEYWORDS.items():
+        hit = sum(1 for kw in keywords if kw in word_set)
+        scores[topic] = float(hit)
+    total = sum(scores.values())
+    if total == 0:
+        # Uniform distribution
+        n = len(TOPIC_KEYWORDS)
+        return {t: round(1.0 / n, 4) for t in TOPIC_KEYWORDS}
+    return {t: round(v / total, 4) for t, v in scores.items()}
+
+
+def _compute_formality_score(
+    archaism_rate: float,
+    contraction_ratio: float,
+    avg_word_length: float,
+    first_person_ratio: float,
+) -> float:
+    """Compute 0.0–1.0 formality score from four signals."""
+    # archaism: rate up to 0.05 = full formal contribution
+    arch = min(1.0, archaism_rate / 0.05)
+    # contractions: 0.15+ → fully informal
+    contr = 1.0 - min(1.0, contraction_ratio / 0.15)
+    # word length: 3 chars informal, 7+ chars formal
+    wl = min(1.0, max(0.0, (avg_word_length - 3.0) / 4.0))
+    # first-person: 0.08+ → fully informal
+    fp = 1.0 - min(1.0, first_person_ratio / 0.08)
+    score = 0.25 * arch + 0.25 * contr + 0.25 * wl + 0.25 * fp
+    return round(max(0.0, min(1.0, score)), 4)
 
 
 @dataclass
 class CharacterVoiceProfile:
     """
     Voice profile for a single character.
-    
+
     Captures how a character speaks: vocabulary, formality,
     sentence patterns, and distinctive phrases.
     """
-    
+
     # Identity
     character_name: str
     character_id: Optional[str] = None  # Canonical entity ID
-    
+
     # Corpus stats
     total_lines: int = 0
     total_words: int = 0
     total_chars: int = 0
-    
+
     # Utterance metrics
     avg_utterance_length: float = 0.0      # Words per line
     utterance_length_std: float = 0.0
     min_utterance_length: int = 0
     max_utterance_length: int = 0
-    
+
     # Dialogue type distribution
     question_ratio: float = 0.0            # % of lines that are questions
     exclamation_ratio: float = 0.0         # % of lines that are exclamations
     statement_ratio: float = 0.0           # % of lines that are statements
-    
+
     # Vocabulary metrics
     unique_words: int = 0
     type_token_ratio: float = 0.0          # Lexical diversity
     avg_word_length: float = 0.0
-    
+
     # Formality indicators
     contraction_ratio: float = 0.0         # Use of contractions (informal)
     first_person_ratio: float = 0.0        # "I", "me", "my" usage
     second_person_ratio: float = 0.0       # "you", "your" usage
-    
+
     # Distinctive features
     top_words: list[tuple[str, int]] = field(default_factory=list)  # Most used words
     distinctive_words: list[str] = field(default_factory=list)       # Words unique to this character
     signature_phrases: list[str] = field(default_factory=list)       # Repeated phrases
-    
+
     # Archaic language (Tolkien-relevant)
     archaism_count: int = 0
     archaisms_used: list[str] = field(default_factory=list)
-    
+
     # Sample quotes
     sample_quotes: list[str] = field(default_factory=list)  # Representative quotes
-    
+
+    # ------------------------------------------------------------------
+    # Issue #10: Audience-variant metrics
+    # ------------------------------------------------------------------
+    formality_by_audience: dict[str, float] = field(default_factory=dict)
+    # e.g. {'hobbit': 0.58, 'elf': 0.84}
+    length_by_audience: dict[str, float] = field(default_factory=dict)
+    # avg utterance length by audience type
+    register_by_audience: dict[str, str] = field(default_factory=dict)
+    # dominant register per audience type
+
+    # Computed formality score (0.0 informal → 1.0 formal)
+    formality_score: float = 0.0
+    archaism_rate: float = 0.0
+    rhetorical_density: float = 0.0   # Questions used for effect, not info-seeking
+    imperative_ratio: float = 0.0     # Lines that issue commands
+
+    # Fingerprint extras
+    never_says: list[str] = field(default_factory=list)
+    # Anachronistic / wrong-register words this character avoids
+    topic_distribution: dict[str, float] = field(default_factory=dict)
+    # e.g. {'history': 0.3, 'practical': 0.4}
+
     @classmethod
     def from_dialogue_lines(
         cls,
         character_name: str,
         lines: list,  # List of DialogueLine objects
         character_id: Optional[str] = None,
-        all_character_words: Optional[dict[str, Counter]] = None,  # For distinctiveness
+        all_character_words: Optional[dict[str, Counter]] = None,
+        audience_lines: Optional[list[tuple]] = None,
+        # List of (DialogueLine, audience_type, context_type) for audience metrics
     ) -> "CharacterVoiceProfile":
         """
         Build a voice profile from dialogue lines.
-        
+
         Args:
             character_name: Name of the character
             lines: List of DialogueLine objects
             character_id: Optional canonical ID
             all_character_words: Word counts for all characters (to find distinctive words)
+            audience_lines: Pre-classified (line, audience_type, context_type) triples
         """
         profile = cls(
             character_name=character_name,
             character_id=character_id,
         )
-        
+
         if not lines:
             return profile
-        
+
         # Basic counts
         profile.total_lines = len(lines)
-        
+
         # Word analysis
         all_words = []
         utterance_lengths = []
         word_lengths = []
-        
+
         questions = 0
         exclamations = 0
         statements = 0
-        
+        rhetorical_questions = 0
+        imperatives = 0
+
         contractions = 0
         first_person = 0
         second_person = 0
-        
+
         first_person_words = {'i', 'me', 'my', 'mine', 'myself', "i'm", "i've", "i'll", "i'd"}
         second_person_words = {'you', 'your', 'yours', 'yourself', "you're", "you've", "you'll", "you'd"}
         contraction_patterns = ["n't", "'s", "'re", "'ve", "'ll", "'d", "'m"]
-        
+
         archaisms_list = [
             "thee", "thou", "thy", "thine", "ye", "hath", "doth", "art", "wast",
             "wherefore", "hither", "thither", "whither", "hence", "thence",
@@ -115,28 +276,34 @@ class CharacterVoiceProfile:
             "verily", "hark", "hearken", "tarry", "prithee",
         ]
         archaisms_found = set()
-        
+
         for line in lines:
             text = line.text
             profile.total_chars += len(text)
-            
+
             # Tokenize simply
             words = text.lower().split()
             word_count = len(words)
             all_words.extend(words)
             utterance_lengths.append(word_count)
-            
+
             # Word lengths
             word_lengths.extend(len(w.strip('.,!?"\'-')) for w in words)
-            
+
             # Classify
             if line.is_question:
                 questions += 1
+                if _is_rhetorical(text):
+                    rhetorical_questions += 1
             elif line.is_exclamation:
                 exclamations += 1
             else:
                 statements += 1
-            
+
+            # Imperatives
+            if _is_imperative(text):
+                imperatives += 1
+
             # Formality indicators
             for word in words:
                 word_lower = word.lower().strip('.,!?"\'')
@@ -150,71 +317,101 @@ class CharacterVoiceProfile:
                         break
                 if word_lower in archaisms_list:
                     archaisms_found.add(word_lower)
-        
+
         profile.total_words = len(all_words)
-        
+
         # Utterance length stats
         if utterance_lengths:
             profile.avg_utterance_length = statistics.mean(utterance_lengths)
             profile.utterance_length_std = statistics.stdev(utterance_lengths) if len(utterance_lengths) > 1 else 0
             profile.min_utterance_length = min(utterance_lengths)
             profile.max_utterance_length = max(utterance_lengths)
-        
+
         # Type ratios
         if profile.total_lines > 0:
             profile.question_ratio = questions / profile.total_lines
             profile.exclamation_ratio = exclamations / profile.total_lines
             profile.statement_ratio = statements / profile.total_lines
-        
+            profile.imperative_ratio = round(imperatives / profile.total_lines, 4)
+
+        # Rhetorical density: fraction of ALL lines that are rhetorical questions
+        if profile.total_lines > 0:
+            profile.rhetorical_density = round(rhetorical_questions / profile.total_lines, 4)
+
         # Vocabulary
         word_counts = Counter(all_words)
         profile.unique_words = len(word_counts)
         profile.type_token_ratio = profile.unique_words / profile.total_words if profile.total_words > 0 else 0
         profile.avg_word_length = statistics.mean(word_lengths) if word_lengths else 0
-        
+
         # Formality ratios
         if profile.total_words > 0:
             profile.contraction_ratio = contractions / profile.total_words
             profile.first_person_ratio = first_person / profile.total_words
             profile.second_person_ratio = second_person / profile.total_words
-        
+
         # Top words (filter out very common words)
         stop_words = {'the', 'a', 'an', 'and', 'or', 'but', 'in', 'on', 'at', 'to', 'for',
                      'of', 'with', 'by', 'is', 'are', 'was', 'were', 'be', 'been', 'being',
                      'have', 'has', 'had', 'do', 'does', 'did', 'will', 'would', 'could',
                      'should', 'may', 'might', 'must', 'shall', 'can', 'that', 'this',
                      'it', 'its', 'as', 'if', 'not', 'no', 'so', 'up', 'out', 'about'}
-        
-        filtered_counts = {w: c for w, c in word_counts.items() 
+
+        filtered_counts = {w: c for w, c in word_counts.items()
                          if w not in stop_words and len(w) > 2}
         profile.top_words = sorted(filtered_counts.items(), key=lambda x: -x[1])[:20]
-        
+
         # Distinctive words (words this character uses more than others)
         if all_character_words:
             profile.distinctive_words = _find_distinctive_words(
                 character_name, word_counts, all_character_words
             )
-        
+
         # Archaisms
         profile.archaism_count = sum(word_counts.get(a, 0) for a in archaisms_found)
         profile.archaisms_used = list(archaisms_found)
-        
+        profile.archaism_rate = round(
+            profile.archaism_count / profile.total_words if profile.total_words > 0 else 0.0,
+            4,
+        )
+
+        # Formality score (composite)
+        profile.formality_score = _compute_formality_score(
+            profile.archaism_rate,
+            profile.contraction_ratio,
+            profile.avg_word_length,
+            profile.first_person_ratio,
+        )
+
+        # Topic distribution
+        profile.topic_distribution = _compute_topic_distribution(all_words)
+
+        # never_says: modern/anachronistic words this character does NOT use
+        used_words_lower = {w.lower().strip('.,!?"\'') for w in all_words}
+        profile.never_says = [w for w in MODERN_ANACHRONISMS if w not in used_words_lower]
+
         # Sample quotes (pick diverse ones)
         profile.sample_quotes = _select_sample_quotes(lines, max_quotes=5)
-        
+
         # Signature phrases (repeated sequences)
         profile.signature_phrases = _find_signature_phrases(lines)
-        
+
+        # Audience-variant metrics
+        if audience_lines:
+            profile.formality_by_audience, profile.length_by_audience, profile.register_by_audience = (
+                _compute_audience_metrics(audience_lines)
+            )
+
         return profile
-    
+
     def to_dict(self) -> dict:
         """Convert to dictionary for serialization."""
         return asdict(self)
-    
+
     def to_json(self, indent: int = 2) -> str:
         """Convert to JSON string."""
         return json.dumps(self.to_dict(), indent=indent)
-    
+
     @classmethod
     def from_dict(cls, d: dict) -> "CharacterVoiceProfile":
         """Create from dictionary."""
@@ -222,15 +419,15 @@ class CharacterVoiceProfile:
         if 'top_words' in d:
             d['top_words'] = [tuple(x) if isinstance(x, list) else x for x in d['top_words']]
         return cls(**d)
-    
+
     @classmethod
     def from_json(cls, json_str: str) -> "CharacterVoiceProfile":
         """Create from JSON string."""
         return cls.from_dict(json.loads(json_str))
-    
+
     def summary(self) -> str:
         """Generate human-readable summary."""
-        lines = [
+        lines_out = [
             f"=== Voice Profile: {self.character_name} ===",
             f"",
             f"[Corpus]",
@@ -242,40 +439,145 @@ class CharacterVoiceProfile:
             f"   Range: {self.min_utterance_length} - {self.max_utterance_length} words",
             f"   Questions: {self.question_ratio*100:.1f}%",
             f"   Exclamations: {self.exclamation_ratio*100:.1f}%",
+            f"   Imperatives: {self.imperative_ratio*100:.1f}%",
+            f"   Rhetorical density: {self.rhetorical_density*100:.1f}%",
+            f"",
+            f"[Formality]",
+            f"   Formality score: {self.formality_score:.3f}",
+            f"   Archaism rate: {self.archaism_rate*100:.1f}%",
+            f"   Contractions: {self.contraction_ratio*100:.1f}%",
             f"",
             f"[Vocabulary]",
             f"   Unique words: {self.unique_words}",
             f"   Type-token ratio: {self.type_token_ratio:.3f}",
-            f"   Contractions: {self.contraction_ratio*100:.1f}%",
             f"",
         ]
-        
-        if self.top_words:
-            lines.append(f"[Top Words]")
-            for word, count in self.top_words[:10]:
-                lines.append(f"   {word}: {count}")
-            lines.append("")
-        
-        if self.distinctive_words:
-            lines.append(f"[Distinctive Words]")
-            lines.append(f"   {', '.join(self.distinctive_words[:10])}")
-            lines.append("")
-        
-        if self.archaisms_used:
-            lines.append(f"[Archaic Language]")
-            lines.append(f"   {', '.join(self.archaisms_used)}")
-            lines.append("")
-        
-        if self.sample_quotes:
-            lines.append(f"[Sample Quotes]")
-            for quote in self.sample_quotes[:3]:
-                # Truncate long quotes
-                display = quote[:80] + "..." if len(quote) > 80 else quote
-                lines.append(f'   "{display}"')
-            lines.append("")
-        
-        return "\n".join(lines)
 
+        if self.top_words:
+            lines_out.append(f"[Top Words]")
+            for word, count in self.top_words[:10]:
+                lines_out.append(f"   {word}: {count}")
+            lines_out.append("")
+
+        if self.distinctive_words:
+            lines_out.append(f"[Distinctive Words]")
+            lines_out.append(f"   {', '.join(self.distinctive_words[:10])}")
+            lines_out.append("")
+
+        if self.archaisms_used:
+            lines_out.append(f"[Archaic Language]")
+            lines_out.append(f"   {', '.join(self.archaisms_used)}")
+            lines_out.append("")
+
+        if self.topic_distribution:
+            lines_out.append(f"[Topic Distribution]")
+            for topic, weight in sorted(self.topic_distribution.items(), key=lambda x: -x[1]):
+                lines_out.append(f"   {topic}: {weight:.2f}")
+            lines_out.append("")
+
+        if self.formality_by_audience:
+            lines_out.append(f"[Formality by Audience]")
+            for aud, score in sorted(self.formality_by_audience.items()):
+                lines_out.append(f"   {aud}: {score:.3f}")
+            lines_out.append("")
+
+        if self.sample_quotes:
+            lines_out.append(f"[Sample Quotes]")
+            for quote in self.sample_quotes[:3]:
+                display = quote[:80] + "..." if len(quote) > 80 else quote
+                lines_out.append(f'   "{display}"')
+            lines_out.append("")
+
+        return "\n".join(lines_out)
+
+
+# ---------------------------------------------------------------------------
+# Audience-variant metric computation
+# ---------------------------------------------------------------------------
+
+def _compute_audience_metrics(
+    audience_lines: list[tuple],
+) -> tuple[dict[str, float], dict[str, float], dict[str, str]]:
+    """
+    Compute per-audience formality, avg length, and dominant register.
+
+    Args:
+        audience_lines: list of (DialogueLine, audience_type, context_type) triples
+
+    Returns:
+        (formality_by_audience, length_by_audience, register_by_audience)
+    """
+    # Group by audience
+    by_audience: dict[str, list] = {}
+    for line, aud_type, ctx_type in audience_lines:
+        if aud_type not in by_audience:
+            by_audience[aud_type] = []
+        by_audience[aud_type].append((line, ctx_type))
+
+    formality_by: dict[str, float] = {}
+    length_by: dict[str, float] = {}
+    register_by: dict[str, str] = {}
+
+    for aud_type, items in by_audience.items():
+        lines_for_aud = [item[0] for item in items]
+        ctx_types = [item[1] for item in items]
+
+        # Avg length
+        lengths = [len(l.text.split()) for l in lines_for_aud]
+        length_by[aud_type] = round(statistics.mean(lengths), 2) if lengths else 0.0
+
+        # Formality approximation per audience
+        all_words = []
+        for l in lines_for_aud:
+            all_words.extend(l.text.lower().split())
+
+        archaisms_list = {
+            "thee", "thou", "thy", "thine", "ye", "hath", "doth", "art", "wast",
+            "wherefore", "hither", "thither", "whither", "hence", "thence",
+            "ere", "nay", "aye", "yea", "behold", "lo", "alas", "forsooth",
+            "methinks", "mayhap", "perchance", "betwixt", "amongst", "whilst",
+            "verily", "hark", "hearken", "tarry", "prithee",
+        }
+        contraction_patterns = ["n't", "'s", "'re", "'ve", "'ll", "'d", "'m"]
+
+        arch_count = sum(1 for w in all_words if w.strip('.,!?"\'') in archaisms_list)
+        contr_count = sum(
+            1 for w in all_words
+            if any(p in w for p in contraction_patterns)
+        )
+        fp_words = {'i', 'me', 'my', 'mine', 'myself', "i'm", "i've", "i'll", "i'd"}
+        fp_count = sum(1 for w in all_words if w.strip('.,!?"\'') in fp_words)
+        word_lengths = [len(w.strip('.,!?"\'')) for w in all_words if w.strip('.,!?"\'')]
+        avg_wl = statistics.mean(word_lengths) if word_lengths else 4.0
+        total = len(all_words) if all_words else 1
+
+        archaism_rate = arch_count / total
+        contraction_ratio = contr_count / total
+        first_person_ratio = fp_count / total
+        formality_by[aud_type] = _compute_formality_score(
+            archaism_rate, contraction_ratio, avg_wl, first_person_ratio
+        )
+
+        # Register: most common context type → register label
+        ctx_counter = Counter(ctx_types)
+        dominant_ctx = ctx_counter.most_common(1)[0][0] if ctx_counter else "neutral"
+        # Map context to register label
+        ctx_to_register = {
+            "command": "authoritative",
+            "warning": "urgent",
+            "comfort": "intimate",
+            "explanation": "didactic",
+            "farewell": "ceremonial",
+            "crisis": "terse",
+        }
+        register_by[aud_type] = ctx_to_register.get(dominant_ctx, "neutral")
+
+    return formality_by, length_by, register_by
+
+
+# ---------------------------------------------------------------------------
+# Helper functions (unchanged from original, plus new ones)
+# ---------------------------------------------------------------------------
 
 def _find_distinctive_words(
     character: str,
@@ -286,33 +588,33 @@ def _find_distinctive_words(
 ) -> list[str]:
     """
     Find words this character uses more frequently than others.
-    
+
     Uses TF-IDF-like scoring: high frequency for this character,
     low frequency for other characters.
     """
     distinctive = []
-    
+
     # Calculate total words per character
     char_totals = {c: sum(words.values()) for c, words in all_char_words.items()}
     total_chars = len(all_char_words)
-    
+
     for word, count in char_words.items():
         if count < min_count:
             continue
-        
+
         # How many other characters use this word?
-        other_usage = sum(1 for c, words in all_char_words.items() 
+        other_usage = sum(1 for c, words in all_char_words.items()
                         if c != character and words.get(word, 0) > 0)
-        
+
         # Score: frequency in this character / (1 + other characters using it)
         char_freq = count / char_totals.get(character, 1)
         distinctiveness = char_freq / (1 + other_usage / total_chars)
-        
+
         distinctive.append((word, distinctiveness, count))
-    
+
     # Sort by distinctiveness score
     distinctive.sort(key=lambda x: -x[1])
-    
+
     return [w for w, _, _ in distinctive[:top_n]]
 
 
@@ -320,75 +622,67 @@ def _select_sample_quotes(lines: list, max_quotes: int = 5) -> list[str]:
     """Select diverse sample quotes."""
     if not lines:
         return []
-    
+
     quotes = []
-    
+
     # Get one question, one exclamation, and some statements
     questions = [l for l in lines if l.is_question]
     exclamations = [l for l in lines if l.is_exclamation]
     statements = [l for l in lines if l.is_statement]
-    
+
     # Pick medium-length quotes (not too short, not too long)
     def quality_score(line):
         length = len(line.text.split())
-        # Prefer 5-20 words
         if 5 <= length <= 20:
             return 1.0
         elif 3 <= length <= 30:
             return 0.5
         else:
             return 0.1
-    
-    # Sort each category by quality
+
     questions.sort(key=lambda x: -quality_score(x))
     exclamations.sort(key=lambda x: -quality_score(x))
     statements.sort(key=lambda x: -quality_score(x))
-    
-    # Pick from each category
+
     if questions:
         quotes.append(questions[0].text)
     if exclamations:
         quotes.append(exclamations[0].text)
-    
-    # Fill rest with statements
+
     for stmt in statements:
         if len(quotes) >= max_quotes:
             break
         if stmt.text not in quotes:
             quotes.append(stmt.text)
-    
+
     return quotes
 
 
 def _find_signature_phrases(lines: list, min_occurrences: int = 2) -> list[str]:
     """Find phrases this character repeats."""
-    # Look for 2-4 word sequences that appear multiple times
     ngram_counts = Counter()
-    
+
     for line in lines:
         words = line.text.lower().split()
-        
+
         # 2-grams
         for i in range(len(words) - 1):
             ngram = ' '.join(words[i:i+2])
             ngram_counts[ngram] += 1
-        
+
         # 3-grams
         for i in range(len(words) - 2):
             ngram = ' '.join(words[i:i+3])
             ngram_counts[ngram] += 1
-    
-    # Filter to repeated phrases
-    # Exclude very common phrases
+
     common_phrases = {'i am', 'you are', 'it is', 'do not', 'i do', 'i have',
                      'you have', 'there is', 'there are', 'what is', 'that is'}
-    
+
     signatures = [
         phrase for phrase, count in ngram_counts.items()
         if count >= min_occurrences and phrase not in common_phrases
     ]
-    
-    # Sort by frequency
+
     signatures.sort(key=lambda x: -ngram_counts[x])
-    
+
     return signatures[:5]

--- a/tests/test_voice_profile.py
+++ b/tests/test_voice_profile.py
@@ -1,0 +1,567 @@
+"""Tests for VoiceProfile extensions (Issue #10).
+
+All tests are self-contained — no Neo4j connection required.
+Graph-dependent tests are patched/skipped via unittest.mock.
+"""
+
+from __future__ import annotations
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from book_graph_analyzer.voice.profile import (
+    CharacterVoiceProfile,
+    _compute_formality_score,
+    _is_rhetorical,
+    _is_imperative,
+    _compute_topic_distribution,
+    MODERN_ANACHRONISMS,
+)
+from book_graph_analyzer.voice.dialogue import DialogueLine
+from book_graph_analyzer.voice.audience import classify_audience, AUDIENCE_TYPES, CONTEXT_TYPES
+from book_graph_analyzer.graph.voice_writer import (
+    _extract_text_metrics,
+    _compute_similarity,
+    VoiceProfileWriter,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers to build DialogueLine fixtures
+# ---------------------------------------------------------------------------
+
+def make_line(
+    text: str,
+    speaker: str = "Gandalf",
+    is_question: bool = False,
+    is_exclamation: bool = False,
+) -> DialogueLine:
+    is_statement = not is_question and not is_exclamation
+    return DialogueLine(
+        text=text,
+        speaker=speaker,
+        is_question=is_question,
+        is_exclamation=is_exclamation,
+        is_statement=is_statement,
+    )
+
+
+# ---------------------
+# Tolkien-esque corpus
+# ---------------------
+
+GANDALF_LINES = [
+    make_line("You shall not pass!", is_exclamation=True),
+    make_line("Fly, you fools!", is_exclamation=True),
+    make_line("A wizard is never late, nor is he early; he arrives precisely when he means to."),
+    make_line("Many that live deserve death. And some that die deserve life."),
+    make_line("All we have to decide is what to do with the time that is given us."),
+    make_line("Even the very wise cannot see all ends."),
+    make_line("The treacherous are ever distrustful."),
+    make_line("Verily I say unto thee, hark, for the hour is come."),
+    make_line("Thou shalt not enter here without leave."),
+    make_line("Behold, ere long the shadow shall fall upon us all."),
+    make_line("Go back to the Shadow!", is_exclamation=True),
+    make_line("Why should I fear thee, dark servant?", is_question=True),
+    make_line("Hark! The hour of doom is nigh!", is_exclamation=True),
+]
+
+SAM_LINES = [
+    make_line("I'm coming with you, Mr. Frodo."),
+    make_line("I can't carry it for you, but I can carry you."),
+    make_line("There's some good in this world, and it's worth fighting for."),
+    make_line("Don't go where I can't follow."),
+    make_line("I don't know half of you half as well as I should like."),
+    make_line("Yeah, I know, it's heavy."),
+    make_line("Okay, okay, I'll do it then."),
+    make_line("What's taters, precious?", is_question=True),
+    make_line("Hi there, Mr. Frodo, how are you today?", is_question=True),
+    make_line("That Gollum, he's a nasty piece of work."),
+    make_line("I don't feel right about this at all."),
+    make_line("It's me, Sam, I've come to find you."),
+]
+
+
+def build_profile(name: str, lines: list[DialogueLine]) -> CharacterVoiceProfile:
+    return CharacterVoiceProfile.from_dialogue_lines(name, lines)
+
+
+# ===========================================================================
+# TestCharacterVoiceProfile
+# ===========================================================================
+
+class TestCharacterVoiceProfile:
+
+    def test_formality_score_gandalf_higher_than_sam(self):
+        gandalf = build_profile("Gandalf", GANDALF_LINES)
+        sam = build_profile("Sam", SAM_LINES)
+        assert gandalf.formality_score > sam.formality_score, (
+            f"Expected Gandalf ({gandalf.formality_score:.3f}) > Sam ({sam.formality_score:.3f})"
+        )
+
+    def test_formality_score_range(self):
+        for name, lines in [("Gandalf", GANDALF_LINES), ("Sam", SAM_LINES)]:
+            profile = build_profile(name, lines)
+            assert 0.0 <= profile.formality_score <= 1.0, (
+                f"{name}: formality_score {profile.formality_score} outside [0,1]"
+            )
+
+    def test_archaism_rate_detected(self):
+        profile = build_profile("Gandalf", GANDALF_LINES)
+        # Gandalf says "thee", "thou", "verily", "ere", "behold", "hark"
+        assert profile.archaism_rate > 0.0, "Expected archaism_rate > 0 for archaic text"
+        assert profile.archaism_count > 0
+
+    def test_archaism_rate_zero_for_modern_text(self):
+        modern_lines = [make_line(t) for t in [
+            "Yeah, okay, I'm cool with that.",
+            "Basically I wanna go now.",
+            "Literally the best thing ever.",
+        ]]
+        profile = build_profile("Modern", modern_lines)
+        assert profile.archaism_rate == 0.0
+
+    def test_archaism_rate_is_proportion(self):
+        profile = build_profile("Gandalf", GANDALF_LINES)
+        assert 0.0 <= profile.archaism_rate <= 1.0
+
+    def test_imperative_ratio_detected(self):
+        imperative_lines = [
+            make_line("Go back to the Shadow!", is_exclamation=True),
+            make_line("Fly, you fools!", is_exclamation=True),
+            make_line("Behold, the hour is come."),
+            make_line("Hark! Listen well.", is_exclamation=True),
+            make_line("Wait here and do not move."),
+        ]
+        profile = build_profile("Commander", imperative_lines)
+        assert profile.imperative_ratio > 0.0, (
+            f"Expected imperative_ratio > 0, got {profile.imperative_ratio}"
+        )
+
+    def test_imperative_ratio_range(self):
+        profile = build_profile("Gandalf", GANDALF_LINES)
+        assert 0.0 <= profile.imperative_ratio <= 1.0
+
+    def test_rhetorical_density_detected(self):
+        rhetorical_lines = [
+            make_line("Why would you do such a thing?", is_question=True),
+            make_line("How dare you speak of such matters?", is_question=True),
+            make_line("Is it not clear that the shadow grows?", is_question=True),
+            make_line("A simple statement here."),
+            make_line("Another statement, not rhetorical."),
+        ]
+        profile = build_profile("Rhetor", rhetorical_lines)
+        assert profile.rhetorical_density > 0.0, (
+            f"Expected rhetorical_density > 0, got {profile.rhetorical_density}"
+        )
+
+    def test_rhetorical_density_range(self):
+        profile = build_profile("Gandalf", GANDALF_LINES)
+        assert 0.0 <= profile.rhetorical_density <= 1.0
+
+    def test_topic_distribution_sums_to_one(self):
+        profile = build_profile("Gandalf", GANDALF_LINES)
+        total = sum(profile.topic_distribution.values())
+        assert abs(total - 1.0) < 0.01, (
+            f"topic_distribution values should sum to 1.0, got {total}"
+        )
+
+    def test_topic_distribution_all_keys_present(self):
+        profile = build_profile("Gandalf", GANDALF_LINES)
+        expected_topics = {"history", "war", "practical", "wisdom", "nature", "friendship"}
+        assert expected_topics == set(profile.topic_distribution.keys())
+
+    def test_audience_variant_metrics_computed(self):
+        """With audience_lines supplied, formality_by_audience should be populated."""
+        from book_graph_analyzer.voice.audience import classify_audience
+
+        lines = GANDALF_LINES[:6]
+        audience_lines = []
+        for line in lines:
+            aud, ctx = classify_audience(line, "")
+            audience_lines.append((line, aud, ctx))
+
+        profile = CharacterVoiceProfile.from_dialogue_lines(
+            "Gandalf", lines, audience_lines=audience_lines
+        )
+        assert isinstance(profile.formality_by_audience, dict)
+        assert isinstance(profile.length_by_audience, dict)
+        assert isinstance(profile.register_by_audience, dict)
+        for aud_type in profile.formality_by_audience:
+            assert aud_type in AUDIENCE_TYPES, f"Unexpected audience type: {aud_type}"
+            val = profile.formality_by_audience[aud_type]
+            assert 0.0 <= val <= 1.0, f"formality_by_audience[{aud_type}] = {val}"
+
+    def test_never_says_is_subset_of_modern_anachronisms(self):
+        profile = build_profile("Gandalf", GANDALF_LINES)
+        for word in profile.never_says:
+            assert word in MODERN_ANACHRONISMS
+
+    def test_never_says_excludes_words_character_actually_used(self):
+        # Build a profile with a modern word
+        modern_line = make_line("Yeah, okay, I'm totally fine with that.")
+        profile = CharacterVoiceProfile.from_dialogue_lines("ModernChar", [modern_line])
+        # "yeah" and "okay" are in MODERN_ANACHRONISMS; character DID say them
+        # so they should NOT be in never_says
+        assert "yeah" not in profile.never_says
+        assert "okay" not in profile.never_says
+
+    def test_empty_lines_returns_defaults(self):
+        profile = CharacterVoiceProfile.from_dialogue_lines("Nobody", [])
+        assert profile.total_lines == 0
+        assert profile.formality_score == 0.0
+        assert profile.archaism_rate == 0.0
+        assert profile.imperative_ratio == 0.0
+        assert profile.rhetorical_density == 0.0
+
+    def test_backward_compat_existing_fields_still_present(self):
+        profile = build_profile("Gandalf", GANDALF_LINES)
+        # Existing fields must still be accessible
+        assert hasattr(profile, "total_lines")
+        assert hasattr(profile, "question_ratio")
+        assert hasattr(profile, "exclamation_ratio")
+        assert hasattr(profile, "statement_ratio")
+        assert hasattr(profile, "contraction_ratio")
+        assert hasattr(profile, "top_words")
+        assert hasattr(profile, "distinctive_words")
+        assert hasattr(profile, "archaism_count")
+        assert hasattr(profile, "archaisms_used")
+        assert hasattr(profile, "sample_quotes")
+        assert hasattr(profile, "signature_phrases")
+
+
+# ===========================================================================
+# TestComputeFormalityScore
+# ===========================================================================
+
+class TestComputeFormalityScore:
+
+    def test_all_archaic_is_formal(self):
+        score = _compute_formality_score(0.05, 0.0, 7.0, 0.0)
+        assert score >= 0.7
+
+    def test_all_informal_is_low(self):
+        score = _compute_formality_score(0.0, 0.20, 3.0, 0.10)
+        assert score <= 0.4
+
+    def test_range_is_zero_to_one(self):
+        for arch in [0.0, 0.05, 0.10]:
+            for contr in [0.0, 0.10, 0.20]:
+                for wl in [3.0, 5.0, 8.0]:
+                    for fp in [0.0, 0.05, 0.10]:
+                        score = _compute_formality_score(arch, contr, wl, fp)
+                        assert 0.0 <= score <= 1.0, (
+                            f"Score {score} out of range for params "
+                            f"(arch={arch}, contr={contr}, wl={wl}, fp={fp})"
+                        )
+
+    def test_more_archaisms_raises_score(self):
+        low = _compute_formality_score(0.0, 0.05, 5.0, 0.03)
+        high = _compute_formality_score(0.05, 0.05, 5.0, 0.03)
+        assert high > low
+
+    def test_more_contractions_lowers_score(self):
+        formal = _compute_formality_score(0.02, 0.0, 5.0, 0.03)
+        informal = _compute_formality_score(0.02, 0.15, 5.0, 0.03)
+        assert informal < formal
+
+
+# ===========================================================================
+# TestHelperFunctions
+# ===========================================================================
+
+class TestHelperFunctions:
+
+    def test_is_rhetorical_why_would(self):
+        assert _is_rhetorical("Why would you do such a thing?")
+
+    def test_is_rhetorical_how_dare(self):
+        assert _is_rhetorical("How dare you enter here?")
+
+    def test_is_rhetorical_is_it_not(self):
+        assert _is_rhetorical("Is it not clear that the shadow grows?")
+
+    def test_is_not_rhetorical_plain_question(self):
+        assert not _is_rhetorical("What is your name?")
+
+    def test_is_not_rhetorical_no_question_mark(self):
+        assert not _is_rhetorical("Why would you do such a thing")
+
+    def test_is_imperative_go(self):
+        assert _is_imperative("Go back to the Shadow!")
+
+    def test_is_imperative_fly(self):
+        assert _is_imperative("Fly, you fools")
+
+    def test_is_imperative_beware(self):
+        assert _is_imperative("beware the shadow that follows")
+
+    def test_is_not_imperative_statement(self):
+        assert not _is_imperative("He went back to the shadow.")
+
+    def test_topic_distribution_sums_to_one(self):
+        words = "battle sword enemy war fight ancient ages kingdom".split()
+        dist = _compute_topic_distribution(words)
+        total = sum(dist.values())
+        assert abs(total - 1.0) < 0.01
+
+    def test_topic_distribution_has_all_keys(self):
+        dist = _compute_topic_distribution(["hello"])
+        assert set(dist.keys()) == {"history", "war", "practical", "wisdom", "nature", "friendship"}
+
+
+# ===========================================================================
+# TestAudienceClassifier
+# ===========================================================================
+
+class TestAudienceClassifier:
+
+    def test_imperative_classified_as_command(self):
+        line = make_line("Go back to the Shadow!", is_exclamation=True)
+        _, context = classify_audience(line, "")
+        assert context == "command"
+
+    def test_farewell_phrase_classified(self):
+        line = make_line("Farewell, may your journey be safe.")
+        _, context = classify_audience(line, "")
+        assert context == "farewell"
+
+    def test_comfort_phrase_classified(self):
+        line = make_line("Fear not, all will be well in the end.")
+        _, context = classify_audience(line, "")
+        assert context == "comfort"
+
+    def test_warning_phrase_classified(self):
+        line = make_line("Beware the shadow that creeps from the east.")
+        _, context = classify_audience(line, "")
+        assert context == "warning"
+
+    def test_unknown_defaults_to_neutral_explanation(self):
+        line = make_line("The sky is blue and the stars are bright.")
+        aud, ctx = classify_audience(line, "")
+        # audience defaults to neutral when no names
+        assert aud == "neutral"
+        # context defaults to explanation
+        assert ctx == "explanation"
+
+    def test_hobbit_name_in_context_classifies_hobbit(self):
+        line = make_line("I hope you are well.")
+        aud, _ = classify_audience(line, "Frodo looked up at him.")
+        assert aud == "hobbit"
+
+    def test_elf_name_in_context_classifies_elf(self):
+        line = make_line("There is much wisdom in your words.")
+        aud, _ = classify_audience(line, "Galadriel smiled graciously.")
+        assert aud == "elf"
+
+    def test_dwarf_name_in_text_classifies_dwarf(self):
+        line = make_line("Gimli, come forward.")
+        aud, _ = classify_audience(line, "")
+        assert aud == "dwarf"
+
+    def test_audience_type_in_valid_set(self):
+        for text in [
+            "Fear not, friend.",
+            "Go! Now!",
+            "Farewell and safe travels.",
+            "Tell me what you know.",
+        ]:
+            line = make_line(text)
+            aud, ctx = classify_audience(line, "")
+            assert aud in AUDIENCE_TYPES, f"Unexpected audience type: {aud}"
+            assert ctx in CONTEXT_TYPES, f"Unexpected context type: {ctx}"
+
+    def test_context_type_in_valid_set(self):
+        line = make_line("Because the ancient lore tells us so.")
+        _, ctx = classify_audience(line, "")
+        assert ctx in CONTEXT_TYPES
+
+
+# ===========================================================================
+# TestVoiceSpeakerIdentify (mocked Neo4j)
+# ===========================================================================
+
+class TestVoiceSpeakerIdentify:
+
+    def _make_writer_with_profiles(self, profiles: list[dict]) -> VoiceProfileWriter:
+        """Return a VoiceProfileWriter whose driver returns canned profile dicts."""
+        mock_driver = MagicMock()
+        mock_session = MagicMock()
+        mock_driver.session.return_value.__enter__ = MagicMock(return_value=mock_session)
+        mock_driver.session.return_value.__exit__ = MagicMock(return_value=False)
+
+        # Build mock rows from profile dicts
+        def make_row(d: dict):
+            row = MagicMock()
+            row.__getitem__ = lambda self, key: d.get(key)
+            row.get = lambda key, default=None: d.get(key, default)
+            # Support dict(row) pattern
+            row.keys = lambda: d.keys()
+            row.values = lambda: d.values()
+            row.items = lambda: d.items()
+            return row
+
+        mock_result = MagicMock()
+        mock_result.__iter__ = MagicMock(return_value=iter(profiles))
+        mock_session.run.return_value = mock_result
+
+        writer = VoiceProfileWriter(driver=mock_driver)
+        return writer
+
+    def test_identify_returns_sorted_by_confidence(self):
+        """Matches should be sorted highest confidence first."""
+        profiles = [
+            {
+                "cid": "gandalf",
+                "formality_score": 0.85,
+                "archaism_rate": 0.08,
+                "question_ratio": 0.10,
+                "exclamation_ratio": 0.15,
+                "imperative_ratio": 0.30,
+                "rhetorical_density": 0.05,
+                "contraction_usage": 0.01,
+                "avg_utterance_length": 10.0,
+            },
+            {
+                "cid": "sam",
+                "formality_score": 0.25,
+                "archaism_rate": 0.00,
+                "question_ratio": 0.20,
+                "exclamation_ratio": 0.10,
+                "imperative_ratio": 0.05,
+                "rhetorical_density": 0.00,
+                "contraction_usage": 0.12,
+                "avg_utterance_length": 8.0,
+            },
+        ]
+        writer = self._make_writer_with_profiles(profiles)
+
+        # Text that sounds very Gandalf-like
+        text = "Thou shalt not enter! Beware the darkness that follows thee!"
+        results = writer.identify_speaker(text, top_n=2)
+
+        assert len(results) == 2
+        # Results must be sorted descending
+        confidences = [c for _, c in results]
+        assert confidences == sorted(confidences, reverse=True), (
+            f"Results not sorted by confidence: {results}"
+        )
+
+    def test_confidence_between_zero_and_one(self):
+        """All confidence scores must lie in [0.0, 1.0]."""
+        profiles = [
+            {
+                "cid": "frodo",
+                "formality_score": 0.50,
+                "archaism_rate": 0.01,
+                "question_ratio": 0.15,
+                "exclamation_ratio": 0.05,
+                "imperative_ratio": 0.05,
+                "rhetorical_density": 0.00,
+                "contraction_usage": 0.05,
+                "avg_utterance_length": 7.0,
+            },
+        ]
+        writer = self._make_writer_with_profiles(profiles)
+        results = writer.identify_speaker("I must carry the Ring alone.", top_n=1)
+
+        for _, conf in results:
+            assert 0.0 <= conf <= 1.0, f"Confidence {conf} out of range [0, 1]"
+
+    def test_identify_returns_at_most_top_n(self):
+        profiles = [
+            {"cid": f"char_{i}", "formality_score": 0.5, "archaism_rate": 0.0,
+             "question_ratio": 0.1, "exclamation_ratio": 0.1, "imperative_ratio": 0.1,
+             "rhetorical_density": 0.0, "contraction_usage": 0.05, "avg_utterance_length": 8.0}
+            for i in range(5)
+        ]
+        writer = self._make_writer_with_profiles(profiles)
+        results = writer.identify_speaker("A simple sentence.", top_n=3)
+        assert len(results) <= 3
+
+    def test_identify_empty_profiles_returns_empty(self):
+        writer = self._make_writer_with_profiles([])
+        results = writer.identify_speaker("You shall not pass!")
+        assert results == []
+
+
+# ===========================================================================
+# TestExtractTextMetrics
+# ===========================================================================
+
+class TestExtractTextMetrics:
+
+    def test_returns_all_expected_keys(self):
+        metrics = _extract_text_metrics("You shall not pass!")
+        expected = {
+            "formality_score", "archaism_rate", "question_ratio",
+            "exclamation_ratio", "imperative_ratio", "rhetorical_density",
+            "contraction_usage", "avg_utterance_length",
+        }
+        assert expected == set(metrics.keys())
+
+    def test_archaic_text_has_high_formality(self):
+        text = "Thou shalt not enter here. Behold, ere long the shadow cometh."
+        metrics = _extract_text_metrics(text)
+        assert metrics["archaism_rate"] > 0.0
+        assert metrics["formality_score"] > 0.5
+
+    def test_modern_text_has_low_formality(self):
+        text = "Yeah, I'm gonna go now. I don't really wanna stay."
+        metrics = _extract_text_metrics(text)
+        assert metrics["formality_score"] < 0.5
+
+    def test_all_values_in_expected_range(self):
+        text = "Go back! Thou shall not pass. Is it not time to leave?"
+        metrics = _extract_text_metrics(text)
+        for key, val in metrics.items():
+            if key == "avg_utterance_length":
+                assert val >= 0.0
+            else:
+                assert 0.0 <= val <= 1.0, f"{key}={val} out of range"
+
+
+# ===========================================================================
+# TestComputeSimilarity
+# ===========================================================================
+
+class TestComputeSimilarity:
+
+    def test_identical_profiles_give_similarity_one(self):
+        profile = {
+            "formality_score": 0.80,
+            "archaism_rate": 0.05,
+            "question_ratio": 0.10,
+            "exclamation_ratio": 0.10,
+            "imperative_ratio": 0.20,
+            "rhetorical_density": 0.05,
+            "contraction_usage": 0.02,
+            "avg_utterance_length": 10.0,
+        }
+        query = dict(profile)
+        sim = _compute_similarity(query, profile)
+        assert abs(sim - 1.0) < 1e-6
+
+    def test_opposite_profiles_give_low_similarity(self):
+        query = {
+            "formality_score": 1.0,
+            "archaism_rate": 1.0,
+            "question_ratio": 0.0,
+            "exclamation_ratio": 0.0,
+            "imperative_ratio": 1.0,
+            "rhetorical_density": 1.0,
+            "contraction_usage": 0.0,
+            "avg_utterance_length": 1.0,  # after normalisation
+        }
+        profile = {
+            "formality_score": 0.0,
+            "archaism_rate": 0.0,
+            "question_ratio": 1.0,
+            "exclamation_ratio": 1.0,
+            "imperative_ratio": 0.0,
+            "rhetorical_density": 0.0,
+            "contraction_usage": 1.0,
+            "avg_utterance_length": 30.0,  # after normalisation → 1.0
+        }
+        sim = _compute_similarity(query, profile)
+        assert sim < 0.5


### PR DESCRIPTION
## Summary

Implements #10 — VoiceProfile schema extension with audience-variant metrics, formality scoring, and Neo4j persistence.

## What this PR adds

### 1. Extended `CharacterVoiceProfile` model (`voice/profile.py`)
- **`formality_score`** (0.0–1.0) — composite signal from archaism rate, contraction use, avg word length, first-person ratio
- **`archaism_rate`** — proportion of words that are archaic (thee, thou, verily…)
- **`rhetorical_density`** — fraction of lines that are rhetorical questions (Why would / How dare / Is it not…)
- **`imperative_ratio`** — fraction of lines that are imperatives (Go / Fly / Beware…)
- **`never_says`** — modern/anachronistic words the character avoids (fingerprint)
- **`topic_distribution`** — keyword-based topic weight dict (history / war / practical / wisdom / nature / friendship)
- **`formality_by_audience`**, **`length_by_audience`**, **`register_by_audience`** — per-audience-type metrics

### 2. New `AudienceClassifier` (`voice/audience.py`)
- `AUDIENCE_TYPES` = hobbit, elf, man, dwarf, enemy, neutral, self, prayer
- `CONTEXT_TYPES` = crisis, explanation, command, comfort, warning, farewell
- `classify_audience(dialogue_line, passage_context)` returns `(audience_type, context_type)`
- Heuristic keyword/pattern matching, no LLM required

### 3. New `VoiceProfileWriter` (`graph/voice_writer.py`)
- `upsert_voice_profile(profile)` — MERGE VoiceProfile node in Neo4j
- `link_passage_to_profile(...)` — `(Passage)-[:VOICED_IN {speaker_id, audience_type, context_type}]->(VoiceProfile)` edge
- `get_voice_profile(character_id)` — fetch node by character_id
- `identify_speaker(text, top_n)` — compare text metrics against all stored profiles, return ranked `(character_id, confidence)` list

### 4. New CLI commands (`cli.py`)
- **`bga voice identify --text "You shall not pass!"`** — speaker identification from raw text
- **`bga voice build-profiles -r results.json`** — persist VoiceProfile nodes from analysis output

### 5. Tests (`tests/test_voice_profile.py`)
52 unit tests. Zero Neo4j required — graph calls are fully mocked.

- `TestCharacterVoiceProfile` — formality ordering (Gandalf > Sam), ranges, archaism/imperative/rhetorical detection, topic distribution, never_says, audience variants, backward compat
- `TestComputeFormalityScore` — edge cases, monotonicity
- `TestHelperFunctions` — is_rhetorical, is_imperative, topic_distribution
- `TestAudienceClassifier` — command/comfort/warning/farewell classification, name-based audience detection
- `TestVoiceSpeakerIdentify` — sorted confidence, bounds, top_n limit (mocked Neo4j)
- `TestExtractTextMetrics`, `TestComputeSimilarity`

## Test results

```
52 passed in 3.51s   (new tests)
519 passed           (existing suite — no regressions introduced)
8 pre-existing failures in test_splitter / test_extract / test_relationships / test_scene_template (unrelated to this PR, reproduced on master)
```

## Key design decisions
- No new pip dependencies — pure stdlib + existing project deps
- Backward compatible — only adds fields, never renames existing ones
- Priority order in context classifier: farewell > comfort > warning > crisis > command > explanation (prevents "Fear not" being labelled command)
- Formality score: weighted composite of archaism rate (25%), low contraction use (25%), avg word length (25%), low first-person ratio (25%)
