### PR TITLE
feat: post automated diagnosis comments for failed workflow issues (#40)

### DIFF
--- a/src/book_graph_analyzer/cli.py
+++ b/src/book_graph_analyzer/cli.py
@@ -5204,6 +5204,50 @@ def workflow_remediation_report(issue_number: int, workflow_path: str, env_file:
 
     if analysis.missing_secrets:
         raise click.Abort()
+
+
+@main.command(name="workflow-post-diagnosis")
+@click.option("--issue", "issue_number", required=True, type=int, help="GitHub issue number")
+@click.option(
+    "--workflow",
+    "workflow_path",
+    default=".github/workflows/architecture-posture-review.lock.yml",
+    show_default=True,
+    help="Workflow YAML used by the failed run",
+)
+@click.option("--env-file", default="", help="Optional .env file for local secret checks")
+def workflow_post_diagnosis(issue_number: int, workflow_path: str, env_file: str) -> None:
+    """Analyze an issue and post markdown diagnosis comment back to that issue."""
+    from book_graph_analyzer.ops import fetch_issue_via_gh, post_issue_comment_via_gh
+    from book_graph_analyzer.ops.workflow_failure import (
+        analyze_failure_from_issue_text,
+        build_remediation_report,
+    )
+
+    issue = fetch_issue_via_gh(issue_number)
+    if not issue:
+        console.print(f"[red]Could not fetch issue #{issue_number} via gh CLI.[/red]")
+        raise click.Abort()
+
+    analysis = analyze_failure_from_issue_text(
+        issue.body,
+        workflow_path=workflow_path,
+        env_file=env_file or None,
+    )
+    report = build_remediation_report(analysis, issue_ref=f"#{issue.number} {issue.title}")
+
+    ok = post_issue_comment_via_gh(issue_number, report)
+    if not ok:
+        console.print(f"[red]Failed to post diagnosis comment to issue #{issue_number}.[/red]")
+        raise click.Abort()
+
+    console.print(f"[green]Posted diagnosis report to issue #{issue_number}.[/green]")
+
+    if analysis.missing_secrets:
+        # Keep non-zero behavior if unresolved
+        raise click.Abort()
+
+
 # ============================================================================
 # World-Building Placeholder Commands (Issue #45 — Tolkien Kickoff)
 # ============================================================================

--- a/src/book_graph_analyzer/ops/__init__.py
+++ b/src/book_graph_analyzer/ops/__init__.py
@@ -8,7 +8,7 @@ from .workflow_failure import (
     analyze_failure_from_issue_text,
     analyze_failure_from_issue_file,
 )
-from .gh_issue import IssueData, fetch_issue_via_gh, list_open_issues_via_gh
+from .gh_issue import IssueData, fetch_issue_via_gh, list_open_issues_via_gh, post_issue_comment_via_gh
 
 __all__ = [
     "extract_required_secrets",
@@ -22,4 +22,5 @@ __all__ = [
     "IssueData",
     "fetch_issue_via_gh",
     "list_open_issues_via_gh",
+    "post_issue_comment_via_gh",
 ]

--- a/src/book_graph_analyzer/ops/gh_issue.py
+++ b/src/book_graph_analyzer/ops/gh_issue.py
@@ -82,3 +82,20 @@ def list_open_issues_via_gh(label: str = "", limit: int = 20) -> list[IssueData]
         return out
     except Exception:
         return []
+
+
+def post_issue_comment_via_gh(issue_number: int, body: str) -> bool:
+    """Post a comment to an issue via gh CLI.
+
+    Returns True on success.
+    """
+    try:
+        proc = subprocess.run(
+            ["gh", "issue", "comment", str(issue_number), "--body", body],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        return proc.returncode == 0
+    except Exception:
+        return False

--- a/tests/test_gh_issue.py
+++ b/tests/test_gh_issue.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 import json
 from types import SimpleNamespace
 
-from book_graph_analyzer.ops.gh_issue import fetch_issue_via_gh, list_open_issues_via_gh
+from book_graph_analyzer.ops.gh_issue import (
+    fetch_issue_via_gh,
+    list_open_issues_via_gh,
+    post_issue_comment_via_gh,
+)
 
 
 def test_fetch_issue_via_gh_success(monkeypatch):
@@ -50,3 +54,19 @@ def test_list_open_issues_via_gh(monkeypatch):
     assert len(issues) == 2
     assert issues[0].number == 40
     assert issues[1].number == 41
+
+
+def test_post_issue_comment_via_gh_success(monkeypatch):
+    def fake_run(*args, **kwargs):
+        return SimpleNamespace(returncode=0, stdout="ok", stderr="")
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    assert post_issue_comment_via_gh(41, "report") is True
+
+
+def test_post_issue_comment_via_gh_failure(monkeypatch):
+    def fake_run(*args, **kwargs):
+        return SimpleNamespace(returncode=1, stdout="", stderr="boom")
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    assert post_issue_comment_via_gh(41, "report") is False

--- a/tests/test_workflow_failure.py
+++ b/tests/test_workflow_failure.py
@@ -265,3 +265,39 @@ jobs:
     assert out.exists()
     text = out.read_text(encoding="utf-8")
     assert "Workflow Failure Remediation Report" in text
+
+
+def test_cli_workflow_post_diagnosis(monkeypatch, tmp_path: Path):
+    wf = tmp_path / "wf.yml"
+    wf.write_text(
+        """
+jobs:
+  a:
+    steps:
+      - run: echo hi
+        env:
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+""",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        "book_graph_analyzer.ops.fetch_issue_via_gh",
+        lambda issue_number: IssueData(number=41, title="failed", body=ISSUE_TEXT, url="u41"),
+    )
+    monkeypatch.setattr("book_graph_analyzer.ops.post_issue_comment_via_gh", lambda issue_number, body: True)
+
+    runner = CliRunner()
+    res = runner.invoke(
+        main,
+        [
+            "workflow-post-diagnosis",
+            "--issue",
+            "41",
+            "--workflow",
+            str(wf),
+        ],
+    )
+    # Missing secret -> command still aborts non-zero after posting
+    assert res.exit_code != 0
+    assert "Posted diagnosis report" in res.output


### PR DESCRIPTION
## Summary
Issue #40 follow-up: add an explicit command to post workflow failure diagnosis back onto the issue as a comment.

## What was added

### New helper in ops/gh_issue.py
- post_issue_comment_via_gh(issue_number, body)
  - wraps gh issue comment
  - returns boolean success/failure

### New CLI command
- ga workflow-post-diagnosis --issue <N> [--workflow ...] [--env-file ...]
  - fetches issue body (gh issue view)
  - runs failure analysis
  - builds markdown remediation report
  - posts report as an issue comment
  - exits non-zero if unresolved missing secrets remain

This closes the loop from analysis -> actionable comment directly on the failing issue.

## Tests
- Updated 	ests/test_workflow_failure.py
  - added 	est_cli_workflow_post_diagnosis
- Updated 	ests/test_gh_issue.py
  - added post comment helper success/failure tests

Run:
`ash
python -m pytest tests/test_workflow_failure.py tests/test_gh_issue.py -v
`
Result: **16 passed**