### PR TITLE
feat: analyze failed workflow issues directly via gh issue API (#40)

### DIFF
--- a/src/book_graph_analyzer/cli.py
+++ b/src/book_graph_analyzer/cli.py
@@ -5032,6 +5032,24 @@ def workflow_check_secrets(workflow_path: str, env_file: str) -> None:
     console.print("\n[green]All required secrets found.[/green]")
 
 
+def _print_workflow_failure_analysis(analysis) -> None:
+    console.print("[bold]Workflow Failure Analysis[/bold]")
+    console.print(f"Run URL: {analysis.run_url or 'n/a'}")
+    console.print(f"Run ID: {analysis.run_id or 'n/a'}")
+    console.print(f"Secret verification phrase detected: {analysis.secret_verification_failed}")
+
+    table = Table(title="Required Secrets")
+    table.add_column("Secret")
+    table.add_column("Status")
+    for s in analysis.present_secrets:
+        table.add_row(s, "[green]present[/green]")
+    for s in analysis.missing_secrets:
+        table.add_row(s, "[red]missing[/red]")
+    console.print(table)
+
+    console.print(f"\n[bold]Diagnosis:[/bold] {analysis.summary}")
+
+
 @main.command(name="workflow-analyze-failure")
 @click.option("--issue-file", required=True, type=click.Path(exists=True), help="Path to saved issue body markdown/text")
 @click.option(
@@ -5054,22 +5072,42 @@ def workflow_analyze_failure(issue_file: str, workflow_path: str, env_file: str)
         workflow_path=workflow_path,
         env_file=env_file or None,
     )
+    _print_workflow_failure_analysis(analysis)
 
-    console.print("[bold]Workflow Failure Analysis[/bold]")
-    console.print(f"Run URL: {analysis.run_url or 'n/a'}")
-    console.print(f"Run ID: {analysis.run_id or 'n/a'}")
-    console.print(f"Secret verification phrase detected: {analysis.secret_verification_failed}")
+    if analysis.missing_secrets:
+        raise click.Abort()
 
-    table = Table(title="Required Secrets")
-    table.add_column("Secret")
-    table.add_column("Status")
-    for s in analysis.present_secrets:
-        table.add_row(s, "[green]present[/green]")
-    for s in analysis.missing_secrets:
-        table.add_row(s, "[red]missing[/red]")
-    console.print(table)
 
-    console.print(f"\n[bold]Diagnosis:[/bold] {analysis.summary}")
+@main.command(name="workflow-analyze-failure-issue")
+@click.option("--issue", "issue_number", required=True, type=int, help="GitHub issue number (e.g. 41)")
+@click.option(
+    "--workflow",
+    "workflow_path",
+    default=".github/workflows/architecture-posture-review.lock.yml",
+    show_default=True,
+    help="Workflow YAML used by the failed run",
+)
+@click.option("--env-file", default="", help="Optional .env file for local secret checks")
+def workflow_analyze_failure_issue(issue_number: int, workflow_path: str, env_file: str) -> None:
+    """Analyze a failed-workflow issue directly via `gh issue view`.
+
+    This avoids manually saving issue body to a file.
+    """
+    from book_graph_analyzer.ops import fetch_issue_via_gh
+    from book_graph_analyzer.ops.workflow_failure import analyze_failure_from_issue_text
+
+    issue = fetch_issue_via_gh(issue_number)
+    if not issue:
+        console.print(f"[red]Could not fetch issue #{issue_number} via gh CLI.[/red]")
+        raise click.Abort()
+
+    console.print(f"Issue #{issue.number}: {issue.title}")
+    analysis = analyze_failure_from_issue_text(
+        issue.body,
+        workflow_path=workflow_path,
+        env_file=env_file or None,
+    )
+    _print_workflow_failure_analysis(analysis)
 
     if analysis.missing_secrets:
         raise click.Abort()

--- a/src/book_graph_analyzer/ops/__init__.py
+++ b/src/book_graph_analyzer/ops/__init__.py
@@ -8,6 +8,7 @@ from .workflow_failure import (
     analyze_failure_from_issue_text,
     analyze_failure_from_issue_file,
 )
+from .gh_issue import IssueData, fetch_issue_via_gh
 
 __all__ = [
     "extract_required_secrets",
@@ -18,4 +19,6 @@ __all__ = [
     "detect_secret_verification_failure",
     "analyze_failure_from_issue_text",
     "analyze_failure_from_issue_file",
+    "IssueData",
+    "fetch_issue_via_gh",
 ]

--- a/src/book_graph_analyzer/ops/gh_issue.py
+++ b/src/book_graph_analyzer/ops/gh_issue.py
@@ -1,0 +1,48 @@
+"""Helpers to read GitHub issue metadata via gh CLI."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class IssueData:
+    number: int
+    title: str
+    body: str
+    url: str
+
+
+def fetch_issue_via_gh(issue_number: int) -> Optional[IssueData]:
+    """Fetch issue body/title/url using `gh issue view --json ...`.
+
+    Returns None if gh is unavailable or call fails.
+    """
+    try:
+        proc = subprocess.run(
+            [
+                "gh",
+                "issue",
+                "view",
+                str(issue_number),
+                "--json",
+                "number,title,body,url",
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if proc.returncode != 0:
+            return None
+        data = json.loads(proc.stdout or "{}")
+        return IssueData(
+            number=int(data.get("number", issue_number)),
+            title=str(data.get("title", "")),
+            body=str(data.get("body", "")),
+            url=str(data.get("url", "")),
+        )
+    except Exception:
+        return None

--- a/tests/test_gh_issue.py
+++ b/tests/test_gh_issue.py
@@ -1,0 +1,36 @@
+"""Tests for gh issue helper wrapper."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+from book_graph_analyzer.ops.gh_issue import fetch_issue_via_gh
+
+
+def test_fetch_issue_via_gh_success(monkeypatch):
+    payload = {
+        "number": 41,
+        "title": "failed run",
+        "body": "body text",
+        "url": "https://github.com/x/y/issues/41",
+    }
+
+    def fake_run(*args, **kwargs):
+        return SimpleNamespace(returncode=0, stdout=json.dumps(payload), stderr="")
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    issue = fetch_issue_via_gh(41)
+    assert issue is not None
+    assert issue.number == 41
+    assert issue.title == "failed run"
+
+
+def test_fetch_issue_via_gh_failure(monkeypatch):
+    def fake_run(*args, **kwargs):
+        return SimpleNamespace(returncode=1, stdout="", stderr="boom")
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    issue = fetch_issue_via_gh(41)
+    assert issue is None

--- a/tests/test_workflow_failure.py
+++ b/tests/test_workflow_failure.py
@@ -12,6 +12,7 @@ from book_graph_analyzer.ops.workflow_failure import (
     detect_secret_verification_failure,
     analyze_failure_from_issue_text,
 )
+from book_graph_analyzer.ops.gh_issue import IssueData
 
 
 ISSUE_TEXT = """
@@ -131,3 +132,40 @@ jobs:
     )
     assert res.exit_code == 0
     assert "Diagnosis" in res.output
+
+
+def test_cli_workflow_analyze_failure_issue(monkeypatch, tmp_path: Path):
+    wf = tmp_path / "wf.yml"
+    wf.write_text(
+        """
+jobs:
+  a:
+    steps:
+      - run: echo hi
+        env:
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+""",
+        encoding="utf-8",
+    )
+
+    def fake_fetch(issue_number: int):
+        assert issue_number == 41
+        return IssueData(number=41, title="failed", body=ISSUE_TEXT, url="https://example")
+
+    monkeypatch.setattr("book_graph_analyzer.ops.fetch_issue_via_gh", fake_fetch)
+
+    runner = CliRunner()
+    res = runner.invoke(
+        main,
+        [
+            "workflow-analyze-failure-issue",
+            "--issue",
+            "41",
+            "--workflow",
+            str(wf),
+        ],
+    )
+    # Missing token -> non-zero + analysis printed
+    assert res.exit_code != 0
+    assert "Issue #41" in res.output
+    assert "Workflow Failure Analysis" in res.output


### PR DESCRIPTION
## Summary
Follow-up for issue #40: adds direct GitHub-issue based failure analysis, so you can debug failed agentic workflow issues without manually copying issue text to files.

## What was added

### New helper: src/book_graph_analyzer/ops/gh_issue.py
- etch_issue_via_gh(issue_number)
  - calls gh issue view <N> --json number,title,body,url
  - returns structured IssueData
  - gracefully returns None on failures

### CLI enhancement
- New command: ga workflow-analyze-failure-issue
  - Inputs:
    - --issue <number> (e.g. 41)
    - --workflow <path> (default architecture-posture-review workflow)
    - optional --env-file
  - Flow:
    1. fetch issue body via gh
    2. parse run URL/run id
    3. detect secret-verification-failed pattern
    4. compare required secrets.* against present/missing env
    5. print diagnosis + fail non-zero if missing secrets

### Refactor
- Added _print_workflow_failure_analysis() helper in CLI to share display logic between:
  - workflow-analyze-failure (file-based)
  - workflow-analyze-failure-issue (issue-number based)
- Exported issue helper from ops/__init__.py

## Tests
- Updated: 	ests/test_workflow_failure.py
  - covers new CLI command with monkeypatched issue fetch
- Added: 	ests/test_gh_issue.py
  - success/failure behavior of etch_issue_via_gh
- Run:
  - python -m pytest tests/test_workflow_failure.py tests/test_gh_issue.py -v
  - **9 passed**