### PR TITLE
feat(issue-50): lore depth slice 1 (artifacts + unresolved refs)

### DIFF
--- a/docs/tolkien-worldbuilding-rfc.md
+++ b/docs/tolkien-worldbuilding-rfc.md
@@ -268,3 +268,20 @@ not a new top-level package.
 - [ ] Batch-optimized Cypher (current impl uses per-lineage transactions)
 - [ ] `worldbible.extractor` integration for automatic language category extraction
 - [ ] Query helpers: "all names for entity X across languages" as a CLI subcommand
+
+### #50 Slice 1 (Impression-of-Depth Engine) Update
+
+Implemented in this slice:
+- Added first-class lore-depth models (`LoreArtifact`, `BrokenReference`) in `models/lore_depth.py`
+- Added extraction helper `lore.depth.extract_lore_depth(...)` for artifact-like mentions and unresolved markers
+- Added GraphWriter persistence/query helpers for lore depth nodes and unresolved-reference reporting
+- Added CLI commands under existing families:
+  - `worldbible artifacts`
+  - `lore unresolved-refs`
+- Added tests in `tests/test_issue_50_lore_depth_slice1.py`
+
+Remaining for Issue #50:
+- stronger context-aware extraction and disambiguation
+- resolver-backed candidate linking for broken references
+- richer provenance/conflict weighting across editorial layers
+- generation-time consumption of unresolved reference queues

--- a/docs/wiki/issue-50-slice1-lore-depth.md
+++ b/docs/wiki/issue-50-slice1-lore-depth.md
@@ -1,0 +1,35 @@
+# Issue #50 Slice 1 — Lore Depth Engine Kickoff
+
+Status: ✅ implemented on `feat/50-lore-depth-slice1`
+
+## Scope delivered
+
+1. First-class models
+- `LoreArtifactType` (`song`, `poem`, `artifact`)
+- `LoreArtifact`
+- `BrokenReference`
+- `LoreDepthExtractionResult`
+
+2. Extraction
+- `extract_lore_depth(text, source_book, passage_id)` in `src/book_graph_analyzer/lore/depth.py`
+- Detects:
+  - artifact-like mentions (`song/poem/artifact/relic/...`)
+  - unresolved markers (`[[...]]`, `unknown/unnamed/forgotten ...`)
+
+3. GraphWriter integration
+- `write_lore_artifacts_batch(...)`
+- `write_broken_references_batch(...)`
+- `query_lore_artifacts(...)`
+- `query_unresolved_references(...)`
+
+4. CLI integration (existing groups)
+- `bga worldbible artifacts <path> [--output out.json] [--write-graph]`
+- `bga lore unresolved-refs [--book BOOK] [--limit N]`
+
+5. Tests
+- `tests/test_issue_50_lore_depth_slice1.py`
+
+## Notes
+
+This slice is additive/backward-compatible and intentionally heuristic-first.
+Later slices should improve extraction precision and candidate-link resolution.

--- a/src/book_graph_analyzer/cli.py
+++ b/src/book_graph_analyzer/cli.py
@@ -5825,6 +5825,84 @@ def worldbible_languages(bible_path: str, entity: str | None, write_graph: bool)
             raise SystemExit(1)
 
 
