### PR TITLE
feat: export open failure analysis to CSV report (#40)

### DIFF
--- a/src/book_graph_analyzer/cli.py
+++ b/src/book_graph_analyzer/cli.py
@@ -5192,7 +5192,8 @@ def workflow_analyze_failure_issue(issue_number: int, workflow_path: str, env_fi
     help="Workflow YAML used by failed runs",
 )
 @click.option("--env-file", default="", help="Optional .env file for local secret checks")
-def workflow_analyze_open_failures(label: str, limit: int, workflow_path: str, env_file: str) -> None:
+@click.option("--out-csv", default="", help="Optional output CSV path for batch analysis report")
+def workflow_analyze_open_failures(label: str, limit: int, workflow_path: str, env_file: str, out_csv: str) -> None:
     """Analyze all open failure issues (batch mode) via gh issue list/view.
 
     Skips known parent tracker issues by title prefix '[agentics] Failed runs'.
@@ -5207,6 +5208,7 @@ def workflow_analyze_open_failures(label: str, limit: int, workflow_path: str, e
 
     analyzed = 0
     missing_any = False
+    csv_rows = []
 
     for issue in issues:
         # Skip parent tracker issue
@@ -5222,12 +5224,34 @@ def workflow_analyze_open_failures(label: str, limit: int, workflow_path: str, e
         console.print(f"\n[bold]Issue #{issue.number}: {issue.title}[/bold]")
         _print_workflow_failure_analysis(analysis)
         analyzed += 1
+        csv_rows.append(analysis.to_row(issue.number, issue.title))
         if analysis.missing_secrets:
             missing_any = True
 
     if analyzed == 0:
         console.print("[yellow]No actionable failure issues found after filtering.[/yellow]")
         return
+
+    if out_csv:
+        import csv
+        out_path = Path(out_csv)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        fieldnames = [
+            "issue_number",
+            "issue_title",
+            "run_id",
+            "run_url",
+            "secret_verification_failed",
+            "required_secrets",
+            "present_secrets",
+            "missing_secrets",
+            "diagnosis",
+        ]
+        with open(out_path, "w", newline="", encoding="utf-8") as f:
+            writer = csv.DictWriter(f, fieldnames=fieldnames)
+            writer.writeheader()
+            writer.writerows(csv_rows)
+        console.print(f"[green]Wrote CSV analysis report:[/green] {out_path}")
 
     if missing_any:
         raise click.Abort()

--- a/src/book_graph_analyzer/ops/workflow_failure.py
+++ b/src/book_graph_analyzer/ops/workflow_failure.py
@@ -21,6 +21,20 @@ class FailureAnalysis:
     present_secrets: list[str]
     missing_secrets: list[str]
 
+    def to_row(self, issue_number: int, issue_title: str) -> dict[str, str]:
+        """Flatten analysis for CSV/report export."""
+        return {
+            "issue_number": str(issue_number),
+            "issue_title": issue_title,
+            "run_id": str(self.run_id or ""),
+            "run_url": str(self.run_url or ""),
+            "secret_verification_failed": "true" if self.secret_verification_failed else "false",
+            "required_secrets": ";".join(self.required_secrets),
+            "present_secrets": ";".join(self.present_secrets),
+            "missing_secrets": ";".join(self.missing_secrets),
+            "diagnosis": self.summary,
+        }
+
     @property
     def summary(self) -> str:
         if self.secret_verification_failed and self.missing_secrets:

--- a/tests/test_workflow_failure.py
+++ b/tests/test_workflow_failure.py
@@ -193,6 +193,7 @@ jobs:
 
     monkeypatch.setattr("book_graph_analyzer.ops.list_open_issues_via_gh", lambda label, limit: issues)
 
+    out_csv = tmp_path / "analysis.csv"
     runner = CliRunner()
     res = runner.invoke(
         main,
@@ -200,12 +201,18 @@ jobs:
             "workflow-analyze-open-failures",
             "--workflow",
             str(wf),
+            "--out-csv",
+            str(out_csv),
         ],
     )
     # Missing secret from issue 41 should fail command
     assert res.exit_code != 0
     assert "Issue #41" in res.output
     assert "Workflow Failure Analysis" in res.output
+    assert out_csv.exists()
+    csv_text = out_csv.read_text(encoding="utf-8")
+    assert "issue_number" in csv_text
+    assert "41" in csv_text
 
 
 def test_build_remediation_report_contains_actions(tmp_path: Path):


### PR DESCRIPTION
## Summary
Issue #40 follow-up: add CSV export for batch open-failure analysis.

## What was added

### workflow-analyze-open-failures enhancement
- New option: --out-csv <path>
- When set, writes a machine-readable CSV report containing one row per analyzed issue.

Fields exported:
- issue_number
- issue_title
- un_id
- un_url
- secret_verification_failed
- equired_secrets
- present_secrets
- missing_secrets
- diagnosis

### FailureAnalysis helper
- Added FailureAnalysis.to_row(issue_number, issue_title) in ops/workflow_failure.py
- Provides normalized CSV row serialization.

## Tests
- Updated 	ests/test_workflow_failure.py
- Verified CSV file generation and contents in 	est_cli_workflow_analyze_open_failures

Run:
`ash
python -m pytest tests/test_workflow_failure.py -v
`
Result: **13 passed**