### PR TITLE
feat: VoiceProfile + audience-variant character voice (#10)

### DIFF
--- a/src/book_graph_analyzer/cli.py
+++ b/src/book_graph_analyzer/cli.py
@@ -1265,6 +1265,188 @@ def voice_quotes(results_path: str, character: str, limit: int) -> None:
     console.print(f"\n[dim]Total lines: {profile.total_lines}[/dim]")
 
 
+@voice.command(name="identify")
+@click.option("--text", "-t", required=True, help="Dialogue text to identify the speaker of")
+@click.option("--results", "-r", type=click.Path(exists=True), help="Pre-computed voice profiles JSON")
+@click.option("--top", "-n", default=3, help="Number of candidates to show (default: 3)")
+def voice_identify(text: str, results: str | None, top: int) -> None:
+    """Identify the most likely speaker of an unmarked quote.
+    
+    The Blindspot Test: given an unmarked Tolkien quote, identify the speaker.
+    
+    Examples:
+        bga voice identify --text 'You shall not pass!'
+        bga voice identify --text 'Precious, my precious.' --results hobbit_voices.json
+    """
+    from book_graph_analyzer.voice import VoiceAnalyzer, VoiceAnalysisResult
+
+    analyzer = VoiceAnalyzer()
+    
+    if results:
+        result = analyzer.load_results(results)
+        profiles = result.profiles
+    else:
+        # Use built-in Tolkien character sketches for demo
+        from book_graph_analyzer.voice.profile import CharacterVoiceProfile
+        from collections import Counter
+        
+        # Bootstrap minimal profiles from known characteristics
+        profiles = _build_demo_profiles()
+    
+    if not profiles:
+        console.print("[red]No profiles available. Run 'bga voice analyze' first or provide --results.[/red]")
+        return
+    
+    console.print(f"\n[bold]Voice Identification[/bold]")
+    console.print(f'  Text: "{text[:100]}{"..." if len(text) > 100 else ""}"\n')
+    
+    candidates = analyzer.identify_speaker(text, profiles, top_n=top)
+    
+    if not candidates:
+        console.print("[yellow]Could not identify speaker.[/yellow]")
+        return
+    
+    table = Table(title="Speaker Identification")
+    table.add_column("Rank", width=5, style="dim")
+    table.add_column("Character", style="cyan")
+    table.add_column("Confidence", justify="right")
+    table.add_column("Match bar")
+    
+    for i, (char_name, confidence) in enumerate(candidates, 1):
+        bar_len = int(confidence * 20)
+        bar = "█" * bar_len + "░" * (20 - bar_len)
+        table.add_row(str(i), char_name, f"{confidence:.2%}", bar)
+    
+    console.print(table)
+    
+    if candidates:
+        top_char, top_conf = candidates[0]
+        console.print(f"\n  Best match: [bold cyan]{top_char}[/bold cyan]  (confidence: {top_conf:.0%})")
+        
+        # Show why
+        p = profiles.get(top_char)
+        if p:
+            console.print(f"  Profile: formality={p.formality_score:.2f}, archaism_rate={p.archaism_rate:.2f}/100w")
+
+
+def _build_demo_profiles() -> dict:
+    """Build minimal demo profiles for Tolkien characters (for identify without pre-analysis)."""
+    from book_graph_analyzer.voice.profile import CharacterVoiceProfile
+    
+    # These profiles capture the key distinguishing features manually
+    demos = {}
+    
+    # Gandalf: high formality, archaic, imperative, rhetorical
+    g = CharacterVoiceProfile(character_name="Gandalf")
+    g.formality_score = 0.85
+    g.archaism_rate = 4.2
+    g.contraction_ratio = 0.01
+    g.imperative_ratio = 0.35
+    g.rhetorical_density = 0.6
+    g.avg_utterance_length = 18.5
+    g.question_ratio = 0.2
+    g.distinctive_words = ["pass", "fool", "shadow", "ancient", "servant", "nameless", "fire"]
+    g.signature_phrases = ["you shall not", "i am", "the grey", "in the ancient"]
+    g.never_says = ["yeah", "ok", "stuff", "things", "gonna", "cool"]
+    g.topic_distribution = {"wisdom": 0.4, "history": 0.3, "war": 0.2, "nature": 0.1}
+    demos["Gandalf"] = g
+    
+    # Sam: low formality, contractions, practical, respectful
+    s = CharacterVoiceProfile(character_name="Samwise")
+    s.formality_score = 0.15
+    s.archaism_rate = 0.3
+    s.contraction_ratio = 0.12
+    s.imperative_ratio = 0.05
+    s.avg_utterance_length = 9.2
+    s.question_ratio = 0.15
+    s.distinctive_words = ["mr", "begging", "pardon", "mister", "taters", "gaffer", "bless"]
+    s.signature_phrases = ["begging your pardon", "mr frodo", "i don't"]
+    s.never_says = ["verily", "forsooth", "thou", "thee", "hath"]
+    s.topic_distribution = {"practical": 0.5, "fellowship": 0.3, "nature": 0.2}
+    demos["Samwise"] = s
+    
+    # Gollum: unique, obsessive, self-referential
+    gol = CharacterVoiceProfile(character_name="Gollum")
+    gol.formality_score = 0.10
+    gol.archaism_rate = 0.5
+    gol.contraction_ratio = 0.05
+    gol.imperative_ratio = 0.08
+    gol.avg_utterance_length = 6.5
+    gol.question_ratio = 0.35
+    gol.distinctive_words = ["precious", "gollum", "nasty", "tricksy", "false", "wicked", "smeagol"]
+    gol.signature_phrases = ["my precious", "we wants it", "we hates"]
+    gol.never_says = ["fellowship", "wisdom", "honour", "courage", "friend"]
+    gol.topic_distribution = {"practical": 0.6, "war": 0.2, "fellowship": 0.2}
+    demos["Gollum"] = gol
+    
+    # Aragorn: moderate formality, command register, warrior
+    a = CharacterVoiceProfile(character_name="Aragorn")
+    a.formality_score = 0.60
+    a.archaism_rate = 1.8
+    a.contraction_ratio = 0.04
+    a.imperative_ratio = 0.30
+    a.avg_utterance_length = 14.0
+    a.question_ratio = 0.12
+    a.distinctive_words = ["rangers", "dunedain", "strider", "isildur", "blade", "king", "hope"]
+    a.signature_phrases = ["hold on", "men of", "the king", "it is not"]
+    a.never_says = ["precious", "taters", "begging", "yeah", "cool"]
+    a.topic_distribution = {"war": 0.4, "wisdom": 0.3, "history": 0.2, "fellowship": 0.1}
+    demos["Aragorn"] = a
+    
+    return demos
+
+
+@voice.command(name="check")
+@click.option("--text", "-t", required=True, help="Generated dialogue text to check")
+@click.option("--character", "-c", required=True, help="Character the text is supposed to be from")
+@click.option("--results", "-r", type=click.Path(exists=True), help="Pre-computed voice profiles JSON")
+def voice_check(text: str, character: str, results: str | None) -> None:
+    """Check generated dialogue for voice consistency violations.
+    
+    Detects: wrong formality, anachronistic vocabulary, never-says words,
+    missing signature patterns.
+    
+    Examples:
+        bga voice check --text 'Yeah, cool, let us go!' --character Gandalf
+        bga voice check --text 'Mr. Frodo sir, I will follow.' --character Samwise --results hobbit_voices.json
+    """
+    from book_graph_analyzer.voice import VoiceAnalyzer
+
+    analyzer = VoiceAnalyzer()
+    
+    if results:
+        result = analyzer.load_results(results)
+        profile = result.get_profile(character)
+    else:
+        # Use demo profiles
+        profiles = _build_demo_profiles()
+        profile = profiles.get(character)
+    
+    if not profile:
+        console.print(f"[red]Character '{character}' not found.[/red]")
+        return
+    
+    violations = analyzer.check_voice_violations(text, profile)
+    
+    console.print(f"\n[bold]Voice Check:[/bold] {character}")
+    console.print(f'  "{text[:100]}{"..." if len(text) > 100 else ""}"\n')
+    
+    if not violations:
+        console.print("[bold green]✓ PASS[/bold green] — No voice violations detected")
+    else:
+        hard = [v for v in violations if v["severity"] == "hard"]
+        soft = [v for v in violations if v["severity"] == "soft"]
+        
+        if hard:
+            console.print(f"[bold red]✗ FAIL — {len(hard)} hard violation(s)[/bold red]")
+        else:
+            console.print(f"[bold yellow]⚠ WARNING — {len(soft)} soft violation(s)[/bold yellow]")
+        
+        for v in violations:
+            icon = "[red]✗[/red]" if v["severity"] == "hard" else "[yellow]~[/yellow]"
+            console.print(f"  {icon} [{v['type']}] {v['message']}")
+
+
 # ============================================================================
 # Pipeline Commands - Unified Analysis
 # ============================================================================

--- a/src/book_graph_analyzer/models/scene_brief.py
+++ b/src/book_graph_analyzer/models/scene_brief.py
@@ -1,0 +1,270 @@
+"""SceneBrief and PipelineResult models for the Scene Generation Pipeline.
+
+SceneBrief  — the structured input spec for generating a scene.
+PipelineCheckResult — the result of a single pre-flight validation check.
+PipelineResult — the full output of the pipeline: all checks + assembled prompt.
+
+The pipeline in generate/pipeline.py accepts a SceneBrief and runs:
+  1. LoreRule validation (Issue #6 / #7)
+  2. Register tagging (Issue #9)
+  3. Emotional arc validation (Issue #8)
+  4. NarrativeWeight computation (Issue #5)
+  5. Generation prompt assembly
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+@dataclass
+class SceneBrief:
+    """Structured input specification for scene generation.
+
+    Contains everything the pipeline needs to validate and generate a scene.
+    Serialises to/from JSON for CLI use.
+    """
+
+    # ── Characters ─────────────────────────────────────────────────────────
+    characters: list[str] = field(default_factory=list)
+    # List of character IDs (e.g. 'frodo_baggins', 'samwise_gamgee')
+
+    # ── Setting ─────────────────────────────────────────────────────────────
+    location: Optional[str] = None         # Place name e.g. 'The plains of Gorgoroth'
+    story_era: Optional[str] = None        # Era e.g. 'Third Age'
+    story_year: Optional[int] = None       # Year in era e.g. 3019
+
+    # ── Scene content ────────────────────────────────────────────────────────
+    scene_summary: str = ""
+    # One or two sentences describing what the scene is about.
+    # E.g. "Frodo and Sam reach the edge of Mordor. The Ring weighs heavily."
+
+    event_types: list[str] = field(default_factory=list)
+    # e.g. ['travel', 'dialogue', 'internal_monologue']
+
+    object_names: list[str] = field(default_factory=list)
+    # Objects present in the scene e.g. ['The One Ring', 'Sting']
+
+    # ── Style targets ────────────────────────────────────────────────────────
+    target_register: Optional[str] = None
+    # ProseRegister value e.g. 'elegiac'. None = auto-detect from scene_summary.
+
+    target_emotional_states: dict[str, str] = field(default_factory=dict)
+    # Map from character_id → target TolkienRegister.
+    # E.g. {'frodo_baggins': 'burden', 'samwise_gamgee': 'resolute'}
+
+    # ── Narrative weight targets ─────────────────────────────────────────────
+    narrative_weight_targets: dict[str, float] = field(default_factory=dict)
+    # Map from NarrativeWeight component name → target score.
+    # E.g. {'temporal_depth': 0.7, 'thematic_threads': 0.6}
+
+    # ── Validation controls ──────────────────────────────────────────────────
+    lore_check_enabled: bool = True
+    arc_check_enabled: bool = True
+    register_tag_enabled: bool = True
+    weight_check_enabled: bool = True
+
+    lore_check_categories: Optional[list[str]] = None
+    # None = check all categories. List to restrict e.g. ['magic', 'race']
+
+    era_references: list[str] = field(default_factory=list)
+    # Additional eras this scene references (for temporal depth scoring)
+
+    def to_dict(self) -> dict:
+        return {
+            "characters": self.characters,
+            "location": self.location,
+            "story_era": self.story_era,
+            "story_year": self.story_year,
+            "scene_summary": self.scene_summary,
+            "event_types": self.event_types,
+            "object_names": self.object_names,
+            "target_register": self.target_register,
+            "target_emotional_states": self.target_emotional_states,
+            "narrative_weight_targets": self.narrative_weight_targets,
+            "lore_check_enabled": self.lore_check_enabled,
+            "arc_check_enabled": self.arc_check_enabled,
+            "register_tag_enabled": self.register_tag_enabled,
+            "weight_check_enabled": self.weight_check_enabled,
+            "lore_check_categories": self.lore_check_categories,
+            "era_references": self.era_references,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "SceneBrief":
+        return cls(
+            characters=list(d.get("characters", [])),
+            location=d.get("location"),
+            story_era=d.get("story_era"),
+            story_year=d.get("story_year"),
+            scene_summary=d.get("scene_summary", ""),
+            event_types=list(d.get("event_types", [])),
+            object_names=list(d.get("object_names", [])),
+            target_register=d.get("target_register"),
+            target_emotional_states=dict(d.get("target_emotional_states", {})),
+            narrative_weight_targets=dict(d.get("narrative_weight_targets", {})),
+            lore_check_enabled=bool(d.get("lore_check_enabled", True)),
+            arc_check_enabled=bool(d.get("arc_check_enabled", True)),
+            register_tag_enabled=bool(d.get("register_tag_enabled", True)),
+            weight_check_enabled=bool(d.get("weight_check_enabled", True)),
+            lore_check_categories=d.get("lore_check_categories"),
+            era_references=list(d.get("era_references", [])),
+        )
+
+    @classmethod
+    def from_json_file(cls, path: str) -> "SceneBrief":
+        with open(path, encoding="utf-8") as f:
+            return cls.from_dict(json.load(f))
+
+    def to_json_file(self, path: str) -> None:
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(self.to_dict(), f, indent=2)
+
+    def short_label(self) -> str:
+        """One-line label for display."""
+        chars = ", ".join(self.characters[:3]) or "no characters"
+        loc = f" at {self.location}" if self.location else ""
+        year = f" (TA {self.story_year})" if self.story_year else ""
+        return f"{chars}{loc}{year}"
+
+
+@dataclass
+class PipelineCheckResult:
+    """Result of one named pre-flight check in the pipeline."""
+    check_name: str
+    passed: bool
+    blocking: bool = True     # If True, a fail here blocks generation
+    warnings: list[str] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+    details: dict = field(default_factory=dict)
+
+    def status_icon(self) -> str:
+        if self.passed:
+            return "✓"
+        return "✗" if self.blocking else "⚠"
+
+    def one_line(self) -> str:
+        icon = self.status_icon()
+        summary = f"{icon} {self.check_name}: "
+        if self.passed:
+            summary += "OK"
+        elif self.blocking:
+            summary += f"BLOCKED — {self.errors[0][:80] if self.errors else 'violation'}"
+        else:
+            summary += f"WARN — {self.warnings[0][:80] if self.warnings else 'warning'}"
+        return summary
+
+
+@dataclass
+class PipelineResult:
+    """Full output of the pre-flight pipeline.
+
+    Contains all check results, the assembled generation prompt,
+    and computed metrics for the scene.
+    """
+
+    brief: SceneBrief
+
+    # ── Per-check results ────────────────────────────────────────────────────
+    lore_check: Optional[PipelineCheckResult] = None
+    arc_checks: dict[str, PipelineCheckResult] = field(default_factory=dict)
+    register_check: Optional[PipelineCheckResult] = None
+    weight_check: Optional[PipelineCheckResult] = None
+
+    # ── Computed values ──────────────────────────────────────────────────────
+    detected_register: Optional[str] = None          # auto-detected from scene_summary
+    final_register: Optional[str] = None             # = target_register ?? detected_register
+    narrative_weight_overall: float = 0.0
+    narrative_weight_summary: str = ""
+    improvement_suggestions: list[str] = field(default_factory=list)
+
+    # ── Lore violation detail ────────────────────────────────────────────────
+    hard_violations: list[str] = field(default_factory=list)
+    soft_warnings: list[str] = field(default_factory=list)
+
+    # ── Pipeline status ──────────────────────────────────────────────────────
+    pipeline_passed: bool = True
+    pipeline_errors: list[str] = field(default_factory=list)
+    pipeline_warnings: list[str] = field(default_factory=list)
+
+    # ── Assembled generation prompt ──────────────────────────────────────────
+    generation_prompt: str = ""
+
+    # ── Optional generated text (filled by actual LLM generation) ───────────
+    generated_text: Optional[str] = None
+
+    def all_checks(self) -> list[PipelineCheckResult]:
+        checks = []
+        if self.lore_check:
+            checks.append(self.lore_check)
+        checks.extend(self.arc_checks.values())
+        if self.register_check:
+            checks.append(self.register_check)
+        if self.weight_check:
+            checks.append(self.weight_check)
+        return checks
+
+    def summary(self) -> str:
+        lines = [
+            f"Pipeline Pre-flight: {self.brief.short_label()}",
+            "",
+        ]
+        for check in self.all_checks():
+            lines.append(f"  {check.one_line()}")
+
+        lines += [
+            "",
+            f"  Final register: {self.final_register or 'not set'}",
+            f"  Narrative weight: {self.narrative_weight_overall:.3f}",
+        ]
+
+        if self.hard_violations:
+            lines += ["", "  Hard violations (BLOCKED):"]
+            for v in self.hard_violations:
+                lines.append(f"    • {v}")
+
+        if self.soft_warnings:
+            lines += ["", "  Soft warnings:"]
+            for w in self.soft_warnings[:5]:
+                lines.append(f"    ~ {w}")
+
+        if self.improvement_suggestions:
+            lines += ["", "  Improvement suggestions:"]
+            for s in self.improvement_suggestions[:3]:
+                lines.append(f"    → {s[:100]}")
+
+        overall = "[PASS]" if self.pipeline_passed else "[FAIL]"
+        lines += ["", f"  Overall: {overall}"]
+        return "\n".join(lines)
+
+    def to_dict(self) -> dict:
+        def _check_to_dict(c: Optional[PipelineCheckResult]) -> Optional[dict]:
+            if c is None:
+                return None
+            return {
+                "check_name": c.check_name,
+                "passed": c.passed,
+                "blocking": c.blocking,
+                "warnings": c.warnings,
+                "errors": c.errors,
+            }
+
+        return {
+            "brief": self.brief.to_dict(),
+            "pipeline_passed": self.pipeline_passed,
+            "final_register": self.final_register,
+            "narrative_weight_overall": self.narrative_weight_overall,
+            "hard_violations": self.hard_violations,
+            "soft_warnings": self.soft_warnings,
+            "improvement_suggestions": self.improvement_suggestions,
+            "lore_check": _check_to_dict(self.lore_check),
+            "arc_checks": {
+                k: _check_to_dict(v)
+                for k, v in self.arc_checks.items()
+            },
+            "register_check": _check_to_dict(self.register_check),
+            "weight_check": _check_to_dict(self.weight_check),
+            "generation_prompt": self.generation_prompt[:2000],  # Truncated for storage
+        }

--- a/src/book_graph_analyzer/voice/__init__.py
+++ b/src/book_graph_analyzer/voice/__init__.py
@@ -5,6 +5,14 @@ Phase 5: Capture how each character speaks distinctly.
 Extract dialogue, attribute to speakers, build per-character profiles.
 """
 
+from .audience import (
+    AudienceClassification,
+    classify_audience_type,
+    classify_context_type,
+    classify_dialogue_line,
+    AUDIENCE_TYPES,
+    CONTEXT_TYPES,
+)
 from .dialogue import (
     DialogueExtraction,
     DialogueLine,
@@ -15,6 +23,13 @@ from .profile import CharacterVoiceProfile
 from .analyzer import VoiceAnalyzer
 
 __all__ = [
+    # Audience classification
+    "AudienceClassification",
+    "classify_audience_type",
+    "classify_context_type",
+    "classify_dialogue_line",
+    "AUDIENCE_TYPES",
+    "CONTEXT_TYPES",
     # Dialogue extraction
     "DialogueExtraction",
     "DialogueLine",

--- a/src/book_graph_analyzer/voice/analyzer.py
+++ b/src/book_graph_analyzer/voice/analyzer.py
@@ -245,6 +245,206 @@ class VoiceAnalyzer:
         
         return comparison
     
+    def identify_speaker(
+        self,
+        text: str,
+        profiles: dict[str, CharacterVoiceProfile],
+        top_n: int = 3,
+    ) -> list[tuple[str, float]]:
+        """
+        Given an unmarked quote, identify the most likely speaker.
+        
+        The Blindspot Test: can we identify the speaker from the profile alone?
+        
+        Args:
+            text: The dialogue text to identify
+            profiles: Dict of character name -> CharacterVoiceProfile
+            top_n: Number of candidates to return
+            
+        Returns:
+            List of (character_name, confidence) sorted by confidence desc
+        """
+        if not profiles:
+            return []
+        
+        # Compute text metrics
+        words = text.lower().split()
+        word_count = len(words)
+        
+        # Archaisms
+        archaisms_list = {
+            "thee", "thou", "thy", "thine", "ye", "hath", "doth", "art", "wast",
+            "wherefore", "hither", "thither", "whither", "hence", "thence",
+            "ere", "nay", "aye", "yea", "behold", "lo", "alas", "forsooth",
+            "methinks", "mayhap", "perchance", "betwixt", "amongst", "whilst",
+            "verily", "hark", "hearken", "tarry", "prithee",
+        }
+        text_archaism_count = sum(1 for w in words if w.strip('.,!?"\'') in archaisms_list)
+        text_archaism_rate = (text_archaism_count / word_count * 100) if word_count > 0 else 0
+        
+        # Contraction ratio
+        contraction_patterns = ["n't", "'s", "'re", "'ve", "'ll", "'d", "'m"]
+        text_contractions = sum(1 for w in words if any(p in w for p in contraction_patterns))
+        text_contraction_ratio = text_contractions / word_count if word_count > 0 else 0
+        
+        # Question / exclamation
+        text_is_question = text.rstrip().endswith('?')
+        text_is_exclamation = text.rstrip().endswith('!')
+        
+        # Word length
+        clean_words = [w.strip('.,!?"\'') for w in words if w.strip('.,!?"\'')]
+        text_avg_word_length = sum(len(w) for w in clean_words) / len(clean_words) if clean_words else 0
+        
+        # Formality estimate for the text
+        arch_norm = min(text_archaism_rate / 5.0, 1.0)
+        contr_inv = max(0.0, 1.0 - text_contraction_ratio * 10)
+        wl_norm = min((text_avg_word_length - 3.0) / 3.0, 1.0) if text_avg_word_length > 3 else 0.0
+        text_formality = arch_norm * 0.5 + contr_inv * 0.3 + wl_norm * 0.2
+        
+        # Distinctive word overlap (strip punctuation for matching)
+        text_word_set = set(w.strip('.,!?"\'-') for w in words)
+        
+        scores: list[tuple[str, float]] = []
+        
+        for char_name, profile in profiles.items():
+            score = 0.0
+            weight_total = 0.0
+            
+            # 1. Formality score proximity (weight: 0.25)
+            formality_diff = abs(profile.formality_score - text_formality)
+            formality_score = max(0.0, 1.0 - formality_diff * 2)
+            score += formality_score * 0.25
+            weight_total += 0.25
+            
+            # 2. Archaism rate proximity (weight: 0.25)
+            arch_diff = abs(profile.archaism_rate - text_archaism_rate)
+            arch_score = max(0.0, 1.0 - arch_diff / 5.0)
+            score += arch_score * 0.25
+            weight_total += 0.25
+            
+            # 3. Contraction ratio proximity (weight: 0.15)
+            contr_diff = abs(profile.contraction_ratio - text_contraction_ratio)
+            contr_score = max(0.0, 1.0 - contr_diff * 5)
+            score += contr_score * 0.15
+            weight_total += 0.15
+            
+            # 4. Distinctive word overlap (weight: 0.20)
+            if profile.distinctive_words:
+                dist_set = set(profile.distinctive_words)
+                overlap = len(text_word_set & dist_set) / max(len(dist_set), 1)
+                score += min(overlap * 5, 1.0) * 0.20  # Amplify (usually few overlap)
+            weight_total += 0.20
+            
+            # 5. Signature phrase match (weight: 0.10)
+            if profile.signature_phrases:
+                text_lower = text.lower()
+                phrase_hits = sum(1 for phrase in profile.signature_phrases if phrase in text_lower)
+                if phrase_hits > 0:
+                    score += min(phrase_hits / 2, 1.0) * 0.10
+            weight_total += 0.10
+            
+            # 6. Penalty: text uses "never_says" words (weight: -0.05 per hit)
+            if profile.never_says:
+                never_set = set(profile.never_says)
+                penalty = sum(1 for w in text_word_set if w in never_set)
+                score -= penalty * 0.05
+            
+            # Normalize
+            normalized = max(0.0, score / weight_total) if weight_total > 0 else 0.0
+            scores.append((char_name, round(normalized, 3)))
+        
+        # Sort by confidence desc
+        scores.sort(key=lambda x: -x[1])
+        return scores[:top_n]
+    
+    def check_voice_violations(
+        self,
+        text: str,
+        profile: CharacterVoiceProfile,
+    ) -> list[dict]:
+        """
+        Check generated dialogue for voice consistency violations.
+        
+        Returns list of violation dicts with keys:
+          - type: 'wrong_formality' | 'uses_never_says' | 'missing_signature' | 'anachronism'
+          - severity: 'hard' | 'soft'
+          - message: Human-readable description
+        """
+        violations = []
+        words = text.lower().split()
+        clean_words = set(w.strip('.,!?"\'') for w in words)
+        
+        # Check 1: Wrong formality level
+        archaisms_list = {
+            "thee", "thou", "thy", "thine", "ye", "hath", "doth",
+        }
+        text_archaism_count = sum(1 for w in clean_words if w in archaisms_list)
+        text_contraction_count = sum(
+            1 for w in words if any(p in w for p in ["n't", "'re", "'ve", "'ll", "'d", "'m"])
+        )
+        word_count = len(words) or 1
+        text_formality = (
+            min(text_archaism_count / word_count * 100 / 5.0, 1.0) * 0.5
+            + max(0.0, 1.0 - (text_contraction_count / word_count) * 10) * 0.5
+        )
+        
+        if abs(text_formality - profile.formality_score) > 0.4:
+            direction = "too formal" if text_formality > profile.formality_score else "too informal"
+            violations.append({
+                "type": "wrong_formality",
+                "severity": "hard" if abs(text_formality - profile.formality_score) > 0.6 else "soft",
+                "message": (
+                    f"Formality mismatch: text is {direction} for {profile.character_name} "
+                    f"(text={text_formality:.2f}, expected≈{profile.formality_score:.2f})"
+                ),
+            })
+        
+        # Check 2: Uses words from never_says list
+        if profile.never_says:
+            never_set = set(profile.never_says)
+            banned_words = clean_words & never_set
+            if banned_words:
+                violations.append({
+                    "type": "uses_never_says",
+                    "severity": "soft",
+                    "message": (
+                        f"{profile.character_name} would never say: {', '.join(banned_words)}"
+                    ),
+                })
+        
+        # Check 3: Modern/anachronistic vocabulary
+        modern_words = {
+            "okay", "ok", "alright", "yeah", "yep", "nope", "sure", "cool",
+            "awesome", "totally", "literally", "basically", "actually",
+            "whatever", "stuff", "things", "guys", "hey", "hi", "bye",
+        }
+        anachronisms = clean_words & modern_words
+        if anachronisms:
+            violations.append({
+                "type": "anachronism",
+                "severity": "hard",
+                "message": (
+                    f"Anachronistic vocabulary for {profile.character_name}: "
+                    f"{', '.join(anachronisms)}"
+                ),
+            })
+        
+        # Check 4: Missing signature patterns (only if many phrases defined)
+        if len(profile.signature_phrases) >= 3:
+            text_lower = text.lower()
+            any_sig = any(phrase in text_lower for phrase in profile.signature_phrases)
+            if not any_sig and len(words) > 10:
+                violations.append({
+                    "type": "missing_signature",
+                    "severity": "soft",
+                    "message": (
+                        f"No signature patterns detected for {profile.character_name}. "
+                        f"Consider: {', '.join(profile.signature_phrases[:3])}"
+                    ),
+                })
+        
+        return violations
+
     def save_results(
         self,
         result: VoiceAnalysisResult,

--- a/src/book_graph_analyzer/voice/audience.py
+++ b/src/book_graph_analyzer/voice/audience.py
@@ -1,0 +1,169 @@
+"""
+Audience & Context Classification for Dialogue
+
+Classifies who a character is speaking to (audience_type) and
+what kind of speech act it is (context_type).
+"""
+
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+# ---------------------------------------------------------------------------
+# Audience type classification
+# ---------------------------------------------------------------------------
+
+# Tolkien-specific character/race name clusters
+_AUDIENCE_KEYWORDS: dict[str, list[str]] = {
+    "hobbit": [
+        "hobbit", "halfling", "shire", "bilbo", "frodo", "samwise", "sam",
+        "merry", "meriadoc", "pippin", "peregrin", "took", "baggins",
+        "bag end", "brandybuck", "gamgee",
+    ],
+    "elf": [
+        "elf", "elves", "elven", "elvish", "elrond", "galadriel", "legolas",
+        "arwen", "celeborn", "glorfindel", "erestor", "haldir", "rivendell",
+        "imladris", "lothlórien", "lothlorien", "lindon", "silvan", "noldor",
+        "sindar", "eldar", "firstborn",
+    ],
+    "man": [
+        "man", "men", "human", "mortal", "aragorn", "strider", "boromir",
+        "faramir", "théoden", "theoden", "éomer", "eomer", "éowyn", "eowyn",
+        "gondor", "rohan", "númenor", "numenor", "dúnedain", "dunedain",
+        "ranger",
+    ],
+    "dwarf": [
+        "dwarf", "dwarves", "dwarven", "dwarfish", "gimli", "glóin", "gloin",
+        "balin", "dwalin", "thorin", "erebor", "moria", "khazad",
+        "durin", "longbeard",
+    ],
+    "enemy": [
+        "orc", "orcs", "orcish", "goblin", "goblinlike", "balrog", "sauron",
+        "morgoth", "mordor", "nazgûl", "nazgul", "wraith", "ringwraith",
+        "uruk", "troll", "warg", "enemy", "enemies", "foe", "foes",
+        "shadow", "dark lord",
+    ],
+    "self": [
+        "himself", "herself", "myself", "itself",
+    ],
+    "prayer": [
+        "ilúvatar", "iluvatar", "eru", "valar", "manwë", "manwe", "varda",
+        "elbereth", "stars", "o lord", "o great",
+    ],
+}
+
+# Context-type detection patterns (order matters — first match wins)
+# More specific patterns come first to avoid false positives.
+_CONTEXT_PATTERNS: list[tuple[str, list[str]]] = [
+    ("farewell", [
+        r"\b(farewell|goodbye|good-bye|namárië|until we meet|parting|depart|go well|godspeed|fare thee well|fare well)\b",
+    ]),
+    ("comfort", [
+        r"\b(fear not|do not fear|be not afraid|all shall be well|do not worry)\b",
+        r"\b(peace|rest|comfort|solace|burden|grief|sorrow|weep|tears|courage|endure)\b",
+    ]),
+    ("warning", [
+        r"\b(beware|peril|careful|heed|caution|lest)\b",
+        r"\b(danger|shadow|doom|trap|ambush|dark lord|wraith)\b",
+    ]),
+    ("crisis", [
+        r"\b(run|flee|hurry|quick|danger|attack|help|aid|escape|save)\b",
+        r"\b(no time|urgent|at once|immediately)\b",
+    ]),
+    ("command", [
+        r"^(go|come|stop|stay|take|bring|follow|hold|stand|rise|sit|listen|look|hear|move)\b",
+        r"\b(do not|never|you must|thou shalt|thou must)\b",
+    ]),
+    ("explanation", [
+        r"\b(because|for|thus|therefore|hence|this is|the reason|let me explain|you see|know that|understand)\b",
+        r"\b(long ago|once|history|legend|tale|story|as you know|recall|remember)\b",
+    ]),
+]
+
+
+AUDIENCE_TYPES = frozenset({"hobbit", "elf", "man", "dwarf", "enemy", "neutral", "self", "prayer"})
+CONTEXT_TYPES = frozenset({"crisis", "explanation", "command", "comfort", "warning", "farewell", "statement"})
+
+
+def classify_audience_type(
+    dialogue_text: str,
+    context_before: str,
+    context_after: str,
+    speaker: Optional[str] = None,
+) -> str:
+    """
+    Classify the audience type for a dialogue line.
+
+    Returns one of: 'hobbit' | 'elf' | 'man' | 'dwarf' | 'enemy' |
+                    'neutral' | 'self' | 'prayer'
+    """
+    # Check for self-referential speech
+    if re.search(r"\b(himself|herself|myself|itself|to himself|to herself)\b",
+                 context_before + " " + context_after, re.IGNORECASE):
+        return "self"
+
+    # Combine context windows for audience detection
+    combined = (context_before + " " + context_after).lower()
+
+    # Score each audience type by keyword hits
+    scores: dict[str, int] = {}
+    for audience, keywords in _AUDIENCE_KEYWORDS.items():
+        if audience == "self":
+            continue
+        count = sum(1 for kw in keywords if kw in combined)
+        if count > 0:
+            scores[audience] = count
+
+    if scores:
+        return max(scores, key=lambda k: scores[k])
+
+    return "neutral"
+
+
+def classify_context_type(dialogue_text: str) -> str:
+    """
+    Classify the context type (speech act) of a dialogue line.
+
+    Returns one of: 'crisis' | 'explanation' | 'command' | 'comfort' |
+                    'warning' | 'farewell' | 'statement'
+    """
+    text_lower = dialogue_text.lower().strip()
+
+    for context_type, patterns in _CONTEXT_PATTERNS:
+        for pattern in patterns:
+            if re.search(pattern, text_lower):
+                return context_type
+
+    return "statement"
+
+
+@dataclass
+class AudienceClassification:
+    """Result of audience + context classification for a dialogue line."""
+    audience_type: str   # One of AUDIENCE_TYPES
+    context_type: str    # One of CONTEXT_TYPES
+    confidence: float    # 0.0 - 1.0
+
+
+def classify_dialogue_line(
+    dialogue_text: str,
+    context_before: str,
+    context_after: str,
+    speaker: Optional[str] = None,
+) -> AudienceClassification:
+    """
+    Classify both audience type and context type for a dialogue line.
+    """
+    audience = classify_audience_type(
+        dialogue_text, context_before, context_after, speaker
+    )
+    context = classify_context_type(dialogue_text)
+
+    # Confidence: higher if we found keyword matches
+    confidence = 0.8 if audience != "neutral" else 0.3
+
+    return AudienceClassification(
+        audience_type=audience,
+        context_type=context,
+        confidence=confidence,
+    )

--- a/src/book_graph_analyzer/voice/dialogue.py
+++ b/src/book_graph_analyzer/voice/dialogue.py
@@ -11,6 +11,8 @@ import re
 import spacy
 from spacy.tokens import Doc
 
+from .audience import classify_dialogue_line
+
 
 # Speech verbs for attribution detection
 SPEECH_VERBS = {
@@ -94,6 +96,13 @@ class DialogueLine:
     is_question: bool = False
     is_exclamation: bool = False
     is_statement: bool = True
+    is_imperative: bool = False         # Starts with a verb (command/request)
+    is_verse: bool = False              # Detected as song/poetry
+    
+    # Audience & context type (Issue #10)
+    audience_type: str = "neutral"      # 'hobbit'|'elf'|'man'|'dwarf'|'enemy'|'neutral'|'self'|'prayer'
+    context_type: str = "statement"     # 'crisis'|'explanation'|'command'|'comfort'|'warning'|'farewell'|'statement'
+    audience_confidence: float = 0.0    # Confidence in audience classification
     
     # Confidence
     attribution_confidence: float = 0.0  # How confident we are about the speaker
@@ -194,6 +203,19 @@ def extract_dialogue(
         is_exclamation = quote_text.rstrip().endswith('!')
         is_statement = not is_question and not is_exclamation
         
+        # Detect imperative (starts with a base-form verb, no subject pronoun)
+        is_imperative = _detect_imperative(quote_text)
+        
+        # Detect verse/song (short lines, often rhythmic, may have internal newlines)
+        is_verse = _detect_verse(quote_text)
+        
+        # Audience & context classification
+        ctx_before_window = context_before[-100:] if len(context_before) > 100 else context_before
+        ctx_after_window = context_after[:100] if len(context_after) > 100 else context_after
+        audience_cls = classify_dialogue_line(
+            quote_text, ctx_before_window, ctx_after_window, speaker
+        )
+        
         line = DialogueLine(
             text=quote_text,
             speaker=speaker,
@@ -205,6 +227,11 @@ def extract_dialogue(
             is_question=is_question,
             is_exclamation=is_exclamation,
             is_statement=is_statement,
+            is_imperative=is_imperative,
+            is_verse=is_verse,
+            audience_type=audience_cls.audience_type,
+            context_type=audience_cls.context_type,
+            audience_confidence=audience_cls.confidence,
             attribution_confidence=confidence,
         )
         
@@ -314,6 +341,61 @@ def _attribute_speaker(
             return speaker, speech_verb, confidence
     
     return None, None, 0.0
+
+
+def _detect_imperative(text: str) -> bool:
+    """
+    Heuristically detect imperative sentences.
+    
+    Imperatives typically start with a base-form verb with no subject.
+    """
+    # Common imperative starters
+    imperative_starters = {
+        # Motion
+        "go", "come", "stay", "stop", "run", "flee", "follow", "lead",
+        "move", "walk", "ride", "fly", "climb", "fall",
+        # Action
+        "take", "bring", "give", "hold", "keep", "put", "set", "get",
+        "make", "do", "let", "leave", "return", "stand", "sit", "rise",
+        # Perception
+        "look", "see", "watch", "hear", "listen", "read", "speak",
+        # Archaic
+        "heed", "behold", "hearken", "hark", "tarry", "stay",
+        # Negative
+        "do not", "do not", "never", "fear not", "worry not",
+    }
+    tokens = text.lower().split()
+    first_word = tokens[0].strip('.,!?"\'-') if tokens else ""
+    first_two_raw = tokens[:2] if len(tokens) >= 2 else tokens
+    first_two = " ".join(w.strip('.,!?"\'-') for w in first_two_raw)
+    
+    return first_word in imperative_starters or first_two in imperative_starters
+
+
+def _detect_verse(text: str) -> bool:
+    """
+    Heuristically detect verse/songs.
+    
+    Verse often has:
+    - Internal newlines
+    - Short, rhythmic lines
+    - May start with 'O' or have unusual capitalization mid-sentence
+    """
+    # Check for internal newlines (multi-line speech)
+    if '\n' in text:
+        return True
+    
+    # Check for verse markers
+    verse_patterns = [
+        r'\bO\s+[A-Z]',             # "O Elbereth" type invocations
+        r'\b(sing|song|sang|sung)\b',  # References to singing
+        r'[,;]\s+\w+\s+\w+[,;]',    # Comma-delimited short phrases (rhythmic)
+    ]
+    for pattern in verse_patterns:
+        if re.search(pattern, text):
+            return True
+    
+    return False
 
 
 def extract_dialogue_from_passages(

--- a/src/book_graph_analyzer/voice/profile.py
+++ b/src/book_graph_analyzer/voice/profile.py
@@ -50,17 +50,34 @@ class CharacterVoiceProfile:
     first_person_ratio: float = 0.0        # "I", "me", "my" usage
     second_person_ratio: float = 0.0       # "you", "your" usage
     
+    # Formality indicators (Issue #10 — VoiceProfile spec)
+    formality_score: float = 0.0        # 0.0 (informal/dialect) to 1.0 (high formal/archaic)
+    archaism_rate: float = 0.0          # Archaisms per 100 words
+    rhetorical_density: float = 0.0     # Questions used rhetorically (not seeking info)
+    imperative_ratio: float = 0.0       # Lines that are commands/imperatives
+    
+    # Audience-variant metrics
+    formality_by_audience: dict = field(default_factory=dict)   # { 'hobbit': 0.58, 'elf': 0.84, ... }
+    length_by_audience: dict = field(default_factory=dict)       # avg words per line by audience type
+    register_by_audience: dict = field(default_factory=dict)     # dominant context_type per audience
+    
     # Distinctive features
-    top_words: list[tuple[str, int]] = field(default_factory=list)  # Most used words
-    distinctive_words: list[str] = field(default_factory=list)       # Words unique to this character
-    signature_phrases: list[str] = field(default_factory=list)       # Repeated phrases
+    top_words: list = field(default_factory=list)           # Most used words (list of [word, count])
+    distinctive_words: list = field(default_factory=list)    # Words unique to this character
+    signature_phrases: list = field(default_factory=list)    # Recurring exact phrases
+    never_says: list = field(default_factory=list)           # Words/constructions this character never uses
+    topic_distribution: dict = field(default_factory=dict)   # { 'history': 0.3, 'practical': 0.4, ... }
     
     # Archaic language (Tolkien-relevant)
     archaism_count: int = 0
-    archaisms_used: list[str] = field(default_factory=list)
+    archaisms_used: list = field(default_factory=list)
+    
+    # Verse/song handling (Issue #10)
+    verse_lines: int = 0                # Lines detected as verse/song
+    prose_lines: int = 0                # Lines detected as prose dialogue
     
     # Sample quotes
-    sample_quotes: list[str] = field(default_factory=list)  # Representative quotes
+    sample_quotes: list = field(default_factory=list)  # Representative quotes
     
     @classmethod
     def from_dialogue_lines(
@@ -98,10 +115,22 @@ class CharacterVoiceProfile:
         questions = 0
         exclamations = 0
         statements = 0
+        imperatives = 0
+        verse_count = 0
+        prose_count = 0
+        rhetorical_questions = 0
         
         contractions = 0
         first_person = 0
         second_person = 0
+        
+        # Audience-variant accumulators: { audience_type: [words_per_line, ...] }
+        audience_lengths: dict[str, list[float]] = {}
+        audience_archaism_counts: dict[str, int] = {}
+        audience_contraction_counts: dict[str, int] = {}
+        audience_word_counts: dict[str, int] = {}
+        # Context type per audience for dominant register detection
+        audience_context_types: dict[str, list[str]] = {}
         
         first_person_words = {'i', 'me', 'my', 'mine', 'myself', "i'm", "i've", "i'll", "i'd"}
         second_person_words = {'you', 'your', 'yours', 'yourself', "you're", "you've", "you'll", "you'd"}
@@ -116,6 +145,14 @@ class CharacterVoiceProfile:
         ]
         archaisms_found = set()
         
+        # Rhetorical question patterns (short, or using certain structures)
+        rhetorical_patterns = [
+            "what does", "what does it", "who knows", "who can", "who would",
+            "what is the use", "why should", "why would", "how could",
+            "do you not", "have you not", "is it not", "was it not",
+            "can you not", "could you not", "shall we not",
+        ]
+        
         for line in lines:
             text = line.text
             profile.total_chars += len(text)
@@ -129,15 +166,32 @@ class CharacterVoiceProfile:
             # Word lengths
             word_lengths.extend(len(w.strip('.,!?"\'-')) for w in words)
             
-            # Classify
+            # Classify line type
+            is_verse = getattr(line, 'is_verse', False)
+            is_imperative = getattr(line, 'is_imperative', False)
+            
+            if is_verse:
+                verse_count += 1
+            else:
+                prose_count += 1
+            
             if line.is_question:
                 questions += 1
+                # Check for rhetorical question
+                text_lower = text.lower()
+                if any(p in text_lower for p in rhetorical_patterns) or word_count <= 4:
+                    rhetorical_questions += 1
             elif line.is_exclamation:
                 exclamations += 1
             else:
                 statements += 1
             
-            # Formality indicators
+            if is_imperative:
+                imperatives += 1
+            
+            # Per-word formality analysis
+            line_archaisms = 0
+            line_contractions = 0
             for word in words:
                 word_lower = word.lower().strip('.,!?"\'')
                 if word_lower in first_person_words:
@@ -147,11 +201,32 @@ class CharacterVoiceProfile:
                 for pattern in contraction_patterns:
                     if pattern in word:
                         contractions += 1
+                        line_contractions += 1
                         break
                 if word_lower in archaisms_list:
                     archaisms_found.add(word_lower)
+                    line_archaisms += 1
+            
+            # Audience-variant accumulation
+            audience = getattr(line, 'audience_type', 'neutral')
+            context = getattr(line, 'context_type', 'statement')
+            
+            if audience not in audience_lengths:
+                audience_lengths[audience] = []
+                audience_archaism_counts[audience] = 0
+                audience_contraction_counts[audience] = 0
+                audience_word_counts[audience] = 0
+                audience_context_types[audience] = []
+            
+            audience_lengths[audience].append(float(word_count))
+            audience_archaism_counts[audience] += line_archaisms
+            audience_contraction_counts[audience] += line_contractions
+            audience_word_counts[audience] += word_count
+            audience_context_types[audience].append(context)
         
         profile.total_words = len(all_words)
+        profile.verse_lines = verse_count
+        profile.prose_lines = prose_count
         
         # Utterance length stats
         if utterance_lengths:
@@ -165,6 +240,7 @@ class CharacterVoiceProfile:
             profile.question_ratio = questions / profile.total_lines
             profile.exclamation_ratio = exclamations / profile.total_lines
             profile.statement_ratio = statements / profile.total_lines
+            profile.imperative_ratio = imperatives / profile.total_lines
         
         # Vocabulary
         word_counts = Counter(all_words)
@@ -177,6 +253,46 @@ class CharacterVoiceProfile:
             profile.contraction_ratio = contractions / profile.total_words
             profile.first_person_ratio = first_person / profile.total_words
             profile.second_person_ratio = second_person / profile.total_words
+        
+        # Archaisms
+        profile.archaism_count = sum(word_counts.get(a, 0) for a in archaisms_found)
+        profile.archaisms_used = list(archaisms_found)
+        profile.archaism_rate = (profile.archaism_count / profile.total_words * 100) if profile.total_words > 0 else 0.0
+        
+        # Formality score (0=informal, 1=formal)
+        # Based on: archaism rate (normalized), low contraction, high avg word length
+        archaism_norm = min(profile.archaism_rate / 5.0, 1.0)    # 5 archaisms/100w = fully formal
+        contraction_inv = max(0.0, 1.0 - profile.contraction_ratio * 10)  # 10% contractions = 0 formality
+        word_len_norm = min((profile.avg_word_length - 3.0) / 3.0, 1.0) if profile.avg_word_length > 3 else 0.0
+        profile.formality_score = (archaism_norm * 0.5 + contraction_inv * 0.3 + word_len_norm * 0.2)
+        profile.formality_score = max(0.0, min(1.0, profile.formality_score))
+        
+        # Rhetorical density: rhetorical questions as fraction of all questions
+        if questions > 0:
+            profile.rhetorical_density = rhetorical_questions / questions
+        
+        # Audience-variant metrics
+        for audience, lengths in audience_lengths.items():
+            if lengths:
+                profile.length_by_audience[audience] = statistics.mean(lengths)
+                # Formality by audience: archaism / words for this audience
+                aud_words = audience_word_counts.get(audience, 0)
+                if aud_words > 0:
+                    aud_arch = audience_archaism_counts.get(audience, 0)
+                    aud_contr = audience_contraction_counts.get(audience, 0)
+                    aud_arch_norm = min(aud_arch / aud_words * 100 / 5.0, 1.0)
+                    aud_contr_inv = max(0.0, 1.0 - (aud_contr / aud_words) * 10)
+                    profile.formality_by_audience[audience] = (
+                        aud_arch_norm * 0.6 + aud_contr_inv * 0.4
+                    )
+                else:
+                    profile.formality_by_audience[audience] = 0.5
+                
+                # Dominant context type for this audience
+                ctx_list = audience_context_types.get(audience, [])
+                if ctx_list:
+                    ctx_counter = Counter(ctx_list)
+                    profile.register_by_audience[audience] = ctx_counter.most_common(1)[0][0]
         
         # Top words (filter out very common words)
         stop_words = {'the', 'a', 'an', 'and', 'or', 'but', 'in', 'on', 'at', 'to', 'for',
@@ -195,9 +311,14 @@ class CharacterVoiceProfile:
                 character_name, word_counts, all_character_words
             )
         
-        # Archaisms
-        profile.archaism_count = sum(word_counts.get(a, 0) for a in archaisms_found)
-        profile.archaisms_used = list(archaisms_found)
+        # Never-says: words that appear in other characters but never in this one
+        if all_character_words:
+            profile.never_says = _find_never_says(
+                character_name, word_counts, all_character_words
+            )
+        
+        # Topic distribution
+        profile.topic_distribution = _compute_topic_distribution(all_words)
         
         # Sample quotes (pick diverse ones)
         profile.sample_quotes = _select_sample_quotes(lines, max_quotes=5)
@@ -230,51 +351,165 @@ class CharacterVoiceProfile:
     
     def summary(self) -> str:
         """Generate human-readable summary."""
-        lines = [
+        summary_lines = [
             f"=== Voice Profile: {self.character_name} ===",
             f"",
             f"[Corpus]",
-            f"   Total lines: {self.total_lines}",
+            f"   Total lines: {self.total_lines} (prose: {self.prose_lines}, verse: {self.verse_lines})",
             f"   Total words: {self.total_words}",
             f"",
             f"[Speech Patterns]",
             f"   Avg utterance: {self.avg_utterance_length:.1f} words",
             f"   Range: {self.min_utterance_length} - {self.max_utterance_length} words",
-            f"   Questions: {self.question_ratio*100:.1f}%",
-            f"   Exclamations: {self.exclamation_ratio*100:.1f}%",
+            f"   Questions: {self.question_ratio*100:.1f}%  Exclamations: {self.exclamation_ratio*100:.1f}%  Imperatives: {self.imperative_ratio*100:.1f}%",
+            f"   Rhetorical density: {self.rhetorical_density:.2f}",
+            f"",
+            f"[Formality & Register]",
+            f"   Formality score: {self.formality_score:.2f}  (0=informal, 1=formal)",
+            f"   Archaism rate: {self.archaism_rate:.2f}/100w",
+            f"   Contractions: {self.contraction_ratio*100:.1f}%",
             f"",
             f"[Vocabulary]",
             f"   Unique words: {self.unique_words}",
             f"   Type-token ratio: {self.type_token_ratio:.3f}",
-            f"   Contractions: {self.contraction_ratio*100:.1f}%",
             f"",
         ]
         
+        if self.formality_by_audience:
+            summary_lines.append(f"[Audience-Variant Formality]")
+            for aud, score in sorted(self.formality_by_audience.items(), key=lambda x: -x[1]):
+                avg_len = self.length_by_audience.get(aud, 0)
+                reg = self.register_by_audience.get(aud, "-")
+                summary_lines.append(f"   {aud:10s}: formality={score:.2f}  avg_len={avg_len:.1f}w  register={reg}")
+            summary_lines.append("")
+        
         if self.top_words:
-            lines.append(f"[Top Words]")
+            summary_lines.append(f"[Top Words]")
             for word, count in self.top_words[:10]:
-                lines.append(f"   {word}: {count}")
-            lines.append("")
+                summary_lines.append(f"   {word}: {count}")
+            summary_lines.append("")
         
         if self.distinctive_words:
-            lines.append(f"[Distinctive Words]")
-            lines.append(f"   {', '.join(self.distinctive_words[:10])}")
-            lines.append("")
+            summary_lines.append(f"[Distinctive Words]")
+            summary_lines.append(f"   {', '.join(self.distinctive_words[:10])}")
+            summary_lines.append("")
+        
+        if self.never_says:
+            summary_lines.append(f"[Never Says]")
+            summary_lines.append(f"   {', '.join(self.never_says[:10])}")
+            summary_lines.append("")
+        
+        if self.topic_distribution:
+            summary_lines.append(f"[Topic Distribution]")
+            for topic, ratio in self.topic_distribution.items():
+                summary_lines.append(f"   {topic}: {ratio*100:.0f}%")
+            summary_lines.append("")
         
         if self.archaisms_used:
-            lines.append(f"[Archaic Language]")
-            lines.append(f"   {', '.join(self.archaisms_used)}")
-            lines.append("")
+            summary_lines.append(f"[Archaic Language]")
+            summary_lines.append(f"   {', '.join(self.archaisms_used)}")
+            summary_lines.append("")
         
         if self.sample_quotes:
-            lines.append(f"[Sample Quotes]")
+            summary_lines.append(f"[Sample Quotes]")
             for quote in self.sample_quotes[:3]:
                 # Truncate long quotes
                 display = quote[:80] + "..." if len(quote) > 80 else quote
-                lines.append(f'   "{display}"')
-            lines.append("")
+                summary_lines.append(f'   "{display}"')
+            summary_lines.append("")
         
-        return "\n".join(lines)
+        return "\n".join(summary_lines)
+
+
+def _find_never_says(
+    character: str,
+    char_words: Counter,
+    all_char_words: dict[str, Counter],
+    min_other_chars: int = 1,
+    top_n: int = 10,
+) -> list[str]:
+    """
+    Find common words that OTHER characters use, but this character never does.
+    
+    These are potential "never says" items — words that break character voice.
+    """
+    # Collect words used by at least min_other_chars other characters
+    other_common: Counter = Counter()
+    other_char_count: Counter = Counter()
+    
+    for other_char, words in all_char_words.items():
+        if other_char == character:
+            continue
+        for word, count in words.items():
+            if count >= 2 and len(word) > 3:
+                other_common[word] += count
+                other_char_count[word] += 1
+    
+    # Find words used by many others but not by this character
+    never_used = []
+    for word, spread in other_char_count.most_common(50):
+        if spread >= min_other_chars and char_words.get(word, 0) == 0:
+            # Filter out stop words
+            if word not in {'the', 'and', 'that', 'this', 'with', 'have', 'from',
+                           'they', 'their', 'what', 'when', 'will', 'been', 'all'}:
+                never_used.append(word)
+    
+    return never_used[:top_n]
+
+
+_TOPIC_KEYWORDS: dict[str, list[str]] = {
+    "history": [
+        "age", "era", "ancient", "long", "ago", "once", "before", "remember",
+        "elder", "days", "old", "time", "past", "tale", "legend", "story",
+        "years", "centuries",
+    ],
+    "practical": [
+        "food", "water", "road", "path", "fire", "camp", "night", "day",
+        "journey", "walk", "ride", "horse", "door", "house", "village",
+        "market", "eat", "drink", "sleep", "rest",
+    ],
+    "war": [
+        "battle", "sword", "enemy", "fight", "army", "war", "orc", "goblin",
+        "attack", "defend", "victory", "defeat", "blood", "weapon", "shield",
+        "host", "forces",
+    ],
+    "wisdom": [
+        "counsel", "wisdom", "advice", "think", "know", "understand", "learn",
+        "truth", "knowledge", "secret", "hidden", "meaning", "purpose",
+        "plan", "strategy", "way",
+    ],
+    "nature": [
+        "tree", "forest", "mountain", "river", "valley", "stone", "sky",
+        "wind", "rain", "flower", "leaf", "bird", "star", "sun", "moon",
+        "earth", "water", "light", "dark",
+    ],
+    "fellowship": [
+        "friend", "companion", "together", "trust", "hope", "heart",
+        "love", "care", "help", "aid", "follow", "loyal", "faithful",
+        "master", "sir",
+    ],
+}
+
+
+def _compute_topic_distribution(all_words: list[str]) -> dict[str, float]:
+    """
+    Compute topic distribution from a list of words.
+    
+    Returns normalized distribution over topic buckets.
+    """
+    word_set = set(all_words)
+    topic_scores: dict[str, int] = {}
+    
+    for topic, keywords in _TOPIC_KEYWORDS.items():
+        score = sum(1 for kw in keywords if kw in word_set)
+        if score > 0:
+            topic_scores[topic] = score
+    
+    total = sum(topic_scores.values())
+    if total == 0:
+        return {}
+    
+    return {t: round(s / total, 3) for t, s in sorted(topic_scores.items(), key=lambda x: -x[1])}
 
 
 def _find_distinctive_words(

--- a/tests/test_voice_profile.py
+++ b/tests/test_voice_profile.py
@@ -1,0 +1,622 @@
+"""
+Tests for Issue #10 — VoiceProfile + Audience-Variant Character Voice
+
+Tests cover:
+- Audience type classification
+- Context type classification
+- DialogueLine new fields (is_imperative, is_verse, audience_type, context_type)
+- CharacterVoiceProfile new fields (formality_score, archaism_rate, etc.)
+- Audience-variant metrics (formality_by_audience, length_by_audience, register_by_audience)
+- never_says computation
+- topic_distribution computation
+- VoiceAnalyzer.identify_speaker
+- VoiceAnalyzer.check_voice_violations
+"""
+import pytest
+
+from book_graph_analyzer.voice.audience import (
+    classify_audience_type,
+    classify_context_type,
+    classify_dialogue_line,
+    AUDIENCE_TYPES,
+    CONTEXT_TYPES,
+)
+from book_graph_analyzer.voice.dialogue import (
+    DialogueLine,
+    extract_dialogue,
+    _detect_imperative,
+    _detect_verse,
+)
+from book_graph_analyzer.voice.profile import (
+    CharacterVoiceProfile,
+    _compute_topic_distribution,
+    _find_never_says,
+)
+from book_graph_analyzer.voice.analyzer import VoiceAnalyzer
+
+
+# ---------------------------------------------------------------------------
+# Audience classification tests
+# ---------------------------------------------------------------------------
+
+class TestAudienceClassification:
+    def test_classify_audience_hobbit_context(self):
+        result = classify_audience_type(
+            "Come with me!",
+            context_before="Gandalf spoke to Bilbo and Frodo",
+            context_after="in Bag End",
+        )
+        assert result == "hobbit"
+
+    def test_classify_audience_elf_context(self):
+        result = classify_audience_type(
+            "Namárië.",
+            context_before="He turned to Galadriel and Elrond",
+            context_after="and spoke in Elvish",
+        )
+        assert result == "elf"
+
+    def test_classify_audience_dwarf_context(self):
+        result = classify_audience_type(
+            "Well met!",
+            context_before="He greeted Gimli the dwarf",
+            context_after="at the gates of Erebor",
+        )
+        assert result == "dwarf"
+
+    def test_classify_audience_neutral(self):
+        # No known race/character keywords in context → "neutral"
+        result = classify_audience_type("Hello.", context_before="said a voice", context_after="in the dark")
+        assert result == "neutral"
+
+    def test_classify_audience_self(self):
+        result = classify_audience_type(
+            "What am I to do?",
+            context_before="he thought to himself",
+            context_after="",
+        )
+        assert result == "self"
+
+    def test_classify_audience_enemy_context(self):
+        result = classify_audience_type(
+            "You shall not pass!",
+            context_before="facing the orc army",
+            context_after="and blocked the bridge",
+        )
+        assert result == "enemy"
+
+    def test_all_audience_types_valid(self):
+        # All returned values must be in the known set
+        for ctx_b, ctx_a in [
+            ("hobbit bilbo frodo", ""),
+            ("elf galadriel elrond", ""),
+            ("dwarf gimli erebor", ""),
+            ("aragorn man gondor", ""),
+            ("orc enemy mordor", ""),
+            ("", ""),
+        ]:
+            result = classify_audience_type("text", ctx_b, ctx_a)
+            assert result in AUDIENCE_TYPES, f"Unknown audience type: {result}"
+
+
+class TestContextTypeClassification:
+    def test_context_crisis(self):
+        assert classify_context_type("Run! They are coming!") == "crisis"
+
+    def test_context_command(self):
+        assert classify_context_type("Go now, and do not return.") == "command"
+
+    def test_context_warning(self):
+        assert classify_context_type("Beware the shadow that lurks here.") == "warning"
+
+    def test_context_farewell(self):
+        assert classify_context_type("Farewell, dear friends, until we meet again.") == "farewell"
+
+    def test_context_comfort(self):
+        assert classify_context_type("Fear not. All shall be well in the end.") == "comfort"
+
+    def test_context_explanation(self):
+        assert classify_context_type("Long ago, in the Elder Days, this was forged.") == "explanation"
+
+    def test_context_statement_default(self):
+        assert classify_context_type("The sun is shining today.") == "statement"
+
+    def test_all_context_types_valid(self):
+        texts = [
+            "Run!",
+            "Go now.",
+            "Beware the dark.",
+            "Farewell.",
+            "Fear not.",
+            "Long ago...",
+            "The sky is blue.",
+        ]
+        for t in texts:
+            result = classify_context_type(t)
+            assert result in CONTEXT_TYPES, f"Unknown context type: {result}"
+
+
+# ---------------------------------------------------------------------------
+# DialogueLine new fields
+# ---------------------------------------------------------------------------
+
+class TestImperativeDetection:
+    def test_imperative_go(self):
+        assert _detect_imperative("Go now and do not look back.") is True
+
+    def test_imperative_behold(self):
+        assert _detect_imperative("Behold the ring of power!") is True
+
+    def test_imperative_do_not(self):
+        assert _detect_imperative("Do not speak that name here.") is True
+
+    def test_not_imperative_subject_first(self):
+        assert _detect_imperative("He walked away in silence.") is False
+
+    def test_not_imperative_question(self):
+        assert _detect_imperative("What are you doing here?") is False
+
+
+class TestVerseDetection:
+    def test_verse_with_newline(self):
+        assert _detect_verse("O Elbereth Gilthoniel\nsilivren penna miriel") is True
+
+    def test_verse_o_invocation(self):
+        assert _detect_verse("O Elbereth, hear my call!") is True
+
+    def test_not_verse_plain_statement(self):
+        assert _detect_verse("I will go to Rivendell.") is False
+
+
+class TestExtractDialogueNewFields:
+    def test_extract_sets_audience_type(self):
+        text = '''Gandalf spoke to Bilbo the hobbit: "Come with me on an adventure."'''
+        result = extract_dialogue(text)
+        assert len(result.dialogue_lines) >= 1
+        line = result.dialogue_lines[0]
+        assert line.audience_type in AUDIENCE_TYPES
+
+    def test_extract_sets_context_type(self):
+        text = '"Go now, and do not return." said the wizard.'
+        result = extract_dialogue(text)
+        assert len(result.dialogue_lines) >= 1
+        line = result.dialogue_lines[0]
+        assert line.context_type in CONTEXT_TYPES
+
+    def test_extract_detects_imperative_line(self):
+        text = '"Run, you fools!" he cried.'
+        result = extract_dialogue(text)
+        assert len(result.dialogue_lines) >= 1
+        # The line starts with "Run" — an imperative
+        line = result.dialogue_lines[0]
+        assert line.is_imperative is True
+
+
+# ---------------------------------------------------------------------------
+# CharacterVoiceProfile new fields
+# ---------------------------------------------------------------------------
+
+def _make_line(text: str, audience: str = "neutral", context: str = "statement",
+               imperative: bool = False, verse: bool = False) -> DialogueLine:
+    """Helper to create a DialogueLine with all new fields."""
+    return DialogueLine(
+        text=text,
+        speaker="TestChar",
+        is_question=text.endswith("?"),
+        is_exclamation=text.endswith("!"),
+        is_statement=not text.endswith("?") and not text.endswith("!"),
+        is_imperative=imperative,
+        is_verse=verse,
+        audience_type=audience,
+        context_type=context,
+        audience_confidence=0.8,
+    )
+
+
+class TestCharacterVoiceProfileNewFields:
+    def test_formality_score_range(self):
+        lines = [_make_line("I am the flame of Udun.")] * 5
+        profile = CharacterVoiceProfile.from_dialogue_lines("Balrog", lines)
+        assert 0.0 <= profile.formality_score <= 1.0
+
+    def test_high_formality_archaic_character(self):
+        archaic_lines = [
+            _make_line("Thee shall not pass, thou foolish mortal."),
+            _make_line("Hearken to me, for ere long thou shalt see."),
+            _make_line("Wherefore dost thou tarry, ye wanderers?"),
+        ]
+        profile = CharacterVoiceProfile.from_dialogue_lines("AncientOne", archaic_lines)
+        assert profile.archaism_rate > 0  # Has archaisms
+        assert profile.archaism_count > 0
+        assert profile.formality_score > 0.5  # Should be formal
+
+    def test_low_formality_informal_character(self):
+        informal_lines = [
+            _make_line("I'm not gonna do it, it's not right."),
+            _make_line("That's what I've been saying all along, isn't it?"),
+            _make_line("We're here, aren't we? So let's get it done."),
+        ]
+        profile = CharacterVoiceProfile.from_dialogue_lines("Informal", informal_lines)
+        assert profile.contraction_ratio > 0.05  # Has contractions
+        # Formality should be lower than archaic character
+
+    def test_archaism_rate_per_100_words(self):
+        # 2 archaic words in ~10 words = ~20 per 100
+        lines = [_make_line("Thee and thou art welcome here in this hall.")]
+        profile = CharacterVoiceProfile.from_dialogue_lines("A", lines)
+        assert profile.archaism_rate > 0
+
+    def test_imperative_ratio(self):
+        lines = [
+            _make_line("Go now.", imperative=True),
+            _make_line("Come to me.", imperative=True),
+            _make_line("I will help you.", imperative=False),
+            _make_line("We are here.", imperative=False),
+        ]
+        profile = CharacterVoiceProfile.from_dialogue_lines("C", lines)
+        assert profile.imperative_ratio == pytest.approx(0.5)
+
+    def test_verse_lines_counted(self):
+        lines = [
+            _make_line("Three rings for the Elven-kings.", verse=True),
+            _make_line("In the land of Mordor.", verse=True),
+            _make_line("I must go now.", verse=False),
+        ]
+        profile = CharacterVoiceProfile.from_dialogue_lines("Poet", lines)
+        assert profile.verse_lines == 2
+        assert profile.prose_lines == 1
+
+    def test_rhetorical_density(self):
+        lines = [
+            # Short rhetorical questions
+            _make_line("Who knows?"),
+            _make_line("What does it matter?"),
+            _make_line("Where are we going?"),  # Genuine question
+        ]
+        profile = CharacterVoiceProfile.from_dialogue_lines("Q", lines)
+        assert 0.0 <= profile.rhetorical_density <= 1.0
+
+    def test_topic_distribution_computed(self):
+        lines = [
+            _make_line("In the ancient age before the sun rose, the battle raged."),
+            _make_line("The war came to the valley and the army marched."),
+        ]
+        profile = CharacterVoiceProfile.from_dialogue_lines("Narrator", lines)
+        assert isinstance(profile.topic_distribution, dict)
+        # Some topics should be detected
+        total = sum(profile.topic_distribution.values())
+        if total > 0:
+            assert abs(total - 1.0) < 0.01  # Should be normalized
+
+    def test_never_says_computed_with_other_chars(self):
+        char_lines = [_make_line("I go to the mountain.")]
+        other_words = {
+            "OtherChar": __import__("collections").Counter(
+                ["precious", "precious", "gollum", "precious"]
+            ),
+        }
+        profile = CharacterVoiceProfile.from_dialogue_lines(
+            "Mine", char_lines, all_character_words=other_words
+        )
+        # If other char uses "precious" 3+ times and Mine never does, it should be in never_says
+        assert "precious" in profile.never_says
+
+    def test_audience_variant_metrics(self):
+        lines = [
+            _make_line("Come, dear hobbit.", audience="hobbit"),
+            _make_line("Come, dear hobbit.", audience="hobbit"),
+            _make_line("Hearken thee, O Elf.", audience="elf"),
+        ]
+        profile = CharacterVoiceProfile.from_dialogue_lines("G", lines)
+        assert "hobbit" in profile.length_by_audience
+        assert "elf" in profile.length_by_audience
+        assert "hobbit" in profile.formality_by_audience
+        assert "hobbit" in profile.register_by_audience
+
+    def test_register_by_audience_is_valid_context_type(self):
+        lines = [
+            _make_line("Run, hobbit!", audience="hobbit", context="crisis"),
+            _make_line("Flee now, hobbit!", audience="hobbit", context="crisis"),
+            _make_line("Farewell, elf.", audience="elf", context="farewell"),
+        ]
+        profile = CharacterVoiceProfile.from_dialogue_lines("A", lines)
+        if "hobbit" in profile.register_by_audience:
+            assert profile.register_by_audience["hobbit"] in CONTEXT_TYPES
+        if "elf" in profile.register_by_audience:
+            assert profile.register_by_audience["elf"] in CONTEXT_TYPES
+
+
+# ---------------------------------------------------------------------------
+# topic_distribution helper
+# ---------------------------------------------------------------------------
+
+class TestTopicDistribution:
+    def test_history_words_detected(self):
+        words = ["in", "the", "ancient", "age", "long", "ago", "tale", "legend"]
+        dist = _compute_topic_distribution(words)
+        assert "history" in dist
+
+    def test_practical_words_detected(self):
+        words = ["food", "water", "road", "fire", "camp", "eat"]
+        dist = _compute_topic_distribution(words)
+        assert "practical" in dist
+
+    def test_war_words_detected(self):
+        words = ["battle", "sword", "enemy", "army", "fight", "war"]
+        dist = _compute_topic_distribution(words)
+        assert "war" in dist
+
+    def test_normalized(self):
+        words = ["battle", "ancient", "food", "river", "friend"]
+        dist = _compute_topic_distribution(words)
+        if dist:
+            total = sum(dist.values())
+            assert abs(total - 1.0) < 0.01
+
+    def test_empty_returns_empty(self):
+        dist = _compute_topic_distribution([])
+        assert dist == {} or isinstance(dist, dict)
+
+
+# ---------------------------------------------------------------------------
+# VoiceAnalyzer.identify_speaker
+# ---------------------------------------------------------------------------
+
+class TestIdentifySpeaker:
+    def _make_profile(self, name, formality, archaism_rate, contraction_ratio,
+                      distinctive=None, signature=None, never=None):
+        p = CharacterVoiceProfile(character_name=name)
+        p.formality_score = formality
+        p.archaism_rate = archaism_rate
+        p.contraction_ratio = contraction_ratio
+        p.imperative_ratio = 0.1
+        p.avg_utterance_length = 10.0
+        p.question_ratio = 0.1
+        p.distinctive_words = distinctive or []
+        p.signature_phrases = signature or []
+        p.never_says = never or []
+        return p
+
+    def test_returns_list(self):
+        analyzer = VoiceAnalyzer()
+        profiles = {
+            "A": self._make_profile("A", 0.8, 4.0, 0.01),
+            "B": self._make_profile("B", 0.2, 0.1, 0.1),
+        }
+        result = analyzer.identify_speaker("Thou art welcome here.", profiles)
+        assert isinstance(result, list)
+        assert len(result) <= 2
+
+    def test_archaic_text_prefers_archaic_profile(self):
+        analyzer = VoiceAnalyzer()
+        profiles = {
+            "Gandalf": self._make_profile("Gandalf", 0.85, 4.5, 0.01,
+                                          distinctive=["thee", "thou", "pass"],
+                                          signature=["you shall not"]),
+            "Sam": self._make_profile("Sam", 0.15, 0.1, 0.12,
+                                      distinctive=["taters", "mr", "frodo"]),
+        }
+        # Archaic text should prefer Gandalf
+        result = analyzer.identify_speaker("Thou shalt not pass, thou fool!", profiles)
+        assert len(result) >= 1
+        # Gandalf should rank higher than Sam
+        char_names = [r[0] for r in result]
+        gandalf_idx = char_names.index("Gandalf") if "Gandalf" in char_names else 999
+        sam_idx = char_names.index("Sam") if "Sam" in char_names else 999
+        assert gandalf_idx < sam_idx
+
+    def test_informal_text_prefers_informal_profile(self):
+        analyzer = VoiceAnalyzer()
+        profiles = {
+            "Gandalf": self._make_profile("Gandalf", 0.85, 4.5, 0.01),
+            "Sam": self._make_profile("Sam", 0.15, 0.1, 0.12,
+                                      distinctive=["taters", "mr", "frodo", "begging"]),
+        }
+        result = analyzer.identify_speaker("I'm not sure we should, Mr. Frodo, begging your pardon.", profiles)
+        char_names = [r[0] for r in result]
+        sam_idx = char_names.index("Sam") if "Sam" in char_names else 999
+        gandalf_idx = char_names.index("Gandalf") if "Gandalf" in char_names else 999
+        assert sam_idx < gandalf_idx
+
+    def test_confidence_between_0_and_1(self):
+        analyzer = VoiceAnalyzer()
+        profiles = {
+            "A": self._make_profile("A", 0.5, 2.0, 0.05),
+        }
+        result = analyzer.identify_speaker("Hello there.", profiles)
+        for _, conf in result:
+            assert 0.0 <= conf <= 1.0
+
+    def test_top_n_respected(self):
+        analyzer = VoiceAnalyzer()
+        profiles = {
+            "A": self._make_profile("A", 0.5, 1.0, 0.05),
+            "B": self._make_profile("B", 0.6, 2.0, 0.03),
+            "C": self._make_profile("C", 0.4, 0.5, 0.08),
+            "D": self._make_profile("D", 0.7, 3.0, 0.01),
+        }
+        result = analyzer.identify_speaker("Test text.", profiles, top_n=2)
+        assert len(result) <= 2
+
+    def test_empty_profiles_returns_empty(self):
+        analyzer = VoiceAnalyzer()
+        result = analyzer.identify_speaker("Some text.", {})
+        assert result == []
+
+    def test_distinctive_word_overlap_boosts_score(self):
+        analyzer = VoiceAnalyzer()
+        profiles = {
+            "Gollum": self._make_profile("Gollum", 0.1, 0.3, 0.04,
+                                         distinctive=["precious", "nasty", "tricksy"],
+                                         signature=["my precious"]),
+            "Frodo": self._make_profile("Frodo", 0.5, 0.5, 0.05,
+                                        distinctive=["ring", "shire", "quest"]),
+        }
+        result = analyzer.identify_speaker("Precious, my precious! We wants it!", profiles)
+        char_names = [r[0] for r in result]
+        gollum_idx = char_names.index("Gollum") if "Gollum" in char_names else 999
+        frodo_idx = char_names.index("Frodo") if "Frodo" in char_names else 999
+        assert gollum_idx < frodo_idx
+
+
+# ---------------------------------------------------------------------------
+# VoiceAnalyzer.check_voice_violations
+# ---------------------------------------------------------------------------
+
+class TestCheckVoiceViolations:
+    def _gandalf_profile(self):
+        p = CharacterVoiceProfile(character_name="Gandalf")
+        p.formality_score = 0.85
+        p.archaism_rate = 4.0
+        p.contraction_ratio = 0.01
+        p.distinctive_words = ["pass", "fool", "shadow", "ancient"]
+        p.signature_phrases = ["you shall not", "the grey", "ancient days"]
+        p.never_says = ["taters", "begging", "pardon", "gaffer"]
+        return p
+
+    def test_no_violations_for_appropriate_text(self):
+        analyzer = VoiceAnalyzer()
+        profile = self._gandalf_profile()
+        violations = analyzer.check_voice_violations(
+            "You shall not pass! I am a servant of the Secret Fire.", profile
+        )
+        # Should be clean or only soft warnings
+        hard = [v for v in violations if v["severity"] == "hard"]
+        assert len(hard) == 0
+
+    def test_anachronism_detected(self):
+        analyzer = VoiceAnalyzer()
+        profile = self._gandalf_profile()
+        violations = analyzer.check_voice_violations(
+            "Yeah, sure, let's go dude. That's totally cool.", profile
+        )
+        types = [v["type"] for v in violations]
+        assert "anachronism" in types
+
+    def test_anachronism_is_hard(self):
+        analyzer = VoiceAnalyzer()
+        profile = self._gandalf_profile()
+        violations = analyzer.check_voice_violations(
+            "Okay yeah whatever.", profile
+        )
+        hard = [v for v in violations if v["type"] == "anachronism"]
+        assert len(hard) >= 1
+        assert hard[0]["severity"] == "hard"
+
+    def test_never_says_violation(self):
+        analyzer = VoiceAnalyzer()
+        profile = self._gandalf_profile()
+        violations = analyzer.check_voice_violations(
+            "Begging your pardon, sir, but taters are good.", profile
+        )
+        types = [v["type"] for v in violations]
+        assert "uses_never_says" in types
+
+    def test_never_says_is_soft(self):
+        analyzer = VoiceAnalyzer()
+        profile = self._gandalf_profile()
+        violations = analyzer.check_voice_violations(
+            "Begging your pardon.", profile
+        )
+        ns = [v for v in violations if v["type"] == "uses_never_says"]
+        if ns:
+            assert ns[0]["severity"] == "soft"
+
+    def test_wrong_formality_detected(self):
+        analyzer = VoiceAnalyzer()
+        # Highly formal profile
+        formal_profile = CharacterVoiceProfile(character_name="Elrond")
+        formal_profile.formality_score = 0.95
+        formal_profile.archaism_rate = 5.0
+        formal_profile.contraction_ratio = 0.0
+        formal_profile.distinctive_words = []
+        formal_profile.signature_phrases = []
+        formal_profile.never_says = []
+        
+        # Very informal text
+        violations = analyzer.check_voice_violations(
+            "I'm gonna do it alright. It's whatever.", formal_profile
+        )
+        types = [v["type"] for v in violations]
+        assert "wrong_formality" in types
+
+    def test_violations_have_required_keys(self):
+        analyzer = VoiceAnalyzer()
+        profile = self._gandalf_profile()
+        violations = analyzer.check_voice_violations("Okay yeah.", profile)
+        for v in violations:
+            assert "type" in v
+            assert "severity" in v
+            assert "message" in v
+
+    def test_empty_text_no_crash(self):
+        analyzer = VoiceAnalyzer()
+        profile = self._gandalf_profile()
+        violations = analyzer.check_voice_violations("", profile)
+        assert isinstance(violations, list)
+
+
+# ---------------------------------------------------------------------------
+# Integration: full pipeline produces expected profile structure
+# ---------------------------------------------------------------------------
+
+class TestVoiceProfileIntegration:
+    _sample_text = """
+    "Come, Mr. Frodo!" Sam called. "We must hurry now!"
+    "I can't go on," Frodo murmured. "I'm too tired."
+    "You shall not pass!" the wizard cried to the darkness.
+    "Thou art welcome in this hall, dear Elf," said the lord.
+    "Precious, my precious," whispered Gollum. "We wants it."
+    "Fear not," said Gandalf. "All shall be well in the end."
+    "Run! They are coming!" shouted Legolas.
+    "Go back to the shadows!" the wizard commanded.
+    """
+
+    def test_analyze_produces_profiles(self):
+        analyzer = VoiceAnalyzer(min_lines_for_profile=1)
+        result = analyzer.analyze_text(self._sample_text)
+        # Should find some characters
+        assert result.total_characters > 0
+
+    def test_profiles_have_new_fields(self):
+        analyzer = VoiceAnalyzer(min_lines_for_profile=1)
+        result = analyzer.analyze_text(self._sample_text)
+        for name, profile in result.profiles.items():
+            assert hasattr(profile, "formality_score")
+            assert hasattr(profile, "archaism_rate")
+            assert hasattr(profile, "rhetorical_density")
+            assert hasattr(profile, "imperative_ratio")
+            assert hasattr(profile, "formality_by_audience")
+            assert hasattr(profile, "length_by_audience")
+            assert hasattr(profile, "register_by_audience")
+            assert hasattr(profile, "never_says")
+            assert hasattr(profile, "topic_distribution")
+            assert hasattr(profile, "verse_lines")
+            assert hasattr(profile, "prose_lines")
+            assert 0.0 <= profile.formality_score <= 1.0
+            assert profile.archaism_rate >= 0.0
+            assert 0.0 <= profile.rhetorical_density <= 1.0
+            assert 0.0 <= profile.imperative_ratio <= 1.0
+
+    def test_profile_serialization_roundtrip(self):
+        """New fields survive to_json / from_json roundtrip."""
+        lines = [
+            _make_line("Thee art welcome here.", audience="elf", context="farewell"),
+            _make_line("Go now, and do not tarry.", audience="hobbit", context="command",
+                       imperative=True),
+        ]
+        profile = CharacterVoiceProfile.from_dialogue_lines("TestChar", lines)
+        
+        # Serialize and deserialize
+        json_str = profile.to_json()
+        restored = CharacterVoiceProfile.from_json(json_str)
+        
+        assert restored.character_name == "TestChar"
+        assert abs(restored.formality_score - profile.formality_score) < 0.001
+        assert abs(restored.archaism_rate - profile.archaism_rate) < 0.001
+        assert restored.verse_lines == profile.verse_lines
+        assert restored.prose_lines == profile.prose_lines
+        assert restored.formality_by_audience == profile.formality_by_audience
+        assert restored.length_by_audience == profile.length_by_audience
+        assert restored.register_by_audience == profile.register_by_audience
+        assert restored.topic_distribution == profile.topic_distribution


### PR DESCRIPTION
## Summary

Implements Issue #10: VoiceProfile + Audience-Variant Character Voice.

## New Modules

### oice/audience.py (new)
- classify_audience_type() — classifies who a character is speaking to: hobbit | elf | man | dwarf | enemy | neutral | self | prayer
- classify_context_type() — classifies the speech act: crisis | command | warning | comfort | farewell | explanation | statement
- classify_dialogue_line() → AudienceClassification dataclass

## Updated DialogueLine
- is_imperative: bool — detects command/request speech acts
- is_verse: bool — detects songs/poetry (internal newlines, O-invocations)
- udience_type: str — auto-classified from context windows
- context_type: str — auto-classified from dialogue text
- udience_confidence: float

## Updated CharacterVoiceProfile
New fields:
- ormality_score: float (0=informal, 1=formal) — composite of archaism rate, contraction ratio, avg word length
- rchaism_rate: float — archaisms per 100 words (not just count)
- hetorical_density: float — fraction of questions that are rhetorical
- imperative_ratio: float — fraction of lines that are commands
- ormality_by_audience: dict — formality score per audience type
- length_by_audience: dict — avg words per line per audience type
- egister_by_audience: dict — dominant context_type per audience
- 
ever_says: list[str] — words other characters use but this one never does
- 	opic_distribution: dict — normalized distribution across 6 topic buckets
- erse_lines: int / prose_lines: int

## Updated VoiceAnalyzer
- identify_speaker(text, profiles, top_n) — The Blindspot Test: ranks characters by likelihood of having spoken a given text using formality proximity, archaism rate, contraction ratio, distinctive word overlap, signature phrases, never-says penalty
- check_voice_violations(text, profile) — detects: wrong_formality, uses_never_says, anachronism (hard), missing_signature (soft)

## New CLI Commands
- ga voice identify --text 'You shall not pass!' — identifies most likely speaker
- ga voice check --text '...' --character Gandalf — checks voice consistency
- Both work with --results for pre-analyzed profiles, or with built-in Tolkien demo profiles

## Tests
60 tests in 	ests/test_voice_profile.py — all green.