+@worldbible.command(name="artifacts")
+@click.argument("path", type=click.Path(exists=True))
+@click.option("--book", "book", default=None, help="Source book label")
+@click.option("--output", "output", type=click.Path(), help="Write extracted lore-depth JSON")
+@click.option("--write-graph", is_flag=True, help="Persist artifacts/unresolved refs to Neo4j")
+def worldbible_artifacts(path: str, book: str | None, output: str | None, write_graph: bool) -> None:
+    """Extract lore artifacts and broken references from raw text."""
+    from book_graph_analyzer.lore.depth import extract_lore_depth
+
+    file_path = Path(path)
+    text = file_path.read_text(encoding="utf-8", errors="replace")
+    source_book = book or file_path.stem.replace("_", " ").replace("-", " ").title()
+
+    result = extract_lore_depth(text, source_book=source_book, passage_id=file_path.name)
+
+    console.print(f"[bold]Lore depth extraction:[/bold] {file_path.name}")
+    console.print(f"  Artifacts: [green]{len(result.artifacts)}[/green]")
+    console.print(f"  Unresolved refs: [yellow]{len(result.broken_references)}[/yellow]")
+
+    if result.artifacts:
+        table = Table(title="Artifacts", show_lines=False)
+        table.add_column("Type", style="cyan")
+        table.add_column("Name", style="bold")
+        table.add_column("Confidence", style="dim")
+        for art in result.artifacts[:20]:
+            atype = getattr(art.artifact_type, "value", str(art.artifact_type))
+            table.add_row(atype, art.name, f"{art.confidence:.2f}")
+        console.print(table)
+
+    if output:
+        data = {
+            "artifacts": [a.model_dump() for a in result.artifacts],
+            "broken_references": [b.model_dump() for b in result.broken_references],
+        }
+        Path(output).write_text(json.dumps(data, indent=2), encoding="utf-8")
+        console.print(f"[green]OK[/green] Saved to {output}")
+
+    if write_graph:
+        from book_graph_analyzer.graph.writer import GraphWriter
+        writer = GraphWriter()
+        a_count = writer.write_lore_artifacts_batch(result.artifacts, book=source_book)
+        b_count = writer.write_broken_references_batch(result.broken_references)
+        writer.close()
+        console.print(f"[green]OK[/green] Wrote {a_count} artifacts and {b_count} unresolved references to Neo4j")
+
+
+@lore.command(name="unresolved-refs")
+@click.option("--book", "book", default=None, help="Filter by source book")
+@click.option("--limit", "limit", default=50, type=int, help="Max rows")
+def lore_unresolved_refs(book: str | None, limit: int) -> None:
+    """Query unresolved references persisted by lore-depth extraction."""
+    from book_graph_analyzer.graph.writer import GraphWriter
+
+    writer = GraphWriter()
+    rows = writer.query_unresolved_references(source_book=book, limit=limit)
+    writer.close()
+
+    if not rows:
+        console.print("[yellow]No unresolved references found.[/yellow]")
+        return
+
+    table = Table(title=f"Unresolved References ({len(rows)})")
+    table.add_column("ID", style="dim", width=24)
+    table.add_column("Mention", style="cyan")
+    table.add_column("Type")
+    table.add_column("Book", style="dim")
+    table.add_column("Conf", justify="right")
+    for r in rows:
+        table.add_row(
+            r.get("id", "")[:24],
+            r.get("mention_text", "")[:50],
+            r.get("expected_type") or "-",
+            r.get("source_book") or "-",
+            f"{(r.get('confidence') or 0):.2f}",
+        )
+    console.print(table)
+
+
 @lore.command(name="genealogy")
 @click.option("--character", "-c", help="Character to show family tree for")
 @click.option("--house", "-H", help="Filter by house (e.g., 'House of Finwë')")

--- a/src/book_graph_analyzer/graph/writer.py
+++ b/src/book_graph_analyzer/graph/writer.py
@@ -1372,6 +1372,125 @@ class GraphWriter:
             )
 
     # =========================================================================
