### PR TITLE
feat: add severity classification to workflow failure analysis outputs (#40)

### DIFF
--- a/src/book_graph_analyzer/cli.py
+++ b/src/book_graph_analyzer/cli.py
@@ -5104,6 +5104,7 @@ def _print_workflow_failure_analysis(analysis) -> None:
     console.print("[bold]Workflow Failure Analysis[/bold]")
     console.print(f"Run URL: {analysis.run_url or 'n/a'}")
     console.print(f"Run ID: {analysis.run_id or 'n/a'}")
+    console.print(f"Severity: [bold]{analysis.severity}[/bold]")
     console.print(f"Secret verification phrase detected: {analysis.secret_verification_failed}")
 
     table = Table(title="Required Secrets")
@@ -5252,6 +5253,7 @@ def workflow_analyze_open_failures(
             "issue_title",
             "run_id",
             "run_url",
+            "severity",
             "secret_verification_failed",
             "required_secrets",
             "present_secrets",
@@ -5279,16 +5281,17 @@ def workflow_analyze_open_failures(
         lines = [
             "# Open Workflow Failure Analysis",
             "",
-            "| Issue | Run ID | Secret Verification Failed | Missing Secrets | Diagnosis |",
-            "|---|---:|:---:|---|---|",
+            "| Issue | Run ID | Severity | Secret Verification Failed | Missing Secrets | Diagnosis |",
+            "|---|---:|---|:---:|---|---|",
         ]
         for row in csv_rows:
             issue = f"#{row['issue_number']} {row['issue_title']}"
             run_id = row.get("run_id", "") or "n/a"
+            severity = row.get("severity", "low")
             svf = row.get("secret_verification_failed", "false")
             missing = row.get("missing_secrets", "") or "none"
             diagnosis = (row.get("diagnosis", "") or "").replace("|", "\\|")
-            lines.append(f"| {issue} | {run_id} | {svf} | {missing} | {diagnosis} |")
+            lines.append(f"| {issue} | {run_id} | {severity} | {svf} | {missing} | {diagnosis} |")
         out_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
         console.print(f"[green]Wrote markdown summary report:[/green] {out_path}")
 
@@ -5723,11 +5726,12 @@ def workflow_post_open_failures_summary(
     lines = [
         "## Automated Failure Summary",
         "",
-        "| Issue | Run ID | Secret Verification Failed | Missing Secrets |",
-        "|---|---:|:---:|---|",
+        "| Issue | Run ID | Severity | Secret Verification Failed | Missing Secrets |",
+        "|---|---:|---|:---:|---|",
     ]
 
     unresolved = 0
+    severity_counts = {"critical": 0, "high": 0, "medium": 0, "low": 0}
     for issue in actionable:
         analysis = analyze_failure_from_issue_text(
             issue.body,
@@ -5736,8 +5740,10 @@ def workflow_post_open_failures_summary(
         )
         if analysis.missing_secrets:
             unresolved += 1
+        severity_counts[analysis.severity] = severity_counts.get(analysis.severity, 0) + 1
         lines.append(
             f"| #{issue.number} {issue.title} | {analysis.run_id or 'n/a'} | "
+            f"{analysis.severity} | "
             f"{str(analysis.secret_verification_failed).lower()} | "
             f"{(';'.join(analysis.missing_secrets) if analysis.missing_secrets else 'none')} |"
         )
@@ -5745,6 +5751,12 @@ def workflow_post_open_failures_summary(
     lines.append("")
     lines.append(f"Open actionable failures: **{len(actionable)}**")
     lines.append(f"Unresolved (missing secrets): **{unresolved}**")
+    lines.append(
+        f"Severity breakdown — critical: **{severity_counts['critical']}**, "
+        f"high: **{severity_counts['high']}**, "
+        f"medium: **{severity_counts['medium']}**, "
+        f"low: **{severity_counts['low']}**"
+    )
 
     body = "\n".join(lines)
     ok = post_issue_comment_via_gh(parent_issue, body)

--- a/src/book_graph_analyzer/ops/workflow_failure.py
+++ b/src/book_graph_analyzer/ops/workflow_failure.py
@@ -21,6 +21,24 @@ class FailureAnalysis:
     present_secrets: list[str]
     missing_secrets: list[str]
 
+    @property
+    def severity(self) -> str:
+        """Classify failure severity for triage dashboards.
+
+        Levels:
+          - critical: explicit secret-verification failure + missing secrets
+          - high: missing secrets (without explicit phrase)
+          - medium: explicit secret-verification phrase but no missing secrets
+          - low: no secret-related indicators in current analyzer
+        """
+        if self.secret_verification_failed and self.missing_secrets:
+            return "critical"
+        if self.missing_secrets:
+            return "high"
+        if self.secret_verification_failed:
+            return "medium"
+        return "low"
+
     def to_row(self, issue_number: int, issue_title: str) -> dict[str, str]:
         """Flatten analysis for CSV/report export."""
         return {
@@ -28,6 +46,7 @@ class FailureAnalysis:
             "issue_title": issue_title,
             "run_id": str(self.run_id or ""),
             "run_url": str(self.run_url or ""),
+            "severity": self.severity,
             "secret_verification_failed": "true" if self.secret_verification_failed else "false",
             "required_secrets": ";".join(self.required_secrets),
             "present_secrets": ";".join(self.present_secrets),

--- a/tests/test_workflow_failure.py
+++ b/tests/test_workflow_failure.py
@@ -63,6 +63,7 @@ jobs:
     assert analysis.run_id == "22260153462"
     assert "GH_AW_GITHUB_TOKEN" in analysis.present_secrets
     assert "COPILOT_GITHUB_TOKEN" in analysis.missing_secrets
+    assert analysis.severity == "critical"
 
 
 def test_cli_workflow_analyze_failure(tmp_path: Path):
@@ -218,17 +219,19 @@ jobs:
     assert out_csv.exists()
     csv_text = out_csv.read_text(encoding="utf-8")
     assert "issue_number" in csv_text
+    assert "severity" in csv_text
     assert "41" in csv_text
 
     assert out_json.exists()
     json_text = out_json.read_text(encoding="utf-8")
     assert "issue_number" in json_text
+    assert "severity" in json_text
     assert "41" in json_text
 
     assert out_md.exists()
     md_text = out_md.read_text(encoding="utf-8")
     assert "# Open Workflow Failure Analysis" in md_text
-    assert "| Issue | Run ID |" in md_text
+    assert "| Issue | Run ID | Severity |" in md_text
     assert "#41" in md_text
 
 
@@ -339,6 +342,8 @@ jobs:
     assert res.exit_code == 0
     assert captured["issue"] == 40
     assert "Automated Failure Summary" in captured["body"]
+    assert "Severity" in captured["body"]
+    assert "Severity breakdown" in captured["body"]
     assert "#41" in captured["body"]
 
 


### PR DESCRIPTION
## Summary
Issue #40 follow-up: adds explicit severity classification to workflow failure diagnostics and exports.

## What changed

### FailureAnalysis enhancement
- Added FailureAnalysis.severity property with triage levels:
  - critical: secret-verification phrase + missing secrets
  - high: missing secrets only
  - medium: secret-verification phrase only
  - low: no secret-related indicators

### Export/report updates
- FailureAnalysis.to_row(...) now includes severity
- workflow-analyze-open-failures exports now include severity in:
  - CSV (--out-csv)
  - JSON (--out-json)
  - Markdown (--out-md)
- Parent summary command (workflow-post-open-failures-summary) now:
  - includes Severity column
  - includes severity breakdown totals (critical/high/medium/low)

## Tests
Updated 	ests/test_workflow_failure.py to verify:
- nalysis.severity == critical for issue #41-style case
- CSV/JSON include severity field
- markdown output includes Severity column
- parent summary includes severity breakdown

Run:
`ash
python -m pytest tests/test_workflow_failure.py -v
`
Result: **14 passed**