### PR TITLE
feat: batch-analyze open failed workflow issues via gh issue list (#40)

### DIFF
--- a/src/book_graph_analyzer/cli.py
+++ b/src/book_graph_analyzer/cli.py
@@ -5113,6 +5113,58 @@ def workflow_analyze_failure_issue(issue_number: int, workflow_path: str, env_fi
         raise click.Abort()
 
 
+@main.command(name="workflow-analyze-open-failures")
+@click.option("--label", default="agentic-workflows", show_default=True, help="Issue label to scan")
+@click.option("--limit", default=20, show_default=True, help="Max open issues to inspect")
+@click.option(
+    "--workflow",
+    "workflow_path",
+    default=".github/workflows/architecture-posture-review.lock.yml",
+    show_default=True,
+    help="Workflow YAML used by failed runs",
+)
+@click.option("--env-file", default="", help="Optional .env file for local secret checks")
+def workflow_analyze_open_failures(label: str, limit: int, workflow_path: str, env_file: str) -> None:
+    """Analyze all open failure issues (batch mode) via gh issue list/view.
+
+    Skips known parent tracker issues by title prefix '[agentics] Failed runs'.
+    """
+    from book_graph_analyzer.ops import list_open_issues_via_gh
+    from book_graph_analyzer.ops.workflow_failure import analyze_failure_from_issue_text
+
+    issues = list_open_issues_via_gh(label=label, limit=limit)
+    if not issues:
+        console.print("[yellow]No open issues found for analysis.[/yellow]")
+        return
+
+    analyzed = 0
+    missing_any = False
+
+    for issue in issues:
+        # Skip parent tracker issue
+        if issue.title.strip().lower().startswith("[agentics] failed runs"):
+            continue
+
+        analysis = analyze_failure_from_issue_text(
+            issue.body,
+            workflow_path=workflow_path,
+            env_file=env_file or None,
+        )
+
+        console.print(f"\n[bold]Issue #{issue.number}: {issue.title}[/bold]")
+        _print_workflow_failure_analysis(analysis)
+        analyzed += 1
+        if analysis.missing_secrets:
+            missing_any = True
+
+    if analyzed == 0:
+        console.print("[yellow]No actionable failure issues found after filtering.[/yellow]")
+        return
+
+    if missing_any:
+        raise click.Abort()
+
+
 if __name__ == "__main__":
     main()
 

--- a/src/book_graph_analyzer/ops/__init__.py
+++ b/src/book_graph_analyzer/ops/__init__.py
@@ -8,7 +8,7 @@ from .workflow_failure import (
     analyze_failure_from_issue_text,
     analyze_failure_from_issue_file,
 )
-from .gh_issue import IssueData, fetch_issue_via_gh
+from .gh_issue import IssueData, fetch_issue_via_gh, list_open_issues_via_gh
 
 __all__ = [
     "extract_required_secrets",
@@ -21,4 +21,5 @@ __all__ = [
     "analyze_failure_from_issue_file",
     "IssueData",
     "fetch_issue_via_gh",
+    "list_open_issues_via_gh",
 ]

--- a/src/book_graph_analyzer/ops/gh_issue.py
+++ b/src/book_graph_analyzer/ops/gh_issue.py
@@ -46,3 +46,39 @@ def fetch_issue_via_gh(issue_number: int) -> Optional[IssueData]:
         )
     except Exception:
         return None
+
+
+def list_open_issues_via_gh(label: str = "", limit: int = 20) -> list[IssueData]:
+    """List open issues via gh CLI with optional label filter."""
+    args = [
+        "gh",
+        "issue",
+        "list",
+        "--state",
+        "open",
+        "--limit",
+        str(limit),
+        "--json",
+        "number,title,body,url",
+    ]
+    if label:
+        args += ["--label", label]
+
+    try:
+        proc = subprocess.run(args, check=False, capture_output=True, text=True)
+        if proc.returncode != 0:
+            return []
+        arr = json.loads(proc.stdout or "[]")
+        out: list[IssueData] = []
+        for d in arr:
+            out.append(
+                IssueData(
+                    number=int(d.get("number", 0)),
+                    title=str(d.get("title", "")),
+                    body=str(d.get("body", "")),
+                    url=str(d.get("url", "")),
+                )
+            )
+        return out
+    except Exception:
+        return []

--- a/tests/test_gh_issue.py
+++ b/tests/test_gh_issue.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from types import SimpleNamespace
 
-from book_graph_analyzer.ops.gh_issue import fetch_issue_via_gh
+from book_graph_analyzer.ops.gh_issue import fetch_issue_via_gh, list_open_issues_via_gh
 
 
 def test_fetch_issue_via_gh_success(monkeypatch):
@@ -34,3 +34,19 @@ def test_fetch_issue_via_gh_failure(monkeypatch):
     monkeypatch.setattr("subprocess.run", fake_run)
     issue = fetch_issue_via_gh(41)
     assert issue is None
+
+
+def test_list_open_issues_via_gh(monkeypatch):
+    payload = [
+        {"number": 40, "title": "[agentics] Failed runs", "body": "x", "url": "u1"},
+        {"number": 41, "title": "[agentics] Architecture failed", "body": "y", "url": "u2"},
+    ]
+
+    def fake_run(*args, **kwargs):
+        return SimpleNamespace(returncode=0, stdout=json.dumps(payload), stderr="")
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    issues = list_open_issues_via_gh(label="agentic-workflows", limit=20)
+    assert len(issues) == 2
+    assert issues[0].number == 40
+    assert issues[1].number == 41

--- a/tests/test_workflow_failure.py
+++ b/tests/test_workflow_failure.py
@@ -169,3 +169,39 @@ jobs:
     assert res.exit_code != 0
     assert "Issue #41" in res.output
     assert "Workflow Failure Analysis" in res.output
+
+
+def test_cli_workflow_analyze_open_failures(monkeypatch, tmp_path: Path):
+    wf = tmp_path / "wf.yml"
+    wf.write_text(
+        """
+jobs:
+  a:
+    steps:
+      - run: echo hi
+        env:
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+""",
+        encoding="utf-8",
+    )
+
+    issues = [
+        IssueData(number=40, title="[agentics] Failed runs", body="parent", url="u40"),
+        IssueData(number=41, title="[agentics] Architecture failed", body=ISSUE_TEXT, url="u41"),
+    ]
+
+    monkeypatch.setattr("book_graph_analyzer.ops.list_open_issues_via_gh", lambda label, limit: issues)
+
+    runner = CliRunner()
+    res = runner.invoke(
+        main,
+        [
+            "workflow-analyze-open-failures",
+            "--workflow",
+            str(wf),
+        ],
+    )
+    # Missing secret from issue 41 should fail command
+    assert res.exit_code != 0
+    assert "Issue #41" in res.output
+    assert "Workflow Failure Analysis" in res.output


### PR DESCRIPTION
## Summary
Another issue #40 enhancement: adds a batch analyzer over open gentic-workflows issues so failure triage can run in one command.

## What was added

### CLI: ga workflow-analyze-open-failures
- Scans open issues via gh issue list (label default: gentic-workflows)
- Filters out parent tracker issue title ([agentics] Failed runs)
- Runs existing failure diagnostics per issue body:
  - run URL / run id extraction
  - secret-verification wording detection
  - required workflow secrets presence check
- Prints analysis per issue
- exits non-zero if any analyzed issue has missing required secrets

### Helpers
- src/book_graph_analyzer/ops/gh_issue.py
  - added list_open_issues_via_gh(label, limit)
- updated exports in src/book_graph_analyzer/ops/__init__.py

## Tests
- Updated 	ests/test_workflow_failure.py
  - added test for workflow-analyze-open-failures command
- Updated 	ests/test_gh_issue.py
  - added test for list_open_issues_via_gh

Run:
`ash
python -m pytest tests/test_workflow_failure.py tests/test_gh_issue.py -v
`
Result: **11 passed**