+    # Lore Depth Engine (Issue #50 slice 1)
+    # =========================================================================
+
+    def write_lore_artifacts_batch(self, artifacts: list, book: str = "") -> int:
+        """Persist lore artifacts (songs/poems/artifacts) as first-class nodes."""
+        if not artifacts:
+            return 0
+
+        with self.driver.session() as session:
+            for art in artifacts:
+                session.run(
+                    """
+                    MERGE (a:LoreArtifact {id: $id})
+                    SET a.name = $name,
+                        a.artifact_type = $artifact_type,
+                        a.description = $description,
+                        a.source_book = $source_book,
+                        a.confidence = $confidence,
+                        a.updated_at = datetime()
+                    """,
+                    id=art.id,
+                    name=art.name,
+                    artifact_type=getattr(getattr(art, "artifact_type", None), "value", None)
+                    or str(getattr(art, "artifact_type", "artifact")),
+                    description=getattr(art, "description", None),
+                    source_book=getattr(art, "source_book", None) or book,
+                    confidence=float(getattr(art, "confidence", 0.7) or 0.7),
+                )
+                if getattr(art, "passage_id", None):
+                    session.run(
+                        """
+                        MATCH (a:LoreArtifact {id: $artifact_id})
+                        MATCH (p:Passage {id: $passage_id})
+                        MERGE (a)-[:ATTESTED_IN]->(p)
+                        """,
+                        artifact_id=art.id,
+                        passage_id=art.passage_id,
+                    )
+        return len(artifacts)
+
+    def write_broken_references_batch(self, refs: list) -> int:
+        """Persist unresolved references for later curation."""
+        if not refs:
+            return 0
+
+        with self.driver.session() as session:
+            for ref in refs:
+                session.run(
+                    """
+                    MERGE (u:UnresolvedReference {id: $id})
+                    SET u.mention_text = $mention_text,
+                        u.context_text = $context_text,
+                        u.expected_type = $expected_type,
+                        u.source_book = $source_book,
+                        u.passage_id = $passage_id,
+                        u.resolved_entity_id = $resolved_entity_id,
+                        u.confidence = $confidence,
+                        u.updated_at = datetime()
+                    """,
+                    id=ref.id,
+                    mention_text=getattr(ref, "mention_text", ""),
+                    context_text=getattr(ref, "context_text", None),
+                    expected_type=getattr(ref, "expected_type", None),
+                    source_book=getattr(ref, "source_book", None),
+                    passage_id=getattr(ref, "passage_id", None),
+                    resolved_entity_id=getattr(ref, "resolved_entity_id", None),
+                    confidence=float(getattr(ref, "confidence", 0.6) or 0.6),
+                )
+        return len(refs)
+
+    def query_lore_artifacts(self, artifact_type: str | None = None, limit: int = 100) -> list[dict]:
+        """Query lore artifacts by optional type."""
+        where = "true"
+        params: dict = {"limit": limit}
+        if artifact_type:
+            where = "a.artifact_type = $artifact_type"
+            params["artifact_type"] = artifact_type
+
+        with self.driver.session() as session:
+            result = session.run(
+                f"""
+                MATCH (a:LoreArtifact)
+                WHERE {where}
+                RETURN a.id AS id, a.name AS name, a.artifact_type AS artifact_type,
+                       a.description AS description, a.source_book AS source_book,
+                       a.confidence AS confidence
+                ORDER BY a.name
+                LIMIT $limit
+                """,
+                **params,
+            )
+            return [dict(r) for r in result]
+
+    def query_unresolved_references(self, source_book: str | None = None, limit: int = 100) -> list[dict]:
+        """Query unresolved references, filtered by source book if provided."""
+        where = "u.resolved_entity_id IS NULL"
+        params: dict = {"limit": limit}
+        if source_book:
+            where += " AND toLower(coalesce(u.source_book,'')) CONTAINS toLower($source_book)"
+            params["source_book"] = source_book
+
+        with self.driver.session() as session:
+            result = session.run(
+                f"""
+                MATCH (u:UnresolvedReference)
+                WHERE {where}
+                RETURN u.id AS id, u.mention_text AS mention_text,
+                       u.expected_type AS expected_type,
+                       u.source_book AS source_book,
+                       u.passage_id AS passage_id,
+                       u.confidence AS confidence
+                ORDER BY u.confidence DESC
+                LIMIT $limit
+                """,
+                **params,
+            )
+            return [dict(r) for r in result]
+
+    # =========================================================================
     # Sociolinguistic Registers (Issue #47 slice 1)
     # =========================================================================
 

--- a/src/book_graph_analyzer/lore/__init__.py
+++ b/src/book_graph_analyzer/lore/__init__.py
@@ -36,6 +36,7 @@ from .sociolinguistic_registers import (
     SociolinguisticRegisterClassifier,
     detect_register_drift,
 )
