### PR TITLE
feat: sort parent failure summary table by severity (#40)

### DIFF
--- a/src/book_graph_analyzer/cli.py
+++ b/src/book_graph_analyzer/cli.py
@@ -5730,6 +5730,9 @@ def workflow_post_open_failures_summary(
         "|---|---:|---|:---:|---|",
     ]
 
+    severity_rank = {"critical": 0, "high": 1, "medium": 2, "low": 3}
+    analyzed_rows = []
+
     unresolved = 0
     severity_counts = {"critical": 0, "high": 0, "medium": 0, "low": 0}
     for issue in actionable:
@@ -5741,6 +5744,11 @@ def workflow_post_open_failures_summary(
         if analysis.missing_secrets:
             unresolved += 1
         severity_counts[analysis.severity] = severity_counts.get(analysis.severity, 0) + 1
+        analyzed_rows.append((issue, analysis))
+
+    analyzed_rows.sort(key=lambda x: (severity_rank.get(x[1].severity, 99), x[0].number))
+
+    for issue, analysis in analyzed_rows:
         lines.append(
             f"| #{issue.number} {issue.title} | {analysis.run_id or 'n/a'} | "
             f"{analysis.severity} | "

--- a/tests/test_workflow_failure.py
+++ b/tests/test_workflow_failure.py
@@ -313,6 +313,7 @@ jobs:
 
     issues = [
         IssueData(number=40, title="[agentics] Failed runs", body="parent", url="u40"),
+        IssueData(number=42, title="[agentics] Non-secret timeout", body="run failed due to timeout", url="u42"),
         IssueData(number=41, title="[agentics] Architecture failed", body=ISSUE_TEXT, url="u41"),
     ]
     monkeypatch.setattr("book_graph_analyzer.ops.list_open_issues_via_gh", lambda label, limit: issues)
@@ -344,7 +345,8 @@ jobs:
     assert "Automated Failure Summary" in captured["body"]
     assert "Severity" in captured["body"]
     assert "Severity breakdown" in captured["body"]
-    assert "#41" in captured["body"]
+    # critical issue (#41) should appear before low issue (#42)
+    assert captured["body"].find("#41") < captured["body"].find("#42")
 
 
 def test_cli_workflow_post_diagnosis(monkeypatch, tmp_path: Path):


### PR DESCRIPTION
## Summary
Issue #40 follow-up: improve triage readability by sorting parent summary rows by severity.

## What changed
- Updated workflow-post-open-failures-summary to sort actionable issue rows by:
  1. severity rank (critical > high > medium > low)
  2. issue number (ascending) as tie-breaker

This ensures the most urgent failures appear first in the posted summary comment.

## Tests
- Updated 	ests/test_workflow_failure.py
- 	est_cli_workflow_post_open_failures_summary now verifies ordering (#41 critical appears before #42 low)

Run:
`ash
python -m pytest tests/test_workflow_failure.py -v
`
Result: **14 passed**