### PR TITLE
feat: add JSON export for open failure batch analysis (#40)

### DIFF
--- a/src/book_graph_analyzer/cli.py
+++ b/src/book_graph_analyzer/cli.py
@@ -5193,7 +5193,15 @@ def workflow_analyze_failure_issue(issue_number: int, workflow_path: str, env_fi
 )
 @click.option("--env-file", default="", help="Optional .env file for local secret checks")
 @click.option("--out-csv", default="", help="Optional output CSV path for batch analysis report")
-def workflow_analyze_open_failures(label: str, limit: int, workflow_path: str, env_file: str, out_csv: str) -> None:
+@click.option("--out-json", default="", help="Optional output JSON path for batch analysis report")
+def workflow_analyze_open_failures(
+    label: str,
+    limit: int,
+    workflow_path: str,
+    env_file: str,
+    out_csv: str,
+    out_json: str,
+) -> None:
     """Analyze all open failure issues (batch mode) via gh issue list/view.
 
     Skips known parent tracker issues by title prefix '[agentics] Failed runs'.
@@ -5234,6 +5242,7 @@ def workflow_analyze_open_failures(label: str, limit: int, workflow_path: str, e
 
     if out_csv:
         import csv
+
         out_path = Path(out_csv)
         out_path.parent.mkdir(parents=True, exist_ok=True)
         fieldnames = [
@@ -5252,6 +5261,15 @@ def workflow_analyze_open_failures(label: str, limit: int, workflow_path: str, e
             writer.writeheader()
             writer.writerows(csv_rows)
         console.print(f"[green]Wrote CSV analysis report:[/green] {out_path}")
+
+    if out_json:
+        import json
+
+        out_path = Path(out_json)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(out_path, "w", encoding="utf-8") as f:
+            json.dump(csv_rows, f, ensure_ascii=False, indent=2)
+        console.print(f"[green]Wrote JSON analysis report:[/green] {out_path}")
 
     if missing_any:
         raise click.Abort()

--- a/tests/test_workflow_failure.py
+++ b/tests/test_workflow_failure.py
@@ -194,6 +194,7 @@ jobs:
     monkeypatch.setattr("book_graph_analyzer.ops.list_open_issues_via_gh", lambda label, limit: issues)
 
     out_csv = tmp_path / "analysis.csv"
+    out_json = tmp_path / "analysis.json"
     runner = CliRunner()
     res = runner.invoke(
         main,
@@ -203,6 +204,8 @@ jobs:
             str(wf),
             "--out-csv",
             str(out_csv),
+            "--out-json",
+            str(out_json),
         ],
     )
     # Missing secret from issue 41 should fail command
@@ -213,6 +216,11 @@ jobs:
     csv_text = out_csv.read_text(encoding="utf-8")
     assert "issue_number" in csv_text
     assert "41" in csv_text
+
+    assert out_json.exists()
+    json_text = out_json.read_text(encoding="utf-8")
+    assert "issue_number" in json_text
+    assert "41" in json_text
 
 
 def test_build_remediation_report_contains_actions(tmp_path: Path):


### PR DESCRIPTION
## Summary
Issue #40 follow-up: add JSON export for batch failure analysis output.

## What changed

### workflow-analyze-open-failures enhancement
- Existing --out-csv support retained.
- Added new option: --out-json <path>
  - writes UTF-8 pretty-printed JSON array
  - each element is the same normalized row shape used in CSV output

Fields exported per issue:
- issue_number
- issue_title
- un_id
- un_url
- secret_verification_failed
- equired_secrets
- present_secrets
- missing_secrets
- diagnosis

## Tests
- Updated 	ests/test_workflow_failure.py
  - 	est_cli_workflow_analyze_open_failures now validates both CSV and JSON outputs
- Run:
`ash
python -m pytest tests/test_workflow_failure.py -v
`
- Result: **13 passed**