### PR TITLE
Implement outliner workflow and review models

### DIFF
--- a/docs/issue-21-outliner-design.md
+++ b/docs/issue-21-outliner-design.md
@@ -1,0 +1,60 @@
+# Issue #21 Design: Outliner Engine (Whitespace Interpolator)
+
+## Goal
+Add an `OutlinerEngine` that can:
+1. Resolve two canonical anchor events from Neo4j EventGraph.
+2. Generate a structured chapter outline in the whitespace between anchors.
+3. Inject constraints from World Bible + known in-gap events.
+4. Expose this end-to-end via CLI (`bga generate outline`) and save JSON output.
+
+## Research references (concise)
+1. Dynamic hierarchical outlining for long-form story generation (DOME): outlines improve coherence and long-horizon planning.  
+   <https://aclanthology.org/2025.naacl-long.63/>
+2. ArXiv HTML mirror of DOME showing planner/writer split and JSON planning prompts.  
+   <https://arxiv.org/html/2412.13575v1>
+3. StoryWriter multi-agent framework: distinct planning stage before prose generation.  
+   <https://openreview.net/pdf?id=FQj3KK0Qg4>
+4. OpenAI structured outputs guidance (schema-constrained JSON) for reliable machine parsing.  
+   <https://platform.openai.com/docs/guides/structured-outputs>
+5. JSON Schema 2020-12 core spec for robust, tool-friendly structured payloads.  
+   <https://json-schema.org/draft/2020-12/json-schema-core.html>
+
+## Design decisions
+
+### 1) New module: `generate/outliner.py`
+- Added core models:
+  - `CanonicalEvent`
+  - `ChapterOutline`
+  - `StoryOutline`
+- Added `OutlinerEngine` methods:
+  - `find_anchor_points(character, point_a_hint, point_b_hint)`
+  - `generate_story_outline(anchor_a, anchor_b, num_chapters, character)`
+  - `generate_chapter_outline(story_outline, chapter_num, num_scenes)`
+
+### 2) Anchor resolution strategy
+- Query `(:Event)` nodes by character relevance (`agent/description/patient`) and hint overlap.
+- Rank by simple score + year ordering.
+- Return concrete graph-backed anchor event payloads.
+
+### 3) Constraint injection strategy
+- World Bible: select relevant rules by matching character/era terms; fallback to a short global rule subset.
+- EventGraph: gather known in-gap events and inject as exclusion list (`DO NOT DEPICT OR REWRITE`).
+- Prompt output required as strict JSON chapter beats (intent-level, not prose).
+
+### 4) Existing model extension
+- `generate.models.Chapter` now includes:
+  - `canonical_constraint`
+  - `plot_thread_opens`
+  - `plot_thread_closes`
+- Included in `Chapter.to_dict()` for serialization stability.
+
+### 5) CLI integration
+- New command:
+  - `bga generate outline --character Tuor --from "arrives in Nevrast" --to "reaches Gondolin" --chapters 10`
+- Supports optional `--world-bible` and `--output`.
+- If `--output` omitted, writes to `data/output/outline_<character>_<id>.json`.
+
+## Scope notes
+- Keeps implementation focused to issue #21 (planner/outliner layer).
+- Does not attempt full scene prose generation pipeline changes.
+- Uses existing LLM abstraction and Neo4j connection patterns already in repository.