+from .depth import extract_lore_depth
 
 __all__ = [
     "LoreChecker",
@@ -68,4 +69,5 @@ __all__ = [
     "RegisterDrift",
     "SociolinguisticRegisterClassifier",
     "detect_register_drift",
+    "extract_lore_depth",
 ]

--- a/src/book_graph_analyzer/lore/depth.py
+++ b/src/book_graph_analyzer/lore/depth.py
@@ -1,0 +1,82 @@
+"""Lore-depth extraction helpers for artifacts and unresolved references."""
+
+from __future__ import annotations
+
+import re
+
+from ..models.lore_depth import (
+    BrokenReference,
+    LoreArtifact,
+    LoreArtifactType,
+    LoreDepthExtractionResult,
+)
+
+
+_ARTIFACT_RE = re.compile(
+    r"\b(?P<kind>song|poem|lay|chant|verse|artifact|relic|amulet|ring|sword|crown)\s+(?:of\s+)?(?P<name>[A-Z][\w'\-]*(?:\s+[A-Z][\w'\-]*){0,4})"
+)
+
+_BROKEN_REF_BRACKETS_RE = re.compile(r"\[\[([^\]]+)\]\]")
+_BROKEN_REF_QUAL_RE = re.compile(
+    r"\b(?P<text>(unknown|unnamed|forgotten)\s+(artifact|relic|song|poem|name|heir))\b",
+    re.IGNORECASE,
+)
+
+
+def extract_lore_depth(
+    text: str,
+    source_book: str | None = None,
+    passage_id: str | None = None,
+) -> LoreDepthExtractionResult:
+    """Extract lore artifacts and unresolved references from raw text."""
+    artifacts: list[LoreArtifact] = []
+    broken: list[BrokenReference] = []
+
+    for i, m in enumerate(_ARTIFACT_RE.finditer(text)):
+        kind = m.group("kind").lower()
+        if kind in {"song", "lay", "chant", "verse"}:
+            artifact_type = LoreArtifactType.SONG
+        elif kind == "poem":
+            artifact_type = LoreArtifactType.POEM
+        else:
+            artifact_type = LoreArtifactType.ARTIFACT
+
+        artifacts.append(
+            LoreArtifact(
+                id=f"artifact_{passage_id or 'inline'}_{i}",
+                name=m.group("name").strip(),
+                artifact_type=artifact_type,
+                description=m.group(0),
+                source_book=source_book,
+                passage_id=passage_id,
+            )
+        )
+
+    for i, m in enumerate(_BROKEN_REF_BRACKETS_RE.finditer(text)):
+        mention = m.group(1).strip()
+        broken.append(
+            BrokenReference(
+                id=f"broken_{passage_id or 'inline'}_b{i}",
+                mention_text=mention,
+                context_text=m.group(0),
+                expected_type="unknown",
+                source_book=source_book,
+                passage_id=passage_id,
+                confidence=0.85,
+            )
+        )
+
+    for i, m in enumerate(_BROKEN_REF_QUAL_RE.finditer(text)):
+        broken.append(
+            BrokenReference(
+                id=f"broken_{passage_id or 'inline'}_q{i}",
+                mention_text=m.group("text"),
+                context_text=m.group(0),
+                expected_type="unresolved_qualifier",
+                source_book=source_book,
+                passage_id=passage_id,
+                confidence=0.65,
+            )
+        )
+
+    return LoreDepthExtractionResult(artifacts=artifacts, broken_references=broken)

--- a/src/book_graph_analyzer/models/__init__.py
+++ b/src/book_graph_analyzer/models/__init__.py
@@ -8,6 +8,12 @@ from book_graph_analyzer.models.worldbuilding import (
     LanguageForm,
     LinguisticLineage,
 )
+from book_graph_analyzer.models.lore_depth import (
+    BrokenReference,
+    LoreArtifact,
+    LoreArtifactType,
+    LoreDepthExtractionResult,
+)
 
 __all__ = [
     "Character",
@@ -21,4 +27,8 @@ __all__ = [
     "GenealogyRelation",
     "LanguageForm",
     "LinguisticLineage",
+    "LoreArtifactType",
+    "LoreArtifact",
+    "BrokenReference",
+    "LoreDepthExtractionResult",
 ]

--- a/src/book_graph_analyzer/models/lore_depth.py
+++ b/src/book_graph_analyzer/models/lore_depth.py
@@ -1,0 +1,47 @@
+"""Models for lore-depth extraction (Issue #50)."""
+
+from __future__ import annotations
+
+from enum import Enum
+from pydantic import BaseModel, Field
+
+
+class LoreArtifactType(str, Enum):
+    """First-class artifact categories for deep lore references."""
+
+    SONG = "song"
+    POEM = "poem"
+    ARTIFACT = "artifact"
+
+
+class LoreArtifact(BaseModel):
+    """A lore artifact mention extracted from text."""
+
+    id: str
+    name: str
+    artifact_type: LoreArtifactType
+    description: str | None = None
+    source_book: str | None = None
+    passage_id: str | None = None
+    referenced_entities: list[str] = Field(default_factory=list)
+    confidence: float = 0.7
+
+
+class BrokenReference(BaseModel):
+    """A likely unresolved/broken reference needing author review."""
+
+    id: str
+    mention_text: str
+    context_text: str | None = None
+    expected_type: str | None = None
+    source_book: str | None = None
+    passage_id: str | None = None
+    resolved_entity_id: str | None = None
+    confidence: float = 0.6
+
+
+class LoreDepthExtractionResult(BaseModel):
+    """Container for a single extraction run."""
+
+    artifacts: list[LoreArtifact] = Field(default_factory=list)
+    broken_references: list[BrokenReference] = Field(default_factory=list)

--- a/tests/test_issue_50_lore_depth_slice1.py
+++ b/tests/test_issue_50_lore_depth_slice1.py
@@ -1,0 +1,58 @@
+from unittest.mock import MagicMock
+
+from click.testing import CliRunner
+
+
+def test_lore_depth_models_importable():
+    from book_graph_analyzer.models import LoreArtifact, BrokenReference, LoreArtifactType
+
+    a = LoreArtifact(id="a1", name="Lay of Leithian", artifact_type=LoreArtifactType.SONG)
+    b = BrokenReference(id="u1", mention_text="[[lost blade]]")
+
+    assert a.artifact_type.value == "song"
+    assert b.mention_text == "[[lost blade]]"
+
+
+def test_extract_lore_depth_finds_artifacts_and_broken_refs():
+    from book_graph_analyzer.lore.depth import extract_lore_depth
+
+    text = "They sang song of Beren and carried artifact Crown of Iron. [[missing name]] and unknown relic remained."
+    result = extract_lore_depth(text, source_book="Silmarillion", passage_id="p1")
+
+    assert len(result.artifacts) >= 1
+    assert any(a.name for a in result.artifacts)
+    assert len(result.broken_references) >= 1
+
+
+def test_graph_writer_lore_depth_methods_exist_and_write():
+    from book_graph_analyzer.graph.writer import GraphWriter
+    from book_graph_analyzer.models.lore_depth import LoreArtifact, LoreArtifactType, BrokenReference
+
+    mock_driver = MagicMock()
+    mock_session = MagicMock()
+    mock_driver.session.return_value.__enter__ = MagicMock(return_value=mock_session)
+    mock_driver.session.return_value.__exit__ = MagicMock(return_value=False)
+
+    writer = GraphWriter(driver=mock_driver)
+
+    a_count = writer.write_lore_artifacts_batch([
+        LoreArtifact(id="a1", name="Lay of Leithian", artifact_type=LoreArtifactType.SONG)
+    ])
+    b_count = writer.write_broken_references_batch([
+        BrokenReference(id="u1", mention_text="[[missing]]")
+    ])
+
+    assert a_count == 1
+    assert b_count == 1
+    assert mock_session.run.called
+
+
+def test_cli_registers_new_commands():
+    from book_graph_analyzer.cli import main
+
+    runner = CliRunner()
+    lore_help = runner.invoke(main, ["lore", "--help"])
+    world_help = runner.invoke(main, ["worldbible", "--help"])
+
+    assert "unresolved-refs" in lore_help.output
+    assert "artifacts" in world_help.output


### PR DESCRIPTION
## Summary\nImplements Issue #50 Slice 1 (Impression-of-Depth Engine kickoff) in an additive/backward-compatible way.\n\n### Included\n- First-class lore depth models:\n  - LoreArtifactType, LoreArtifact, BrokenReference, LoreDepthExtractionResult\n- Extraction helper:\n  - lore.depth.extract_lore_depth(...) for artifact-like mentions and unresolved reference markers\n- GraphWriter persistence/query helpers:\n  - write_lore_artifacts_batch(...)\n  - write_broken_references_batch(...)\n  - query_lore_artifacts(...)\n  - query_unresolved_references(...)\n- CLI integration under existing groups (no new top-level group):\n  - ga worldbible artifacts ...\n  - ga lore unresolved-refs ...\n- Tests:\n  - 	ests/test_issue_50_lore_depth_slice1.py\n- Docs:\n  - RFC update in docs/tolkien-worldbuilding-rfc.md\n  - Wiki note docs/wiki/issue-50-slice1-lore-depth.md\n\n## Validation\n- python -m pytest -q tests/test_issue_50_lore_depth_slice1.py tests/test_worldbuilding_kickoff.py\n\n## Remaining for #50\n- Higher-precision extraction/disambiguation (context + LLM fallback)\n- Resolver-backed candidate linking for broken references\n- Deeper provenance weighting and generation-time usage\n\nCloses #50 (slice 1 progress; full issue remains open).