### PR TITLE
feat: workflow secret verification helper for failed runs (#40)

### DIFF
--- a/src/book_graph_analyzer/cli.py
+++ b/src/book_graph_analyzer/cli.py
@@ -4977,6 +4977,61 @@ def review_seed_demo(db_path: str) -> None:
     console.print("[green]Seeded demo review items.[/green]")
 
 
+@main.command(name="workflow-check-secrets")
+@click.option(
+    "--workflow",
+    "workflow_path",
+    default=".github/workflows/architecture-posture-review.lock.yml",
+    show_default=True,
+    help="Path to workflow YAML to inspect for secrets.* references",
+)
+@click.option(
+    "--env-file",
+    default="",
+    help="Optional .env file to include when checking secret availability",
+)
+def workflow_check_secrets(workflow_path: str, env_file: str) -> None:
+    """Check whether secrets required by a workflow are present in local env.
+
+    This helps diagnose agentic workflow failures that say:
+    "Secret Verification Failed".
+    """
+    from book_graph_analyzer.ops.workflow_secrets import (
+        extract_required_secrets,
+        parse_env_file,
+        check_secrets_available,
+    )
+
+    path = Path(workflow_path)
+    if not path.exists():
+        console.print(f"[red]Workflow file not found:[/red] {path}")
+        raise click.Abort()
+
+    required = extract_required_secrets(path)
+    overrides = parse_env_file(env_file) if env_file else {}
+    present, missing = check_secrets_available(required, env_overrides=overrides)
+
+    table = Table(title=f"Workflow Secret Check: {path.name}")
+    table.add_column("Secret")
+    table.add_column("Status")
+
+    for s in present:
+        table.add_row(s, "[green]present[/green]")
+    for s in missing:
+        table.add_row(s, "[red]missing[/red]")
+
+    console.print(table)
+
+    if missing:
+        console.print(
+            "\n[yellow]Missing required secret(s).[/yellow] "
+            "Configure them in repo/org settings or provide via environment."
+        )
+        raise click.Abort()
+
+    console.print("\n[green]All required secrets found.[/green]")
+
+
 if __name__ == "__main__":
     main()
 

--- a/src/book_graph_analyzer/ops/__init__.py
+++ b/src/book_graph_analyzer/ops/__init__.py
@@ -1,0 +1,1 @@
+"""Operational helper utilities."""

--- a/src/book_graph_analyzer/ops/workflow_secrets.py
+++ b/src/book_graph_analyzer/ops/workflow_secrets.py
@@ -1,0 +1,63 @@
+"""Utilities for checking required GitHub Actions secrets in local env.
+
+Used to debug agentic workflow failures like:
+- "Secret Verification Failed"
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+_SECRET_PATTERN = re.compile(r"secrets\.([A-Z0-9_]+)")
+
+
+def extract_required_secrets(workflow_path: str | Path) -> list[str]:
+    """Extract unique secret names referenced in a workflow YAML file.
+
+    This is a regex-based parser that looks for `secrets.NAME` usages.
+    """
+    content = Path(workflow_path).read_text(encoding="utf-8")
+    names = sorted(set(_SECRET_PATTERN.findall(content)))
+    return names
+
+
+def parse_env_file(env_file: str | Path) -> dict[str, str]:
+    """Parse a .env-style file into key/value mapping."""
+    env: dict[str, str] = {}
+    path = Path(env_file)
+    if not path.exists():
+        return env
+
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        k, v = line.split("=", 1)
+        env[k.strip()] = v.strip().strip('"').strip("'")
+    return env
+
+
+def check_secrets_available(
+    required: list[str],
+    env_overrides: dict[str, str] | None = None,
+) -> tuple[list[str], list[str]]:
+    """Return (present, missing) for required secret names.
+
+    Checks process environment first, then env_overrides.
+    """
+    present: list[str] = []
+    missing: list[str] = []
+
+    for name in required:
+        val = os.environ.get(name)
+        if not val and env_overrides:
+            val = env_overrides.get(name)
+
+        if val:
+            present.append(name)
+        else:
+            missing.append(name)
+
+    return present, missing

--- a/tests/test_workflow_secrets.py
+++ b/tests/test_workflow_secrets.py
@@ -1,0 +1,120 @@
+"""Tests for workflow secret-check utilities and CLI command."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from book_graph_analyzer.cli import main
+from book_graph_analyzer.ops.workflow_secrets import (
+    extract_required_secrets,
+    parse_env_file,
+    check_secrets_available,
+)
+
+
+def test_extract_required_secrets(tmp_path: Path):
+    wf = tmp_path / "wf.yml"
+    wf.write_text(
+        """
+name: test
+jobs:
+  a:
+    steps:
+      - run: echo hi
+        env:
+          GH_TOKEN: ${{ secrets.GH_AW_GITHUB_TOKEN }}
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+      - run: echo bye
+        env:
+          GH_TOKEN2: ${{ secrets.GH_AW_GITHUB_TOKEN }}
+""",
+        encoding="utf-8",
+    )
+    names = extract_required_secrets(wf)
+    assert "GH_AW_GITHUB_TOKEN" in names
+    assert "COPILOT_GITHUB_TOKEN" in names
+    assert names.count("GH_AW_GITHUB_TOKEN") == 1
+
+
+def test_parse_env_file(tmp_path: Path):
+    envf = tmp_path / ".env"
+    envf.write_text(
+        """
+# comment
+COPILOT_GITHUB_TOKEN=abc
+GH_AW_GITHUB_TOKEN="def"
+INVALID_LINE
+""",
+        encoding="utf-8",
+    )
+    env = parse_env_file(envf)
+    assert env["COPILOT_GITHUB_TOKEN"] == "abc"
+    assert env["GH_AW_GITHUB_TOKEN"] == "def"
+    assert "INVALID_LINE" not in env
+
+
+def test_check_secrets_available(monkeypatch):
+    monkeypatch.delenv("COPILOT_GITHUB_TOKEN", raising=False)
+    monkeypatch.setenv("GH_AW_GITHUB_TOKEN", "token")
+
+    present, missing = check_secrets_available([
+        "GH_AW_GITHUB_TOKEN",
+        "COPILOT_GITHUB_TOKEN",
+    ])
+    assert "GH_AW_GITHUB_TOKEN" in present
+    assert "COPILOT_GITHUB_TOKEN" in missing
+
+
+def test_cli_workflow_check_secrets_missing(tmp_path: Path, monkeypatch):
+    wf = tmp_path / "wf.yml"
+    wf.write_text(
+        """
+jobs:
+  a:
+    steps:
+      - run: echo hi
+        env:
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.delenv("COPILOT_GITHUB_TOKEN", raising=False)
+
+    runner = CliRunner()
+    res = runner.invoke(main, ["workflow-check-secrets", "--workflow", str(wf)])
+    assert res.exit_code != 0
+    assert "missing" in res.output.lower()
+
+
+def test_cli_workflow_check_secrets_present_via_env_file(tmp_path: Path, monkeypatch):
+    wf = tmp_path / "wf.yml"
+    wf.write_text(
+        """
+jobs:
+  a:
+    steps:
+      - run: echo hi
+        env:
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+""",
+        encoding="utf-8",
+    )
+    envf = tmp_path / ".env"
+    envf.write_text("COPILOT_GITHUB_TOKEN=abc\n", encoding="utf-8")
+    monkeypatch.delenv("COPILOT_GITHUB_TOKEN", raising=False)
+
+    runner = CliRunner()
+    res = runner.invoke(
+        main,
+        [
+            "workflow-check-secrets",
+            "--workflow",
+            str(wf),
+            "--env-file",
+            str(envf),
+        ],
+    )
+    assert res.exit_code == 0
+    assert "all required secrets found" in res.output.lower()


### PR DESCRIPTION
## Summary
Implements issue #40 by adding a concrete troubleshooting/fix aid for agentic workflow failures caused by missing secrets.

The latest sub-issue (#41) reported:
- **Secret Verification Failed** for the Architecture Posture Review workflow.

This PR adds a local verifier to quickly detect missing required secrets before/while debugging failed runs.

## What was built

### 1) Secret extraction + validation utility
- New module: src/book_graph_analyzer/ops/workflow_secrets.py
- extract_required_secrets(workflow_path)
  - regex-parses workflow files for secrets.NAME references
  - returns unique required secret names
- parse_env_file(env_file)
  - reads .env-style files for local testing
- check_secrets_available(required, env_overrides=None)
  - checks process env + optional .env overrides
  - returns (present, missing)

### 2) New CLI command
- Added ga workflow-check-secrets
  - default workflow: .github/workflows/architecture-posture-review.lock.yml
  - optional --env-file for local secret simulation
  - outputs rich table of present/missing secrets
  - exits non-zero if required secrets are missing

Example:
`ash
bga workflow-check-secrets \
  --workflow .github/workflows/architecture-posture-review.lock.yml \
  --env-file .env
`

## Tests
- New test file: 	ests/test_workflow_secrets.py
- Run: python -m pytest tests/test_workflow_secrets.py -v
- **5 passed**

Coverage includes:
- secret extraction from workflow YAML
- .env parsing
- present/missing resolution logic
- CLI failure path when secret missing
- CLI success path with env-file overrides