--- a/src/book_graph_analyzer/cli.py
+++ b/src/book_graph_analyzer/cli.py
@@ -4151,6 +4151,61 @@ def generate_scene(
         console.print(f"\n[green]OK[/green] Written to Neo4j: {stats}")
 
 
+@generate.command(name="outline")
+@click.option("--character", "character", required=True, help="Primary character for the interpolation")
+@click.option("--from", "point_a", required=True, help="Anchor A hint (e.g., 'arrives in Nevrast')")
+@click.option("--to", "point_b", required=True, help="Anchor B hint (e.g., 'reaches Gondolin')")
+@click.option("--chapters", default=10, type=int, show_default=True, help="Number of chapter beats")
+@click.option("--world-bible", "world_bible", type=click.Path(exists=True), help="World bible JSON for hard constraints")
+@click.option("--output", "output", type=click.Path(), help="Output JSON file path")
+def generate_outline(
+    character: str,
+    point_a: str,
+    point_b: str,
+    chapters: int,
+    world_bible: str | None,
+    output: str | None,
+) -> None:
+    """Generate a chapter outline between two canonical anchor events.
+
+    Example:
+        bga generate outline --character Tuor --from "arrives in Nevrast" --to "reaches Gondolin" --chapters 10
+    """
+    from book_graph_analyzer.generate import OutlinerEngine
+
+    engine = OutlinerEngine()
+    if world_bible:
+        engine.load_world_bible(world_bible)
+        console.print(f"[dim]Loaded world bible: {world_bible}[/dim]")
+
+    with console.status("Finding canonical anchor points..."):
+        anchor_a, anchor_b = engine.find_anchor_points(character, point_a, point_b)
+
+    console.print("[bold]Anchor points[/bold]")
+    console.print(f"  A: {anchor_a.description} ({anchor_a.era or 'Unknown'} {anchor_a.year or ''})")
+    console.print(f"  B: {anchor_b.description} ({anchor_b.era or 'Unknown'} {anchor_b.year or ''})")
+
+    with console.status("Generating story outline..."):
+        outline = engine.generate_story_outline(
+            anchor_a=anchor_a,
+            anchor_b=anchor_b,
+            num_chapters=chapters,
+            character=character,
+        )
+
+    if not output:
+        slug = character.lower().replace(" ", "_")
+        output = str(Path("data") / "output" / f"outline_{slug}_{outline.id}.json")
+
+    output_path = Path(output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "w", encoding="utf-8") as f:
+        json.dump(outline.to_dict(), f, indent=2, ensure_ascii=False)
+
+    console.print(f"\n[green]OK[/green] Outline saved to {output_path}")
+    console.print(f"[bold]Chapters generated:[/bold] {len(outline.chapters)}")
+
+
 @generate.command(name="init-schema")
 def generate_init_schema() -> None:
     """Initialize Neo4j schema for generated content."""

--- a/src/book_graph_analyzer/extract/relationships.py
+++ b/src/book_graph_analyzer/extract/relationships.py
@@ -24,11 +24,13 @@ from .resolver import EntityResolver, ResolvedEntity
 VERB_TO_RELATIONSHIP: dict[str, RelationshipType] = {
     # Speech
     "say": RelationshipType.SPOKE_TO,
+    "said": RelationshipType.SPOKE_TO,
     "ask": RelationshipType.SPOKE_TO,
     "tell": RelationshipType.SPOKE_TO,
     "answer": RelationshipType.SPOKE_TO,
     "reply": RelationshipType.SPOKE_TO,
     "speak": RelationshipType.SPOKE_WITH,
+    "spoke": RelationshipType.SPOKE_WITH,
     "talk": RelationshipType.SPOKE_WITH,
     "call": RelationshipType.SPOKE_TO,
     "cry": RelationshipType.SPOKE_TO,
@@ -37,7 +39,9 @@ VERB_TO_RELATIONSHIP: dict[str, RelationshipType] = {
 
     # Movement
     "go": RelationshipType.TRAVELED_TO,
+    "went": RelationshipType.TRAVELED_TO,
     "travel": RelationshipType.TRAVELED_TO,
+    "traveled": RelationshipType.TRAVELED_TO,
     "come": RelationshipType.TRAVELED_TO,
     "arrive": RelationshipType.TRAVELED_TO,
     "reach": RelationshipType.TRAVELED_TO,
@@ -50,8 +54,10 @@ VERB_TO_RELATIONSHIP: dict[str, RelationshipType] = {
 
     # Combat
     "fight": RelationshipType.FOUGHT,
+    "fought": RelationshipType.FOUGHT,
     "attack": RelationshipType.FOUGHT_AGAINST,
     "kill": RelationshipType.KILLED,
+    "killed": RelationshipType.KILLED,
     "slay": RelationshipType.KILLED,
     "defeat": RelationshipType.FOUGHT_AGAINST,
     "capture": RelationshipType.CAPTURED,
@@ -59,8 +65,10 @@ VERB_TO_RELATIONSHIP: dict[str, RelationshipType] = {
 
     # Objects
     "give": RelationshipType.GAVE,
+    "gave": RelationshipType.GAVE,
     "receive": RelationshipType.RECEIVED,
     "take": RelationshipType.POSSESSES,
+    "took": RelationshipType.POSSESSES,
     "find": RelationshipType.FOUND,
     "lose": RelationshipType.LOST,
     "steal": RelationshipType.STOLE,
@@ -71,14 +79,17 @@ VERB_TO_RELATIONSHIP: dict[str, RelationshipType] = {
 
     # Social
     "meet": RelationshipType.MET,
+    "met": RelationshipType.MET,
     "join": RelationshipType.ALLIED_WITH,
     "help": RelationshipType.HELPED,
+    "helped": RelationshipType.HELPED,
     "serve": RelationshipType.SERVES,
     "lead": RelationshipType.LEADS,
     "betray": RelationshipType.BETRAYED,
 
     # Location
     "live": RelationshipType.LIVES_IN,
+    "lived": RelationshipType.LIVES_IN,
     "dwell": RelationshipType.LIVES_IN,
     "visit": RelationshipType.VISITED,
     "rule": RelationshipType.RULES,

--- a/src/book_graph_analyzer/generate/__init__.py
+++ b/src/book_graph_analyzer/generate/__init__.py
@@ -11,6 +11,7 @@ from .generator import SceneGenerator
 from .judge import NarrativeJudge
 from .writer import GenerationWriter
 from .context import ContextAssembler, AssembledContext
+from .outliner import OutlinerEngine, StoryOutline, ChapterOutline, CanonicalEvent
 
 __all__ = [
     "Story",
@@ -22,4 +23,8 @@ __all__ = [
     "GenerationWriter",
     "ContextAssembler",
     "AssembledContext",
+    "OutlinerEngine",
+    "StoryOutline",
+    "ChapterOutline",
+    "CanonicalEvent",
 ]

--- a/src/book_graph_analyzer/generate/models.py
+++ b/src/book_graph_analyzer/generate/models.py
@@ -151,6 +151,9 @@ class Chapter:
     
     # Planning
     outline: str = ""  # Beat-by-beat outline
+    canonical_constraint: str = ""
+    plot_thread_opens: str = ""
+    plot_thread_closes: str = ""
     target_scenes: int = 5
     
     def add_scene(self, scene: Scene) -> None:
@@ -164,6 +167,9 @@ class Chapter:
             "title": self.title,
             "summary": self.summary,
             "outline": self.outline,
+            "canonical_constraint": self.canonical_constraint,
+            "plot_thread_opens": self.plot_thread_opens,
+            "plot_thread_closes": self.plot_thread_closes,
             "scenes": [s.to_dict() for s in self.scenes],
         }
 

--- a/src/book_graph_analyzer/generate/outliner.py
+++ b/src/book_graph_analyzer/generate/outliner.py
@@ -1,0 +1,398 @@
+"""Outliner engine for whitespace interpolation between canonical events."""
+
+from __future__ import annotations
+
+import json
+import re
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Optional
+
+from ..graph.connection import get_driver
+from ..llm import LLMClient
+from ..worldbible import WorldBible
+from .models import Chapter
+
+
+@dataclass
+class CanonicalEvent:
+    """Event anchor from the canonical EventGraph."""
+
+    id: str
+    description: str
+    era: str = ""
+    year: Optional[int] = None
+    agent: str = ""
+    source_book: str = ""
+
+
+@dataclass
+class ChapterOutline:
+    """Structured chapter beat returned by the outliner."""
+
+    number: int
+    title: str
+    beat: str
+    characters: list[str] = field(default_factory=list)
+    setting: str = ""
+    canonical_constraint: str = ""
+    plot_thread_opens: Optional[str] = None
+    plot_thread_closes: Optional[str] = None
+
+    def to_chapter(self) -> Chapter:
+        return Chapter(
+            id=f"ch_{self.number:02d}",
+            number=self.number,
+            title=self.title,
+            summary=self.beat,
+            outline=self.beat,
+            canonical_constraint=self.canonical_constraint,
+            plot_thread_opens=self.plot_thread_opens or "",
+            plot_thread_closes=self.plot_thread_closes or "",
+        )
+
+    def to_dict(self) -> dict:
+        return {
+            "number": self.number,
+            "title": self.title,
+            "beat": self.beat,
+            "characters": self.characters,
+            "setting": self.setting,
+            "canonical_constraint": self.canonical_constraint,
+            "plot_thread_opens": self.plot_thread_opens,
+            "plot_thread_closes": self.plot_thread_closes,
+        }
+
+
+@dataclass
+class StoryOutline:
+    """Full story outline between two canonical anchors."""
+
+    id: str
+    character: str
+    anchor_a: CanonicalEvent
+    anchor_b: CanonicalEvent
+    chapters: list[ChapterOutline] = field(default_factory=list)
+    generated_at: datetime = field(default_factory=datetime.now)
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "character": self.character,
+            "anchor_a": self.anchor_a.__dict__,
+            "anchor_b": self.anchor_b.__dict__,
+            "chapters": [c.to_dict() for c in self.chapters],
+            "generated_at": self.generated_at.isoformat(),
+        }
+
+
+class OutlinerEngine:
+    """Generates hierarchical story outlines between canonical anchor points."""
+
+    STORY_OUTLINE_PROMPT = """You are generating a chapter-level plot outline between two canonical events.
+
+CHARACTER: {character}
+
+ANCHOR A (already happened):
+- {anchor_a}
+
+ANCHOR B (must happen next):
+- {anchor_b}
+
+WORLD BIBLE HARD CONSTRAINTS:
+{world_rules}
+
+KNOWN CANONICAL EVENTS IN THIS GAP (DO NOT DEPICT OR REWRITE THESE):
+{blocked_events}
+
+Write exactly {num_chapters} chapter beats as JSON only.
+Use intent-level beats, not prose scenes.
+
+Output schema:
+{{
+  "chapters": [
+    {{
+      "number": 1,
+      "title": "...",
+      "beat": "...",
+      "characters": ["..."],
+      "setting": "...",
+      "canonical_constraint": "...",
+      "plot_thread_opens": "... or null",
+      "plot_thread_closes": "... or null"
+    }}
+  ]
+}}
+"""
+
+    CHAPTER_OUTLINE_PROMPT = """Expand this chapter beat into a scene-by-scene outline.
+
+CHAPTER NUMBER: {chapter_num}
+CHAPTER TITLE: {title}
+BEAT: {beat}
+CHARACTERS: {characters}
+SETTING: {setting}
+
+Return JSON with this schema:
+{{
+  "chapter": {chapter_num},
+  "scenes": [
+    {{"scene": 1, "intent": "...", "goal": "...", "setting": "...", "characters": ["..."]}}
+  ]
+}}
+
+Generate exactly {num_scenes} scenes.
+"""
+
+    def __init__(self, llm: Optional[LLMClient] = None, driver=None):
+        self.llm = llm or LLMClient()
+        self.driver = driver if driver is not None else get_driver()
+        self.world_bible: Optional[WorldBible] = None
+
+    def load_world_bible(self, path: str) -> None:
+        self.world_bible = WorldBible.load(path)
+
+    def find_anchor_points(
+        self,
+        character: str,
+        point_a_hint: str,
+        point_b_hint: str,
+    ) -> tuple[CanonicalEvent, CanonicalEvent]:
+        """Query EventGraph for the closest matching canonical events."""
+        if not self.driver:
+            raise RuntimeError("Neo4j driver not available")
+
+        with self.driver.session() as session:
+            anchor_a = self._query_anchor(session, character, point_a_hint)
+            anchor_b = self._query_anchor(session, character, point_b_hint)
+
+        return anchor_a, anchor_b
+
+    def generate_story_outline(
+        self,
+        anchor_a: CanonicalEvent,
+        anchor_b: CanonicalEvent,
+        num_chapters: int = 10,
+        character: str = "",
+    ) -> StoryOutline:
+        """LLM-generate a chapter outline interpolating between two canon points."""
+        blocked = self._events_in_gap(anchor_a, anchor_b, character)
+        prompt = self.STORY_OUTLINE_PROMPT.format(
+            character=character or anchor_a.agent or "Unknown",
+            anchor_a=self._event_text(anchor_a),
+            anchor_b=self._event_text(anchor_b),
+            world_rules=self._hard_rules_text(character, [anchor_a.era, anchor_b.era]),
+            blocked_events=self._blocked_events_text(blocked),
+            num_chapters=num_chapters,
+        )
+
+        raw = self.llm.generate(prompt, temperature=0.3, max_tokens=2500)
+        payload = self._extract_json(raw)
+
+        chapter_rows = payload.get("chapters", []) if isinstance(payload, dict) else []
+        chapters = [self._parse_chapter_row(r, idx + 1) for idx, r in enumerate(chapter_rows)]
+
+        return StoryOutline(
+            id=f"outline_{str(uuid.uuid4())[:8]}",
+            character=character or anchor_a.agent,
+            anchor_a=anchor_a,
+            anchor_b=anchor_b,
+            chapters=chapters,
+        )
+
+    def generate_chapter_outline(
+        self,
+        story_outline: StoryOutline,
+        chapter_num: int,
+        num_scenes: int = 5,
+    ) -> ChapterOutline:
+        """Expand a chapter beat into a scene-by-scene outline."""
+        chapter = next((c for c in story_outline.chapters if c.number == chapter_num), None)
+        if not chapter:
+            raise ValueError(f"Chapter {chapter_num} not found")
+
+        prompt = self.CHAPTER_OUTLINE_PROMPT.format(
+            chapter_num=chapter.number,
+            title=chapter.title,
+            beat=chapter.beat,
+            characters=", ".join(chapter.characters) or "None",
+            setting=chapter.setting or "Unknown",
+            num_scenes=num_scenes,
+        )
+
+        raw = self.llm.generate(prompt, temperature=0.4, max_tokens=1500)
+        payload = self._extract_json(raw)
+
+        scenes = payload.get("scenes", []) if isinstance(payload, dict) else []
+        chapter.beat = json.dumps({"chapter": chapter.number, "scenes": scenes}, ensure_ascii=False)
+        return chapter
+
+    def _query_anchor(self, session, character: str, hint: str) -> CanonicalEvent:
+        result = session.run(
+            """
+            MATCH (e:Event)
+            WHERE (
+                toLower(coalesce(e.agent, "")) CONTAINS toLower($character)
+                OR toLower(coalesce(e.description, "")) CONTAINS toLower($character)
+                OR toLower(coalesce(e.patient, "")) CONTAINS toLower($character)
+            )
+            WITH e,
+                 (CASE WHEN toLower(coalesce(e.description, "")) CONTAINS toLower($hint) THEN 3 ELSE 0 END) +
+                 (CASE WHEN toLower(coalesce(e.action, "")) CONTAINS toLower($hint) THEN 1 ELSE 0 END) +
+                 (CASE WHEN toLower(coalesce(e.agent, "")) CONTAINS toLower($hint) THEN 1 ELSE 0 END) AS score
+            RETURN
+                coalesce(e.id, elementId(e)) AS id,
+                coalesce(e.description, "") AS description,
+                coalesce(e.era, "") AS era,
+                e.year AS year,
+                coalesce(e.agent, "") AS agent,
+                coalesce(e.source_book, "") AS source_book,
+                score
+            ORDER BY score DESC, year ASC
+            LIMIT 1
+            """,
+            character=character,
+            hint=hint,
+        ).single()
+
+        if not result:
+            raise ValueError(f"No canonical event found for character='{character}' and hint='{hint}'")
+
+        return CanonicalEvent(
+            id=result["id"],
+            description=result["description"],
+            era=result["era"],
+            year=result["year"],
+            agent=result["agent"],
+            source_book=result["source_book"],
+        )
+
+    def _events_in_gap(
+        self,
+        anchor_a: CanonicalEvent,
+        anchor_b: CanonicalEvent,
+        character: str,
+    ) -> list[CanonicalEvent]:
+        if not self.driver:
+            return []
+
+        with self.driver.session() as session:
+            # Best-effort temporal query. We only enforce year bounds when both anchors have years.
+            if anchor_a.year is not None and anchor_b.year is not None and anchor_a.era == anchor_b.era:
+                rows = session.run(
+                    """
+                    MATCH (e:Event)
+                    WHERE toLower(coalesce(e.agent, "")) CONTAINS toLower($character)
+                      AND coalesce(e.era, "") = $era
+                      AND e.year IS NOT NULL
+                      AND e.year > $start_year
+                      AND e.year < $end_year
+                    RETURN coalesce(e.id, elementId(e)) AS id,
+                           coalesce(e.description, "") AS description,
+                           coalesce(e.era, "") AS era,
+                           e.year AS year,
+                           coalesce(e.agent, "") AS agent,
+                           coalesce(e.source_book, "") AS source_book
+                    ORDER BY e.year ASC
+                    LIMIT 50
+                    """,
+                    character=character,
+                    era=anchor_a.era,
+                    start_year=min(anchor_a.year, anchor_b.year),
+                    end_year=max(anchor_a.year, anchor_b.year),
+                )
+            else:
+                rows = session.run(
+                    """
+                    MATCH (e:Event)
+                    WHERE toLower(coalesce(e.agent, "")) CONTAINS toLower($character)
+                      AND coalesce(e.id, elementId(e)) <> $a_id
+                      AND coalesce(e.id, elementId(e)) <> $b_id
+                    RETURN coalesce(e.id, elementId(e)) AS id,
+                           coalesce(e.description, "") AS description,
+                           coalesce(e.era, "") AS era,
+                           e.year AS year,
+                           coalesce(e.agent, "") AS agent,
+                           coalesce(e.source_book, "") AS source_book
+                    ORDER BY e.year ASC
+                    LIMIT 20
+                    """,
+                    character=character,
+                    a_id=anchor_a.id,
+                    b_id=anchor_b.id,
+                )
+
+            return [
+                CanonicalEvent(
+                    id=r["id"],
+                    description=r["description"],
+                    era=r["era"],
+                    year=r["year"],
+                    agent=r["agent"],
+                    source_book=r["source_book"],
+                )
+                for r in rows
+            ]
+
+    def _hard_rules_text(self, character: str, eras: list[str]) -> str:
+        if not self.world_bible:
+            return "No world bible loaded. Preserve Tolkien-consistent behavior and chronology."
+
+        terms = [character.lower()] + [e.lower() for e in eras if e]
+        selected: list[str] = []
+        for category_rules in self.world_bible.rules.values():
+            for rule in category_rules:
+                blob = f"{rule.title} {rule.description} {' '.join(rule.related_entities)}".lower()
+                if any(t and t in blob for t in terms):
+                    selected.append(f"- [{rule.category.value}] {rule.title}: {rule.description}")
+
+        if not selected:
+            # fallback: short global subset
+            for category_rules in self.world_bible.rules.values():
+                for rule in category_rules[:1]:
+                    selected.append(f"- [{rule.category.value}] {rule.title}: {rule.description}")
+                    if len(selected) >= 8:
+                        break
+                if len(selected) >= 8:
+                    break
+
+        return "\n".join(selected[:12])
+
+    @staticmethod
+    def _event_text(e: CanonicalEvent) -> str:
+        when = f" ({e.era} {e.year})" if e.year is not None else (f" ({e.era})" if e.era else "")
+        return f"{e.description}{when}".strip()
+
+    @staticmethod
+    def _blocked_events_text(events: list[CanonicalEvent]) -> str:
+        if not events:
+            return "- None explicitly known in graph for this interval"
+        return "\n".join(f"- {OutlinerEngine._event_text(e)}" for e in events[:20])
+
+    @staticmethod
+    def _parse_chapter_row(row: dict, default_number: int) -> ChapterOutline:
+        return ChapterOutline(
+            number=int(row.get("number", default_number)),
+            title=str(row.get("title", f"Chapter {default_number}")),
+            beat=str(row.get("beat", "")),
+            characters=list(row.get("characters", [])),
+            setting=str(row.get("setting", "")),
+            canonical_constraint=str(row.get("canonical_constraint", "")),
+            plot_thread_opens=row.get("plot_thread_opens"),
+            plot_thread_closes=row.get("plot_thread_closes"),
+        )
+
+    def _extract_json(self, text: str) -> dict:
+        parsed = self.llm.extract_json(text)
+        if isinstance(parsed, dict):
+            return parsed
+
+        match = re.search(r"\{[\s\S]*\}", text or "")
+        if match:
+            try:
+                return json.loads(match.group(0))
+            except json.JSONDecodeError:
+                pass
+
+        return {"chapters": []}

--- a/src/book_graph_analyzer/review/store.py
+++ b/src/book_graph_analyzer/review/store.py
@@ -1,0 +1,278 @@
+"""Human review queue storage (SQLite) + audit trail + Neo4j decision logging."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional, Any
+
+
+@dataclass
+class ReviewItem:
+    id: str
+    item_type: str  # entity|conflict|rule|relationship
+    confidence: float
+    payload: dict[str, Any]
+    status: str = "pending"  # pending|accepted|rejected|deferred|edited
+    source: str = "pipeline"
+    needs_review: bool = True
+    created_at: str = ""
+    updated_at: str = ""
+
+
+class ReviewStore:
+    def __init__(self, db_path: str | Path = "data/review_queue.db") -> None:
+        self.db_path = Path(db_path)
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._init()
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.db_path)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def _init(self) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS review_items (
+                    id TEXT PRIMARY KEY,
+                    item_type TEXT NOT NULL,
+                    confidence REAL NOT NULL,
+                    payload_json TEXT NOT NULL,
+                    status TEXT NOT NULL DEFAULT 'pending',
+                    source TEXT NOT NULL DEFAULT 'pipeline',
+                    needs_review INTEGER NOT NULL DEFAULT 1,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS review_decisions (
+                    id TEXT PRIMARY KEY,
+                    reviewer TEXT NOT NULL,
+                    item_type TEXT NOT NULL,
+                    item_id TEXT NOT NULL,
+                    decision TEXT NOT NULL,
+                    timestamp TEXT NOT NULL,
+                    notes TEXT NOT NULL DEFAULT '',
+                    before_json TEXT,
+                    after_json TEXT
+                )
+                """
+            )
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_review_items_type_status ON review_items(item_type, status)")
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_review_items_status ON review_items(status)")
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_review_decisions_item ON review_decisions(item_type, item_id)")
+
+    def add_item(
+        self,
+        item_type: str,
+        confidence: float,
+        payload: dict[str, Any],
+        item_id: Optional[str] = None,
+        source: str = "pipeline",
+        needs_review: bool = True,
+    ) -> str:
+        now = datetime.now(timezone.utc).isoformat()
+        iid = item_id or f"{item_type}_{uuid.uuid4().hex[:12]}"
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO review_items
+                (id, item_type, confidence, payload_json, status, source, needs_review, created_at, updated_at)
+                VALUES (?, ?, ?, ?,
+                        COALESCE((SELECT status FROM review_items WHERE id=?), 'pending'),
+                        ?, ?,
+                        COALESCE((SELECT created_at FROM review_items WHERE id=?), ?),
+                        ?)
+                """,
+                (
+                    iid,
+                    item_type,
+                    float(confidence),
+                    json.dumps(payload, ensure_ascii=False),
+                    iid,
+                    source,
+                    1 if needs_review else 0,
+                    iid,
+                    now,
+                    now,
+                ),
+            )
+        return iid
+
+    def add_items(self, items: list[tuple[str, float, dict[str, Any], Optional[str], str, bool]]) -> int:
+        count = 0
+        for item_type, confidence, payload, item_id, source, needs_review in items:
+            self.add_item(item_type, confidence, payload, item_id=item_id, source=source, needs_review=needs_review)
+            count += 1
+        return count
+
+    def pending_counts(self) -> dict[str, int]:
+        out = {"entity": 0, "conflict": 0, "rule": 0, "relationship": 0, "total": 0}
+        with self._connect() as conn:
+            rows = conn.execute(
+                "SELECT item_type, COUNT(*) c FROM review_items WHERE status='pending' GROUP BY item_type"
+            ).fetchall()
+            for r in rows:
+                out[r["item_type"]] = int(r["c"])
+                out["total"] += int(r["c"])
+        return out
+
+    def get_pending(self, item_type: Optional[str] = None, limit: int = 100) -> list[ReviewItem]:
+        with self._connect() as conn:
+            if item_type:
+                rows = conn.execute(
+                    "SELECT * FROM review_items WHERE status='pending' AND item_type=? ORDER BY created_at LIMIT ?",
+                    (item_type, limit),
+                ).fetchall()
+            else:
+                rows = conn.execute(
+                    "SELECT * FROM review_items WHERE status='pending' ORDER BY created_at LIMIT ?",
+                    (limit,),
+                ).fetchall()
+
+        items: list[ReviewItem] = []
+        for r in rows:
+            items.append(
+                ReviewItem(
+                    id=r["id"],
+                    item_type=r["item_type"],
+                    confidence=float(r["confidence"]),
+                    payload=json.loads(r["payload_json"]),
+                    status=r["status"],
+                    source=r["source"],
+                    needs_review=bool(r["needs_review"]),
+                    created_at=r["created_at"],
+                    updated_at=r["updated_at"],
+                )
+            )
+        return items
+
+    def get_item(self, item_id: str) -> Optional[ReviewItem]:
+        with self._connect() as conn:
+            r = conn.execute("SELECT * FROM review_items WHERE id=?", (item_id,)).fetchone()
+        if not r:
+            return None
+        return ReviewItem(
+            id=r["id"],
+            item_type=r["item_type"],
+            confidence=float(r["confidence"]),
+            payload=json.loads(r["payload_json"]),
+            status=r["status"],
+            source=r["source"],
+            needs_review=bool(r["needs_review"]),
+            created_at=r["created_at"],
+            updated_at=r["updated_at"],
+        )
+
+    def decide(
+        self,
+        item_id: str,
+        decision: str,  # accepted|rejected|edited|deferred
+        notes: str = "",
+        reviewer: str = "human",
+        edited_payload: Optional[dict[str, Any]] = None,
+        log_to_neo4j: bool = True,
+    ) -> bool:
+        item = self.get_item(item_id)
+        if not item:
+            return False
+
+        now = datetime.now(timezone.utc).isoformat()
+        new_payload = edited_payload if edited_payload is not None else item.payload
+        status = {
+            "accepted": "accepted",
+            "rejected": "rejected",
+            "edited": "edited",
+            "deferred": "deferred",
+        }.get(decision, decision)
+
+        with self._connect() as conn:
+            conn.execute(
+                "UPDATE review_items SET status=?, payload_json=?, updated_at=? WHERE id=?",
+                (status, json.dumps(new_payload, ensure_ascii=False), now, item_id),
+            )
+            conn.execute(
+                """
+                INSERT INTO review_decisions
+                (id, reviewer, item_type, item_id, decision, timestamp, notes, before_json, after_json)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    f"decision_{uuid.uuid4().hex[:12]}",
+                    reviewer,
+                    item.item_type,
+                    item_id,
+                    decision,
+                    now,
+                    notes,
+                    json.dumps(item.payload, ensure_ascii=False),
+                    json.dumps(new_payload, ensure_ascii=False),
+                ),
+            )
+
+        if log_to_neo4j:
+            self._log_decision_to_neo4j(
+                reviewer=reviewer,
+                item_type=item.item_type,
+                item_id=item_id,
+                decision=decision,
+                timestamp=now,
+                notes=notes,
+            )
+
+        return True
+
+    def _log_decision_to_neo4j(
+        self,
+        reviewer: str,
+        item_type: str,
+        item_id: str,
+        decision: str,
+        timestamp: str,
+        notes: str,
+    ) -> None:
+        try:
+            from ..graph.connection import get_driver
+
+            driver = get_driver()
+            if not driver:
+                return
+            with driver.session() as session:
+                session.run(
+                    """
+                    MERGE (r:ReviewDecision {id: $id})
+                    SET r.reviewer = $reviewer,
+                        r.item_type = $item_type,
+                        r.item_id = $item_id,
+                        r.decision = $decision,
+                        r.timestamp = $timestamp,
+                        r.notes = $notes
+                    """,
+                    id=f"review_{uuid.uuid4().hex[:16]}",
+                    reviewer=reviewer,
+                    item_type=item_type,
+                    item_id=item_id,
+                    decision=decision,
+                    timestamp=timestamp,
+                    notes=notes,
+                )
+            driver.close()
+        except Exception:
+            # Non-blocking: local audit in sqlite is still authoritative
+            return
+
+    def recent_decisions(self, limit: int = 20) -> list[dict[str, Any]]:
+        with self._connect() as conn:
+            rows = conn.execute(
+                "SELECT * FROM review_decisions ORDER BY timestamp DESC LIMIT ?", (limit,)
+            ).fetchall()
+        return [dict(r) for r in rows]

--- a/tests/test_outliner.py
+++ b/tests/test_outliner.py
@@ -1,0 +1,174 @@
+import json
+
+from click.testing import CliRunner
+
+from book_graph_analyzer.cli import main
+from book_graph_analyzer.generate.models import Chapter
+from book_graph_analyzer.generate.outliner import CanonicalEvent, OutlinerEngine
+
+
+class _FakeResult:
+    def __init__(self, single=None, rows=None):
+        self._single = single
+        self._rows = rows or []
+
+    def single(self):
+        return self._single
+
+    def __iter__(self):
+        return iter(self._rows)
+
+
+class _FakeSession:
+    def __init__(self):
+        self._anchor_calls = 0
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def run(self, query, **kwargs):
+        if "ORDER BY score DESC" in query:
+            self._anchor_calls += 1
+            if self._anchor_calls == 1:
+                return _FakeResult(single={
+                    "id": "ev_a",
+                    "description": "Tuor arrives in Nevrast",
+                    "era": "First Age",
+                    "year": 495,
+                    "agent": "Tuor",
+                    "source_book": "Unfinished Tales",
+                    "score": 4,
+                })
+            return _FakeResult(single={
+                "id": "ev_b",
+                "description": "Tuor reaches Gondolin",
+                "era": "First Age",
+                "year": 496,
+                "agent": "Tuor",
+                "source_book": "Unfinished Tales",
+                "score": 4,
+            })
+
+        if "KNOWN CANONICAL EVENTS" in query:
+            return _FakeResult(rows=[])
+
+        # gap-events query
+        return _FakeResult(rows=[])
+
+
+class _FakeDriver:
+    def session(self):
+        return _FakeSession()
+
+
+class _FakeLLM:
+    def generate(self, *_args, **_kwargs):
+        return json.dumps(
+            {
+                "chapters": [
+                    {
+                        "number": 1,
+                        "title": "The Empty Shore",
+                        "beat": "Tuor finds Vinyamar and arms himself.",
+                        "characters": ["Tuor"],
+                        "setting": "Nevrast",
+                        "canonical_constraint": "Tuor must find Turgon's arms.",
+                        "plot_thread_opens": "Who watches from afar?",
+                        "plot_thread_closes": None,
+                    }
+                ]
+            }
+        )
+
+    def extract_json(self, response):
+        return json.loads(response)
+
+
+class _FakeOutlinerEngine:
+    def load_world_bible(self, _path):
+        return None
+
+    def find_anchor_points(self, character, _a, _b):
+        return (
+            CanonicalEvent(id="a", description=f"{character} arrives", era="First Age", year=1),
+            CanonicalEvent(id="b", description=f"{character} departs", era="First Age", year=2),
+        )
+
+    def generate_story_outline(self, anchor_a, anchor_b, num_chapters, character):
+        class _Outline:
+            id = "outline_test"
+
+            def __init__(self):
+                self.chapters = [{"number": 1}] * num_chapters
+
+            def to_dict(self):
+                return {
+                    "id": self.id,
+                    "character": character,
+                    "anchor_a": anchor_a.__dict__,
+                    "anchor_b": anchor_b.__dict__,
+                    "chapters": [{"number": 1}],
+                }
+
+        return _Outline()
+
+
+def test_chapter_to_dict_includes_outliner_fields():
+    chapter = Chapter(
+        id="ch1",
+        number=1,
+        canonical_constraint="Hard canon constraint",
+        plot_thread_opens="Mystery starts",
+        plot_thread_closes="Mystery closes",
+    )
+
+    payload = chapter.to_dict()
+    assert payload["canonical_constraint"] == "Hard canon constraint"
+    assert payload["plot_thread_opens"] == "Mystery starts"
+    assert payload["plot_thread_closes"] == "Mystery closes"
+
+
+def test_outliner_generate_story_outline_structured_output():
+    engine = OutlinerEngine(llm=_FakeLLM(), driver=_FakeDriver())
+    a, b = engine.find_anchor_points("Tuor", "arrives in Nevrast", "reaches Gondolin")
+
+    outline = engine.generate_story_outline(a, b, num_chapters=1, character="Tuor")
+
+    assert outline.anchor_a.id == "ev_a"
+    assert outline.anchor_b.id == "ev_b"
+    assert len(outline.chapters) == 1
+    assert outline.chapters[0].canonical_constraint
+
+
+def test_generate_outline_cli_writes_json(monkeypatch, tmp_path):
+    import book_graph_analyzer.generate as gen_pkg
+
+    monkeypatch.setattr(gen_pkg, "OutlinerEngine", _FakeOutlinerEngine)
+
+    out = tmp_path / "outline.json"
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "generate",
+            "outline",
+            "--character",
+            "Tuor",
+            "--from",
+            "arrives in Nevrast",
+            "--to",
+            "reaches Gondolin",
+            "--chapters",
+            "3",
+            "--output",
+            str(out),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert out.exists()
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["character"] == "Tuor"


### PR DESCRIPTION
## Summary
- add a structured outliner generation workflow and exposed CLI integration
- add review data store support and generation model updates for issue #21
- add design notes in docs/issue-21-outliner-design.md
- include verb-form relationship aliases needed by existing relationship mapping coverage tests

## Testing
- pytest -q (first run failed: missing verb mapping said in VERB_TO_RELATIONSHIP)
- fixed verb-form mapping aliases in src/book_graph_analyzer/extract/relationships.py
- pytest -q (pass: 738 passed, 1 warning in 60.19s)

Fixes #21