### PR TITLE
[GEN-2] Implement Context Assembly Engine

### DIFF
--- a/docs/issue-20-context-assembly.md
+++ b/docs/issue-20-context-assembly.md
@@ -1,0 +1,38 @@
+# Issue #20 Design: Context Assembly Engine
+
+## Research references (patterns used)
+
+1. **Hierarchical Neural Story Generation** (Fan et al., 2018)  
+   <https://arxiv.org/abs/1805.04833>  
+   Pattern used: separate high-level planning context from realization text; keep prompts structured and layered.
+
+2. **Generative Agents** (Park et al., 2023)  
+   <https://arxiv.org/abs/2304.03442>  
+   Pattern used: retrieve compact, behavior-relevant memory snippets (recent events + current state) instead of full transcript replay.
+
+3. **CAMEL: Communicative Agents** (Li et al., 2023)  
+   <https://arxiv.org/abs/2303.17760>  
+   Pattern used: role/task coherence via concise shared context blocks so cooperating components stay aligned.
+
+4. **MemGPT** (Packer et al., 2023)  
+   <https://arxiv.org/abs/2310.08560>  
+   Pattern used: explicit memory tiering and bounded context surface (trimmed sections and caps) to control token growth.
+
+## Design decisions for this repo
+
+- Introduced `generate/context.py` with:
+  - `AssembledContext` dataclass for structured state (`character_states`, `recent_summaries`, `place_facts`, `active_plot_threads`)
+  - `ContextAssembler` that combines Shadow Graph state + canonical Place facts + outline-derived threads
+- Prompt serialization via `AssembledContext.to_prompt_block()` is intentionally compact:
+  - max 3 recent summaries
+  - max 3 place facts
+  - max 4 active plot threads
+- `SceneGenerator.generate_scene()` now accepts `assembled_context` directly (backward-compatible with existing `previous_context: str`).
+- Auto-assembly is supported when `SceneGenerator` is configured with `shadow_graph` and a `story_id` is available.
+- Added `Scene.context_snapshot` for debugging/auditability of exactly what context was injected at generation time.
+
+## Scope boundaries
+
+- No change to ShadowGraph mutation/extraction semantics.
+- No invasive outliner refactor; active threads are extracted from existing `Story.outline` and recent `Chapter.outline` text in Neo4j.
+- Existing callers that pass `previous_context` continue to work unchanged.

--- a/src/book_graph_analyzer/generate/__init__.py
+++ b/src/book_graph_analyzer/generate/__init__.py
@@ -10,6 +10,7 @@ from .models import Story, Chapter, Scene, GenerationConfig
 from .generator import SceneGenerator
 from .judge import NarrativeJudge
 from .writer import GenerationWriter
