### PR TITLE
feat: add markdown summary export for open failure batch analysis (#40)

### DIFF
--- a/src/book_graph_analyzer/cli.py
+++ b/src/book_graph_analyzer/cli.py
@@ -5194,6 +5194,7 @@ def workflow_analyze_failure_issue(issue_number: int, workflow_path: str, env_fi
 @click.option("--env-file", default="", help="Optional .env file for local secret checks")
 @click.option("--out-csv", default="", help="Optional output CSV path for batch analysis report")
 @click.option("--out-json", default="", help="Optional output JSON path for batch analysis report")
+@click.option("--out-md", default="", help="Optional output markdown summary path")
 def workflow_analyze_open_failures(
     label: str,
     limit: int,
@@ -5201,6 +5202,7 @@ def workflow_analyze_open_failures(
     env_file: str,
     out_csv: str,
     out_json: str,
+    out_md: str,
 ) -> None:
     """Analyze all open failure issues (batch mode) via gh issue list/view.
 
@@ -5270,6 +5272,25 @@ def workflow_analyze_open_failures(
         with open(out_path, "w", encoding="utf-8") as f:
             json.dump(csv_rows, f, ensure_ascii=False, indent=2)
         console.print(f"[green]Wrote JSON analysis report:[/green] {out_path}")
+
+    if out_md:
+        out_path = Path(out_md)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        lines = [
+            "# Open Workflow Failure Analysis",
+            "",
+            "| Issue | Run ID | Secret Verification Failed | Missing Secrets | Diagnosis |",
+            "|---|---:|:---:|---|---|",
+        ]
+        for row in csv_rows:
+            issue = f"#{row['issue_number']} {row['issue_title']}"
+            run_id = row.get("run_id", "") or "n/a"
+            svf = row.get("secret_verification_failed", "false")
+            missing = row.get("missing_secrets", "") or "none"
+            diagnosis = (row.get("diagnosis", "") or "").replace("|", "\\|")
+            lines.append(f"| {issue} | {run_id} | {svf} | {missing} | {diagnosis} |")
+        out_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        console.print(f"[green]Wrote markdown summary report:[/green] {out_path}")
 
     if missing_any:
         raise click.Abort()

--- a/tests/test_workflow_failure.py
+++ b/tests/test_workflow_failure.py
@@ -195,6 +195,7 @@ jobs:
 
     out_csv = tmp_path / "analysis.csv"
     out_json = tmp_path / "analysis.json"
+    out_md = tmp_path / "analysis.md"
     runner = CliRunner()
     res = runner.invoke(
         main,
@@ -206,6 +207,8 @@ jobs:
             str(out_csv),
             "--out-json",
             str(out_json),
+            "--out-md",
+            str(out_md),
         ],
     )
     # Missing secret from issue 41 should fail command
@@ -221,6 +224,12 @@ jobs:
     json_text = out_json.read_text(encoding="utf-8")
     assert "issue_number" in json_text
     assert "41" in json_text
+
+    assert out_md.exists()
+    md_text = out_md.read_text(encoding="utf-8")
+    assert "# Open Workflow Failure Analysis" in md_text
+    assert "| Issue | Run ID |" in md_text
+    assert "#41" in md_text
 
 
 def test_build_remediation_report_contains_actions(tmp_path: Path):


### PR DESCRIPTION
## Summary
Issue #40 follow-up: add markdown summary export for batch open-failure analysis.

## What changed

### workflow-analyze-open-failures enhancement
- Existing exports retained:
  - --out-csv
  - --out-json
- Added:
  - --out-md <path>

The markdown export writes a compact table suitable for issue comments or status docs:
- Issue
- Run ID
- Secret Verification Failed
- Missing Secrets
- Diagnosis

## Tests
- Updated 	ests/test_workflow_failure.py
- Extended 	est_cli_workflow_analyze_open_failures to validate markdown export file and content.

Run:
`ash
python -m pytest tests/test_workflow_failure.py -v
`
Result: **13 passed**