### PR TITLE
feat: auto-close resolved agentic failure sub-issues from analysis (#40)

### DIFF
--- a/src/book_graph_analyzer/cli.py
+++ b/src/book_graph_analyzer/cli.py
@@ -5316,6 +5316,67 @@ def workflow_post_diagnosis(issue_number: int, workflow_path: str, env_file: str
         raise click.Abort()
 
 
+@main.command(name="workflow-close-resolved-failures")
+@click.option("--label", default="agentic-workflows", show_default=True, help="Issue label to scan")
+@click.option("--limit", default=20, show_default=True, help="Max open issues to inspect")
+@click.option(
+    "--workflow",
+    "workflow_path",
+    default=".github/workflows/architecture-posture-review.lock.yml",
+    show_default=True,
+    help="Workflow YAML used by failed runs",
+)
+@click.option("--env-file", default="", help="Optional .env file for local secret checks")
+@click.option("--dry-run", is_flag=True, help="Show issues that would be closed without closing")
+def workflow_close_resolved_failures(
+    label: str,
+    limit: int,
+    workflow_path: str,
+    env_file: str,
+    dry_run: bool,
+) -> None:
+    """Close actionable failure sub-issues when analysis indicates resolution.
+
+    Criteria for auto-close:
+      - not the parent tracker issue
+      - no missing required secrets
+      - no explicit secret-verification-failed phrase in issue body
+    """
+    from book_graph_analyzer.ops import list_open_issues_via_gh, close_issue_via_gh
+    from book_graph_analyzer.ops.workflow_failure import analyze_failure_from_issue_text
+
+    issues = list_open_issues_via_gh(label=label, limit=limit)
+    if not issues:
+        console.print("[yellow]No open issues found.[/yellow]")
+        return
+
+    close_candidates = []
+    for issue in issues:
+        if issue.title.strip().lower().startswith("[agentics] failed runs"):
+            continue
+
+        analysis = analyze_failure_from_issue_text(
+            issue.body,
+            workflow_path=workflow_path,
+            env_file=env_file or None,
+        )
+        if (not analysis.missing_secrets) and (not analysis.secret_verification_failed):
+            close_candidates.append(issue)
+
+    if not close_candidates:
+        console.print("[green]No resolved failure issues to close.[/green]")
+        return
+
+    for issue in close_candidates:
+        if dry_run:
+            console.print(f"[yellow][dry-run][/yellow] would close issue #{issue.number}: {issue.title}")
+        else:
+            ok = close_issue_via_gh(issue.number, reason="completed")
+            if ok:
+                console.print(f"[green]Closed issue #{issue.number}[/green]: {issue.title}")
+            else:
+                console.print(f"[red]Failed to close issue #{issue.number}[/red]: {issue.title}")
+
 # ============================================================================
 # World-Building Placeholder Commands (Issue #45 — Tolkien Kickoff)
 # ============================================================================

--- a/src/book_graph_analyzer/ops/__init__.py
+++ b/src/book_graph_analyzer/ops/__init__.py
@@ -8,7 +8,13 @@ from .workflow_failure import (
     analyze_failure_from_issue_text,
     analyze_failure_from_issue_file,
 )
-from .gh_issue import IssueData, fetch_issue_via_gh, list_open_issues_via_gh, post_issue_comment_via_gh
+from .gh_issue import (
+    IssueData,
+    fetch_issue_via_gh,
+    list_open_issues_via_gh,
+    post_issue_comment_via_gh,
+    close_issue_via_gh,
+)
 
 __all__ = [
     "extract_required_secrets",
@@ -23,4 +29,5 @@ __all__ = [
     "fetch_issue_via_gh",
     "list_open_issues_via_gh",
     "post_issue_comment_via_gh",
+    "close_issue_via_gh",
 ]

--- a/src/book_graph_analyzer/ops/gh_issue.py
+++ b/src/book_graph_analyzer/ops/gh_issue.py
@@ -99,3 +99,17 @@ def post_issue_comment_via_gh(issue_number: int, body: str) -> bool:
         return proc.returncode == 0
     except Exception:
         return False
+
+
+def close_issue_via_gh(issue_number: int, reason: str = "completed") -> bool:
+    """Close an issue via gh CLI. Returns True on success."""
+    try:
+        proc = subprocess.run(
+            ["gh", "issue", "close", str(issue_number), "--reason", reason],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        return proc.returncode == 0
+    except Exception:
+        return False

--- a/tests/test_gh_issue.py
+++ b/tests/test_gh_issue.py
@@ -9,6 +9,7 @@ from book_graph_analyzer.ops.gh_issue import (
     fetch_issue_via_gh,
     list_open_issues_via_gh,
     post_issue_comment_via_gh,
+    close_issue_via_gh,
 )
 
 
@@ -70,3 +71,19 @@ def test_post_issue_comment_via_gh_failure(monkeypatch):
 
     monkeypatch.setattr("subprocess.run", fake_run)
     assert post_issue_comment_via_gh(41, "report") is False
+
+
+def test_close_issue_via_gh_success(monkeypatch):
+    def fake_run(*args, **kwargs):
+        return SimpleNamespace(returncode=0, stdout="ok", stderr="")
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    assert close_issue_via_gh(41) is True
+
+
+def test_close_issue_via_gh_failure(monkeypatch):
+    def fake_run(*args, **kwargs):
+        return SimpleNamespace(returncode=1, stdout="", stderr="boom")
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    assert close_issue_via_gh(41) is False

--- a/tests/test_workflow_failure.py
+++ b/tests/test_workflow_failure.py
@@ -301,3 +301,79 @@ jobs:
     # Missing secret -> command still aborts non-zero after posting
     assert res.exit_code != 0
     assert "Posted diagnosis report" in res.output
+
+
+def test_cli_workflow_close_resolved_failures_dry_run(monkeypatch, tmp_path: Path):
+    wf = tmp_path / "wf.yml"
+    wf.write_text(
+        """
+jobs:
+  a:
+    steps:
+      - run: echo hi
+        env:
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+""",
+        encoding="utf-8",
+    )
+
+    envf = tmp_path / ".env"
+    envf.write_text("COPILOT_GITHUB_TOKEN=abc\n", encoding="utf-8")
+
+    # Parent tracker + one actionable issue
+    issues = [
+        IssueData(number=40, title="[agentics] Failed runs", body="parent", url="u40"),
+        IssueData(number=41, title="[agentics] Architecture failed", body="Timeout only, no secret errors", url="u41"),
+    ]
+    monkeypatch.setattr("book_graph_analyzer.ops.list_open_issues_via_gh", lambda label, limit: issues)
+
+    runner = CliRunner()
+    res = runner.invoke(
+        main,
+        [
+            "workflow-close-resolved-failures",
+            "--workflow",
+            str(wf),
+            "--env-file",
+            str(envf),
+            "--dry-run",
+        ],
+    )
+    assert res.exit_code == 0
+    assert "would close issue #41" in res.output
+
+
+def test_cli_workflow_close_resolved_failures_real_close(monkeypatch, tmp_path: Path):
+    wf = tmp_path / "wf.yml"
+    wf.write_text(
+        """
+jobs:
+  a:
+    steps:
+      - run: echo hi
+        env:
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+""",
+        encoding="utf-8",
+    )
+
+    envf = tmp_path / ".env"
+    envf.write_text("COPILOT_GITHUB_TOKEN=abc\n", encoding="utf-8")
+
+    issues = [IssueData(number=41, title="[agentics] Architecture failed", body="No secret validation failure.", url="u41")]
+    monkeypatch.setattr("book_graph_analyzer.ops.list_open_issues_via_gh", lambda label, limit: issues)
+    monkeypatch.setattr("book_graph_analyzer.ops.close_issue_via_gh", lambda issue_number, reason="completed": True)
+
+    runner = CliRunner()
+    res = runner.invoke(
+        main,
+        [
+            "workflow-close-resolved-failures",
+            "--workflow",
+            str(wf),
+            "--env-file",
+            str(envf),
+        ],
+    )
+    assert res.exit_code == 0
+    assert "Closed issue #41" in res.output


### PR DESCRIPTION
## Summary
Issue #40 follow-up: add an optional auto-close operation for resolved failure sub-issues.

## What was added

### New helper (ops/gh_issue.py)
- close_issue_via_gh(issue_number, reason='completed')
  - wraps gh issue close
  - boolean success/failure return

### New CLI command
- ga workflow-close-resolved-failures
  - scans open issues by label (gentic-workflows by default)
  - skips parent tracker issue ([agentics] Failed runs)
  - analyzes each issue body with existing workflow failure analyzer
  - closes issues meeting all criteria:
    - no missing required secrets
    - no explicit secret-verification-failed phrase
  - supports --dry-run to preview closures

### Existing flow integration
- Reuses established analyzers and issue list helpers.
- Keeps parent tracker behavior intact (not auto-closing parent issue).

## Tests
Updated:
- 	ests/test_workflow_failure.py
  - dry-run auto-close path
  - real close path (mocked)
- 	ests/test_gh_issue.py
  - close helper success/failure

Run:
`ash
python -m pytest tests/test_workflow_failure.py tests/test_gh_issue.py -v
`
Result: **20 passed**