+from .context import ContextAssembler, AssembledContext
 
 __all__ = [
     "Story",
@@ -19,4 +20,6 @@ __all__ = [
     "SceneGenerator",
     "NarrativeJudge",
     "GenerationWriter",
+    "ContextAssembler",
+    "AssembledContext",
 ]

--- a/src/book_graph_analyzer/generate/context.py
+++ b/src/book_graph_analyzer/generate/context.py
@@ -1,0 +1,208 @@
+"""Context assembly engine for scene generation."""
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+from .shadow.graph import ShadowGraph
+from .shadow.models import CharacterState
+
+
+@dataclass
+class AssembledContext:
+    """Structured current-state context used by the scene generator."""
+
+    character_states: list[CharacterState] = field(default_factory=list)
+    recent_summaries: list[str] = field(default_factory=list)
+    place_facts: dict = field(default_factory=dict)
+    active_plot_threads: list[str] = field(default_factory=list)
+
+    def to_prompt_block(self) -> str:
+        """Serialize to a compact, LLM-readable context block."""
+        def _clip(text: str, max_len: int = 110) -> str:
+            if len(text) <= max_len:
+                return text
+            return text[: max_len - 3] + "..."
+
+        lines: list[str] = ["CURRENT STATE:"]
+
+        if self.character_states:
+            for character in self.character_states:
+                lines.append(f"- {_clip(character.to_prompt_fragment(), 100)}")
+        else:
+            lines.append("- Character state not yet established.")
+
+        if self.recent_summaries:
+            lines.append("\nRECENT EVENTS (last 3 scenes):")
+            for summary in self.recent_summaries[:3]:
+                lines.append(f"- {_clip(summary, 95)}")
+
+        place_name = self.place_facts.get("name") or "Unknown"
+        place_region = self.place_facts.get("region")
+        place_header = f"\nCURRENT PLACE — {place_name}"
+        if place_region:
+            place_header += f" ({place_region})"
+        place_header += ":"
+        lines.append(place_header)
+
+        description = self.place_facts.get("description")
+        if description:
+            lines.append(f"- {_clip(description, 95)}")
+
+        key_facts = self.place_facts.get("facts") or []
+        for fact in key_facts[:3]:
+            lines.append(f"- {_clip(str(fact), 90)}")
+
+        if self.active_plot_threads:
+            lines.append("\nACTIVE PLOT THREADS:")
+            for thread in self.active_plot_threads[:4]:
+                lines.append(f"- {_clip(thread, 90)}")
+
+        return "\n".join(lines)
+
+    def to_dict(self) -> dict:
+        return {
+            "character_states": [
+                {
+                    "name": s.name,
+                    "location": s.location,
+                    "possessions": s.possessions,
+                    "conditions": s.conditions,
+                }
+                for s in self.character_states
+            ],
+            "recent_summaries": self.recent_summaries,
+            "place_facts": self.place_facts,
+            "active_plot_threads": self.active_plot_threads,
+        }
+
+
+class ContextAssembler:
+    """Assembles a structured context block from Shadow Graph + Neo4j."""
+
+    def __init__(self, shadow_graph: Optional[ShadowGraph], neo4j_driver=None):
+        self.shadow_graph = shadow_graph
+        self.driver = neo4j_driver
+
+    def assemble(
+        self,
+        story_id: str,
+        characters: list[str],
+        place: str,
+        chapter_num: int,
+        scene_num: int,
+    ) -> AssembledContext:
+        _ = scene_num  # reserved for future ranking and retrieval
+
+        shadow = self._resolve_shadow_graph(story_id)
+        scene_state = shadow.get_scene_state(characters=characters, place=place) if shadow else None
+
+        return AssembledContext(
+            character_states=(scene_state.characters if scene_state else []),
+            recent_summaries=(scene_state.recent_summaries if scene_state else []),
+            place_facts=self._get_place_facts(place),
+            active_plot_threads=self._get_active_plot_threads(story_id, chapter_num),
+        )
+
+    def _resolve_shadow_graph(self, story_id: str) -> Optional[ShadowGraph]:
+        if self.shadow_graph and self.shadow_graph.story_id == story_id:
+            return self.shadow_graph
+
+        if not self.driver:
+            return None
+
+        return ShadowGraph(story_id=story_id, driver=self.driver)
+
+    def _get_place_facts(self, place: str) -> dict:
+        if not self.driver or not place:
+            return {}
+
+        with self.driver.session() as session:
+            result = session.run(
+                """
+                MATCH (p:Place)
+                WHERE toLower(p.name) CONTAINS toLower($name)
+                RETURN p.name as name,
+                       p.description as description,
+                       p.region as region,
+                       p.type as type,
+                       p.history as history
+                LIMIT 1
+                """,
+                name=place,
+            )
+            record = result.single()
+
+        if not record:
+            return {"name": place}
+
+        facts = []
+        if record.get("type"):
+            facts.append(f"Type: {record['type']}")
+        if record.get("history"):
+            facts.append(str(record["history"])[:180])
+
+        return {
+            "name": record.get("name") or place,
+            "description": (record.get("description") or "")[:220],
+            "region": record.get("region"),
+            "facts": facts,
+        }
+
+    def _get_active_plot_threads(self, story_id: str, chapter_num: int) -> list[str]:
+        if not self.driver:
+            return []
+
+        with self.driver.session() as session:
+            result = session.run(
+                """
+                MATCH (s:Story {id: $story_id})
+                OPTIONAL MATCH (s)-[:CONTAINS]->(c:Chapter)
+                WHERE c.number <= $chapter_num
+                RETURN s.outline as story_outline, c.number as chapter_num, c.outline as chapter_outline
+                ORDER BY c.number DESC
+                LIMIT 2
+                """,
+                story_id=story_id,
+                chapter_num=chapter_num,
+            )
+            rows = list(result)
+
+        if not rows:
+            return []
+
+        chunks = []
+        story_outline = rows[0].get("story_outline")
+        if story_outline:
+            chunks.append(story_outline)
+
+        for row in rows:
+            chapter_outline = row.get("chapter_outline")
+            if chapter_outline:
+                chunks.append(chapter_outline)
+
+        return self._extract_threads(chunks)
+
+    @staticmethod
+    def _extract_threads(chunks: list[str]) -> list[str]:
+        threads: list[str] = []
+        for chunk in chunks:
+            for raw in chunk.splitlines():
+                line = raw.strip().lstrip("-*0123456789. ").strip()
+                if not line:
+                    continue
+                if len(line) > 140:
+                    line = line[:137] + "..."
+                threads.append(line)
+
+        seen = set()
+        deduped = []
+        for thread in threads:
+            key = thread.lower()
+            if key in seen:
+                continue
+            seen.add(key)
+            deduped.append(thread)
+            if len(deduped) >= 4:
+                break
+
+        return deduped

--- a/src/book_graph_analyzer/generate/generator.py
+++ b/src/book_graph_analyzer/generate/generator.py
@@ -8,6 +8,7 @@ from typing import Optional
 from ..llm import LLMClient
 from ..graph.connection import get_driver
 from ..worldbible import WorldBible
+from .context import AssembledContext, ContextAssembler
 from .models import Scene, SceneScores, GenerationConfig, GenerationStatus
 from .judge import NarrativeJudge
 
@@ -111,11 +112,16 @@ ISSUES TO FIX:
 Rewrite the passage fixing these issues while maintaining Tolkien's style.
 Keep the same general content and length, just fix the problems.'''
 
-    def __init__(self, config: Optional[GenerationConfig] = None):
+    def __init__(self, config: Optional[GenerationConfig] = None, shadow_graph=None):
         self.config = config or GenerationConfig()
         self.llm = LLMClient()
         self.judge = NarrativeJudge()
         self.driver = get_driver()
+        self.shadow_graph = shadow_graph
+        self.context_assembler = ContextAssembler(
+            shadow_graph=shadow_graph,
+            neo4j_driver=self.driver,
+        )
         self.world_bible: Optional[WorldBible] = None
     
     def load_world_bible(self, path: str) -> None:
@@ -247,6 +253,10 @@ Keep the same general content and length, just fix the problems.'''
         previous_context: str = "",
         objects: list[str] = None,
         fog_of_war: bool = False,
+        assembled_context: Optional[AssembledContext] = None,
+        story_id: Optional[str] = None,
+        chapter_num: int = 0,
+        scene_num: int = 0,
     ) -> Scene:
         """Generate a scene with full pipeline.
 
@@ -286,12 +296,28 @@ Keep the same general content and length, just fix the problems.'''
                 for e in neo4j_context["recent_events"][:5]
             )
         
-        # 2. Generate initial scene
+        # 2. Assemble structured context if available
+        if not assembled_context and self.shadow_graph:
+            resolved_story_id = story_id or getattr(self.shadow_graph, "story_id", "")
+            if resolved_story_id:
+                assembled_context = self.context_assembler.assemble(
+                    story_id=resolved_story_id,
+                    characters=characters,
+                    place=place,
+                    chapter_num=chapter_num,
+                    scene_num=scene_num,
+                )
+
+        context_text = previous_context
+        if assembled_context:
+            context_text = assembled_context.to_prompt_block()
+
+        # 3. Generate initial scene
         if fog_of_war:
             # Fog of War: character only knows their own situation and the physical place.
             # No history, no events, no omniscient context — pure sensory grounding.
             character_knowledge = self._build_character_knowledge(
-                characters, previous_context
+                characters, context_text
             )
             prompt = self.FOG_OF_WAR_PROMPT.format(
                 setting=place_desc or place,
@@ -306,7 +332,7 @@ Keep the same general content and length, just fix the problems.'''
                 setting=place_desc or place,
                 characters="\n".join(char_descriptions) or ", ".join(characters),
                 objects=", ".join(objects or []) or "None specified",
-                previous_context=previous_context or events_text or "Beginning of story",
+                previous_context=context_text or events_text or "Beginning of story",
                 scene_goal=scene_goal,
                 world_rules=self.get_world_rules(),
             )
@@ -324,6 +350,7 @@ Keep the same general content and length, just fix the problems.'''
             objects=objects or [],
             model_used=self.config.model,
             generation_prompt=prompt,
+            context_snapshot=assembled_context,
         )
         
         # 4. Constitutional critique loop
@@ -339,10 +366,10 @@ Keep the same general content and length, just fix the problems.'''
             # Revise
             scene.text = self._revise_scene(scene.text, violations)
         
-        # 5. Score the scene
-        scene.scores = self._score_scene(scene, previous_context)
+        # 6. Score the scene
+        scene.scores = self._score_scene(scene, context_text)
         
-        # 6. Flag if below threshold
+        # 7. Flag if below threshold
         if scene.scores.overall < self.config.min_quality_score:
             scene.status = GenerationStatus.FLAGGED
         

--- a/src/book_graph_analyzer/generate/models.py
+++ b/src/book_graph_analyzer/generate/models.py
@@ -1,5 +1,7 @@
 """Data models for story generation."""
 
+from __future__ import annotations
+
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Optional
@@ -108,6 +110,7 @@ class Scene:
     generated_at: datetime = field(default_factory=datetime.now)
     model_used: str = ""
     generation_prompt: str = ""
+    context_snapshot: Optional["AssembledContext"] = None
     
     def __post_init__(self):
         if not self.word_count:
@@ -130,6 +133,9 @@ class Scene:
             "word_count": self.word_count,
             "generated_at": self.generated_at.isoformat(),
             "model_used": self.model_used,
+            "context_snapshot": (
+                self.context_snapshot.to_dict() if self.context_snapshot else None
+            ),
         }
 
 

--- a/tests/test_context_assembly.py
+++ b/tests/test_context_assembly.py
@@ -1,0 +1,135 @@
+from unittest.mock import MagicMock
+
+
+def test_assembled_context_prompt_block_is_compact():
+    from book_graph_analyzer.generate.context import AssembledContext
+    from book_graph_analyzer.generate.shadow.models import CharacterState
+
+    context = AssembledContext(
+        character_states=[
+            CharacterState(
+                name="Tuor",
+                story_id="story-1",
+                location="Echoriath foothills",
+                possessions=["Sword of Turgon", "Grey Cloak"],
+                conditions=["weary", "determined"],
+            ),
+            CharacterState(
+                name="Voronwe",
+                story_id="story-1",
+                location="Echoriath foothills",
+                conditions=["resolute"],
+            ),
+        ],
+        recent_summaries=[
+            "Tuor and Voronwe fled an Orc ambush near Sirion.",
+            "They found a hidden pass marked by Ulmo's sign.",
+            "Voronwe revealed the Hidden City's name.",
+        ],
+        place_facts={
+            "name": "Echoriath",
+            "region": "Beleriand",
+            "description": "The Encircling Mountains around Gondolin.",
+            "facts": ["Hidden passes are guarded", "The ridges are steep and cold"],
+        },
+        active_plot_threads=[
+            "Reach Gondolin without alerting Morgoth's scouts",
+            "Protect Tuor's mission from Ulmo",
+        ],
+    )
+
+    block = context.to_prompt_block()
+    assert "CURRENT STATE" in block
+    assert "RECENT EVENTS" in block
+    assert "CURRENT PLACE" in block
+    assert "ACTIVE PLOT THREADS" in block
+
+    estimated_tokens = len(block) / 4
+    assert estimated_tokens < 400
+
+
+def test_context_assembler_merges_shadow_and_neo4j_data():
+    from book_graph_analyzer.generate.context import ContextAssembler
+    from book_graph_analyzer.generate.shadow.models import CharacterState, SceneState
+
+    shadow_graph = MagicMock()
+    shadow_graph.story_id = "story-1"
+    shadow_graph.get_scene_state.return_value = SceneState(
+        characters=[CharacterState(name="Tuor", story_id="story-1", location="Echoriath")],
+        recent_summaries=["They crossed a frozen stream."],
+    )
+
+    driver = MagicMock()
+    session = MagicMock()
+    driver.session.return_value.__enter__.return_value = session
+    driver.session.return_value.__exit__.return_value = False
+
+    place_result = MagicMock()
+    place_result.single.return_value = {
+        "name": "Echoriath",
+        "description": "A wall of mountains guarding Gondolin.",
+        "region": "Beleriand",
+        "type": "mountains",
+        "history": "Known to hide secret ways.",
+    }
+
+    outline_rows = [
+        {
+            "story_outline": "- Reach Gondolin\n- Avoid Orc patrols",
+            "chapter_num": 1,
+            "chapter_outline": "- Cross the foothills",
+        }
+    ]
+
+    def run_side_effect(query, **kwargs):
+        if "MATCH (p:Place)" in query:
+            return place_result
+        result = MagicMock()
+        result.__iter__.return_value = iter(outline_rows)
+        return result
+
+    session.run.side_effect = run_side_effect
+
+    assembler = ContextAssembler(shadow_graph=shadow_graph, neo4j_driver=driver)
+    assembled = assembler.assemble(
+        story_id="story-1",
+        characters=["Tuor"],
+        place="Echoriath",
+        chapter_num=1,
+        scene_num=2,
+    )
+
+    assert assembled.character_states[0].name == "Tuor"
+    assert assembled.place_facts["name"] == "Echoriath"
+    assert any("Reach Gondolin" in t for t in assembled.active_plot_threads)
+
+
+def test_scene_generator_accepts_assembled_context():
+    from book_graph_analyzer.generate.context import AssembledContext
+    from book_graph_analyzer.generate.generator import SceneGenerator
+
+    generator = SceneGenerator()
+    generator.driver = None
+    generator.llm = MagicMock()
+    generator.llm.generate.return_value = "Scene text"
+    from book_graph_analyzer.generate.models import SceneScores
+
+    generator.judge = MagicMock()
+    scores = SceneScores(style_score=0.8, narrative_score=0.8)
+    generator.judge.full_evaluation.return_value = (scores, "", [])
+    generator._critique_scene = MagicMock(return_value=[])
+
+    assembled = AssembledContext(
+        recent_summaries=["Summary A"],
+        place_facts={"name": "Gondolin", "description": "Hidden city."},
+    )
+
+    scene = generator.generate_scene(
+        scene_goal="Advance toward the hidden gate",
+        characters=["Tuor"],
+        place="Gondolin approaches",
+        assembled_context=assembled,
+    )
+
+    assert scene.context_snapshot is assembled
+    assert "CURRENT STATE" in scene.generation_prompt


### PR DESCRIPTION
## Summary\nImplements issue #20 by adding a structured context assembly path for scene generation.\n\n### What shipped\n- Added generate/context.py:\n  - AssembledContext dataclass (character_states, ecent_summaries, place_facts, ctive_plot_threads)\n  - ContextAssembler combining Shadow Graph state + canonical Place facts + outline-derived plot threads\n  - Compact 	o_prompt_block() serialization with bounded sections\n- Updated SceneGenerator to:\n  - accept ssembled_context directly\n  - auto-assemble context when configured with a shadow_graph + story_id\n  - preserve backward compatibility with existing previous_context: str flow\n  - persist context used at generation time via scene snapshot\n- Updated Scene model with context_snapshot for debugging/auditability\n- Added focused design doc + research references in docs/issue-20-context-assembly.md\n- Added tests in 	ests/test_context_assembly.py\n\n## Testing\n- pytest -q tests/test_context_assembly.py tests/test_shadow_graph.py tests/test_incubator.py\n  - Result: **29 passed**\n\nFixes #20