### PR TITLE
Issue #48 closeout slice 7: source metadata persistence + corpus reconcile integration

### DIFF
--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -89,3 +89,9 @@ Slice 6 additions:
 - report now includes source-attribution counts by `source_book`
 - LLM causal extraction auto-batches large event sets and still falls back safely
 - `bga ingest` prints inferred editorial source metadata when recognized
+
+Slice 7 closeout additions:
+- `CorpusReconciler.add_book_from_json()` now accepts both normalized spatiotemporal payloads and raw `lore events` payloads (`{"events": {...}}` and `{"events": [...]}`), bridging automatically.
+- Cross-book reconcile now namespaces imported event IDs as `<book_id>:<event_id>` to avoid accidental ID collisions across books.
+- Bridged events persist editorial/source metadata (`source_id`, `editorial_status`, `source_authority_weight`) inferred from corpus book titles.
+- Persisted `TimelineConflict` nodes now include source metadata for both involved events (`event_a_*` / `event_b_*` source fields).

--- a/docs/tolkien-worldbuilding-rfc.md
+++ b/docs/tolkien-worldbuilding-rfc.md
@@ -209,9 +209,10 @@ not a new top-level package.
 
 ### Phase 4 - Editorial Layers (Issue #48)
 
-- Source-text metadata tagging in ingest
-- Provenance-weighted lore conflict resolution
-- CLI: `bga corpus sources`
+- ✅ Source-text metadata tagging in ingest + bridge/corpus reconciliation paths
+- ✅ Provenance-weighted lore conflict resolution (authority-aware calibration + persisted conflict source fields)
+- ✅ CLI: `bga corpus sources`
+- ✅ Cross-book reconcile compatibility with both normalized and raw `lore events` JSON payloads
 
 ### Phase 5 - Cultural Rules (Issue #49)
 

--- a/docs/wiki/issue-48-closeout-slice7.md
+++ b/docs/wiki/issue-48-closeout-slice7.md
@@ -1,0 +1,36 @@
+# Issue #48 — Closeout Slice 7
+
+## What this slice closes
+
+- Added end-to-end source/editorial metadata persistence for spatiotemporal events.
+- Added source metadata propagation onto persisted timeline conflicts.
+- Improved cross-book reconciliation ingestion compatibility for corpus pipelines.
+- Added a real fixture-backed integration test for corpus reconciliation.
+
+## Key implementation notes
+
+- `SpatiotemporalEvent` now carries:
+  - `source_id`
+  - `editorial_status`
+  - `source_authority_weight`
+- `TimelineConflict` now carries:
+  - `event_a_source_book`, `event_b_source_book`
+  - `event_a_source_authority_weight`, `event_b_source_authority_weight`
+- `ExtractionBridge.bridge_event()` infers editorial layers from source book and populates metadata.
+- `ConflictDetector.detect_conflicts()` backfills conflict source metadata from involved events.
+- `GraphWriter` now persists and queries the new event/conflict source fields.
+- `CorpusReconciler.add_book_from_json()` now supports:
+  - normalized spatiotemporal event JSON (`{"events": [...]}`)
+  - raw lore-event JSON (`{"events": {...}}` and `{"events": [...]}`)
+- Imported events are namespaced as `<book_id>:<event_id>` to avoid cross-book ID collisions.
+
+## Validation
+
+- New test: `tests/test_issue48_closeout_integration.py`
+- Uses real fixtures:
+  - `data/output/hobbit_events.json`
+  - `data/output/unfinished_tales_events.json`
+- Verifies:
+  - fixture loading through corpus reconciler path
+  - event ID namespacing
+  - editorial/source metadata inferred and retained end-to-end

--- a/src/book_graph_analyzer/cli.py
+++ b/src/book_graph_analyzer/cli.py
@@ -6012,6 +6012,8 @@ def corpus_timeline_reconcile(
             search_dir / f"{book_slug}_events.json",
             search_dir / f"{corpus_name}_{book_slug}_events.json",
             search_dir / f"{book_slug}.json",
+            search_dir / book_slug / "events.json",
+            search_dir / book_slug / f"{book_slug}_events.json",
         ]
         found = None
         for c in candidates:

--- a/src/book_graph_analyzer/graph/writer.py
+++ b/src/book_graph_analyzer/graph/writer.py
@@ -1583,6 +1583,8 @@ class GraphWriter:
             e.location_id = $location_id, e.location_name = $location_name,
             e.description = $description, e.event_type = $event_type,
             e.source_book = $source_book, e.source_passage_id = $source_passage_id,
+            e.source_id = $source_id, e.editorial_status = $editorial_status,
+            e.source_authority_weight = $source_authority_weight,
             e.time_era = $time_era, e.time_year_start = $time_year_start,
             e.time_year_end = $time_year_end, e.time_confidence = $time_confidence,
             e.time_raw_text = $time_raw_text
@@ -1593,6 +1595,9 @@ class GraphWriter:
             "location_name": event.location_name, "description": event.description,
             "event_type": event.event_type, "source_book": event.source_book,
             "source_passage_id": event.source_passage_id,
+            "source_id": getattr(event, "source_id", None),
+            "editorial_status": getattr(event, "editorial_status", None),
+            "source_authority_weight": getattr(event, "source_authority_weight", None),
             "time_era": event.time.era, "time_year_start": event.time.year_start,
             "time_year_end": event.time.year_end, "time_confidence": event.time.confidence,
             "time_raw_text": event.time.raw_text,
@@ -1674,6 +1679,10 @@ class GraphWriter:
             c.description = $description, c.event_a_id = $event_a_id,
             c.event_b_id = $event_b_id, c.entity_id = $entity_id,
             c.suggestion = $suggestion, c.confidence = $confidence,
+            c.event_a_source_book = $event_a_source_book,
+            c.event_b_source_book = $event_b_source_book,
+            c.event_a_source_authority_weight = $event_a_source_authority_weight,
+            c.event_b_source_authority_weight = $event_b_source_authority_weight,
             c.updated_at = datetime()
         """
         params = {
@@ -1686,6 +1695,10 @@ class GraphWriter:
             "entity_id": conflict.entity_id,
             "suggestion": conflict.suggestion,
             "confidence": conflict.confidence,
+            "event_a_source_book": getattr(conflict, "event_a_source_book", None),
+            "event_b_source_book": getattr(conflict, "event_b_source_book", None),
+            "event_a_source_authority_weight": getattr(conflict, "event_a_source_authority_weight", None),
+            "event_b_source_authority_weight": getattr(conflict, "event_b_source_authority_weight", None),
         }
         with self.driver.session() as session:
             session.run(query, **params)
@@ -1750,7 +1763,11 @@ class GraphWriter:
                c.severity AS severity, c.description AS description,
                c.event_a_id AS event_a_id, c.event_b_id AS event_b_id,
                c.entity_id AS entity_id, c.suggestion AS suggestion,
-               c.confidence AS confidence
+               c.confidence AS confidence,
+               c.event_a_source_book AS event_a_source_book,
+               c.event_b_source_book AS event_b_source_book,
+               c.event_a_source_authority_weight AS event_a_source_authority_weight,
+               c.event_b_source_authority_weight AS event_b_source_authority_weight
         ORDER BY c.confidence DESC
         LIMIT $limit
         """

--- a/src/book_graph_analyzer/spatiotemporal/conflict_detector.py
+++ b/src/book_graph_analyzer/spatiotemporal/conflict_detector.py
@@ -63,6 +63,18 @@ class ConflictDetector:
             links = causal_links if causal_links is not None else self.causal_links
             if links:
                 conflicts.extend(self._detect_causal_paradoxes(events, links))
+
+        events_by_id = {e.id: e for e in events}
+        for conflict in conflicts:
+            ev_a = events_by_id.get(conflict.event_a_id or "")
+            ev_b = events_by_id.get(conflict.event_b_id or "")
+            if ev_a:
+                conflict.event_a_source_book = ev_a.source_book
+                conflict.event_a_source_authority_weight = ev_a.source_authority_weight
+            if ev_b:
+                conflict.event_b_source_book = ev_b.source_book
+                conflict.event_b_source_authority_weight = ev_b.source_authority_weight
+
         conflicts.sort(key=lambda c: -c.confidence)
         return conflicts
 

--- a/src/book_graph_analyzer/spatiotemporal/corpus_reconciler.py
+++ b/src/book_graph_analyzer/spatiotemporal/corpus_reconciler.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 from .causal_extraction import extract_causal_links_heuristic
 from .conflict_detector import ConflictDetector
+from .extraction_bridge import ExtractionBridge
 from .models import (
     CausalLink, ConflictType, LocationEdge, LocationNode,
     SpatiotemporalEvent, TimelineConflict,
@@ -158,18 +159,48 @@ class CorpusReconciler:
         self.books.append(book)
 
     def add_book_from_json(self, json_path: str | Path, book_id: str, book_title: str) -> int:
-        """Load events from a JSON file and add to reconciler. Returns event count."""
+        """Load events from a JSON file and add to reconciler. Returns event count.
+
+        Supports both:
+        - spatiotemporal event payloads (list[SpatiotemporalEvent-like dict])
+        - lore/events payloads ({"events": {id: {...}}} or {"events": [...]})
+        """
         path = Path(json_path)
         with open(path, "r", encoding="utf-8") as f:
             raw = json.load(f)
+
+        raw_events = raw
         if isinstance(raw, dict) and "events" in raw:
             raw_events = raw["events"]
-        elif isinstance(raw, list):
-            raw_events = raw
-        else:
+
+        if isinstance(raw_events, dict):
+            raw_events = list(raw_events.values())
+        if not isinstance(raw_events, list):
             raw_events = []
 
-        events = [SpatiotemporalEvent(**e) for e in raw_events]
+        events: list[SpatiotemporalEvent] = []
+        bridge = ExtractionBridge()
+        for item in raw_events:
+            if not isinstance(item, dict):
+                continue
+            if "entity_id" in item and "time" in item:
+                ev = SpatiotemporalEvent(**item)
+                if not ev.source_book:
+                    ev.source_book = book_title
+                if ":" not in ev.id:
+                    ev.id = f"{book_id}:{ev.id}"
+                events.append(ev)
+                continue
+
+            # Fallback: treat as lore.events.Event-like payload and bridge it.
+            from ..lore.events import Event
+
+            lore_event = Event.from_dict(item)
+            bridged = bridge.bridge_event(lore_event, source_book=book_title).event
+            if ":" not in bridged.id:
+                bridged.id = f"{book_id}:{bridged.id}"
+            events.append(bridged)
+
         self.add_book(book_id, book_title, events)
         return len(events)
 

--- a/src/book_graph_analyzer/spatiotemporal/extraction_bridge.py
+++ b/src/book_graph_analyzer/spatiotemporal/extraction_bridge.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass, field
 
 from ..graph.temporal import canonicalize_era
 from ..lore.events import Event
+from ..models.worldbuilding import infer_editorial_layer
 from .models import NormalizedTime, SpatiotemporalEvent
 from .normalizer import TimeNormalizer
 
@@ -164,19 +165,33 @@ class ExtractionBridge:
             era_display = _era_display_name(raw_era_text)
 
         # Normalize time
+        parsed_year: int | None = None
+        if isinstance(event.year, int):
+            parsed_year = event.year
+        elif isinstance(event.year, str):
+            try:
+                parsed_year = int(event.year)
+            except ValueError:
+                parsed_year = None
+
         if event.year_text:
             norm_time = self.normalizer.normalize(event.year_text)
+        elif parsed_year is None and event.year is not None:
+            norm_time = self.normalizer.normalize(str(event.year))
         else:
             norm_time = self.normalizer.normalize_event_time(
                 raw_text=event.year_text,
                 era=era_display,
-                year=event.year,
+                year=parsed_year,
             )
 
         # Check if era changed during normalization
         era_changed = False
         if raw_era_text and norm_time.era:
             era_changed = raw_era_text.lower().replace(" ", "") != norm_time.era.lower().replace(" ", "")
+
+        source_name = source_book or event.source_book or None
+        layer = infer_editorial_layer(source_name) if source_name else None
 
         # Build SpatiotemporalEvent
         st_event = SpatiotemporalEvent(
@@ -187,8 +202,11 @@ class ExtractionBridge:
             time=norm_time,
             description=event.description,
             event_type="extracted",
-            source_book=source_book or event.source_book or None,
+            source_book=source_name,
             source_passage_id=None,
+            source_id=getattr(layer, "source_id", None),
+            editorial_status=getattr(getattr(layer, "editorial_status", None), "value", None),
+            source_authority_weight=float(getattr(layer, "authority_weight", 1.0)) if layer else None,
         )
 
         return NormalizationResult(

--- a/src/book_graph_analyzer/spatiotemporal/models.py
+++ b/src/book_graph_analyzer/spatiotemporal/models.py
@@ -79,6 +79,9 @@ class SpatiotemporalEvent(BaseModel):
     event_type: str = "presence"
     source_book: str | None = None
     source_passage_id: str | None = None
+    source_id: str | None = None
+    editorial_status: str | None = None
+    source_authority_weight: float | None = None
 
     def to_dict(self) -> dict:
         return {
@@ -92,6 +95,9 @@ class SpatiotemporalEvent(BaseModel):
             "event_type": self.event_type,
             "source_book": self.source_book,
             "source_passage_id": self.source_passage_id,
+            "source_id": self.source_id,
+            "editorial_status": self.editorial_status,
+            "source_authority_weight": self.source_authority_weight,
         }
 
 
@@ -150,6 +156,10 @@ class TimelineConflict(BaseModel):
     entity_id: str | None = None
     suggestion: str | None = None
     confidence: float = 0.5
+    event_a_source_book: str | None = None
+    event_b_source_book: str | None = None
+    event_a_source_authority_weight: float | None = None
+    event_b_source_authority_weight: float | None = None
 
     def to_dict(self) -> dict:
         return {
@@ -162,4 +172,8 @@ class TimelineConflict(BaseModel):
             "entity_id": self.entity_id,
             "suggestion": self.suggestion,
             "confidence": self.confidence,
+            "event_a_source_book": self.event_a_source_book,
+            "event_b_source_book": self.event_b_source_book,
+            "event_a_source_authority_weight": self.event_a_source_authority_weight,
+            "event_b_source_authority_weight": self.event_b_source_authority_weight,
         }

--- a/tests/test_issue48_closeout_integration.py
+++ b/tests/test_issue48_closeout_integration.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+from book_graph_analyzer.spatiotemporal import CorpusReconciler
+
+
+def test_issue48_corpus_reconcile_with_real_fixtures_enriches_source_metadata():
+    """End-to-end: real corpus fixtures -> bridge -> cross-book reconcile.
+
+    Uses representative repository fixtures from data/output and validates that
+    source/editorial metadata is preserved on normalized events.
+    """
+    repo_root = Path(__file__).resolve().parents[1]
+    hobbit = repo_root / "data" / "output" / "hobbit_events.json"
+    ut = repo_root / "data" / "output" / "unfinished_tales_events.json"
+
+    assert hobbit.exists(), f"Missing fixture: {hobbit}"
+    assert ut.exists(), f"Missing fixture: {ut}"
+
+    reconciler = CorpusReconciler(extract_causal=False)
+    hobbit_count = reconciler.add_book_from_json(hobbit, "hobbit", "The Hobbit")
+    ut_count = reconciler.add_book_from_json(ut, "unfinished_tales", "Unfinished Tales")
+
+    assert hobbit_count > 0
+    assert ut_count > 0
+
+    result = reconciler.reconcile(check_causal=False)
+    assert result.total_events == hobbit_count + ut_count
+    assert len(result.books) == 2
+
+    # Event IDs are namespaced per book to avoid collisions during cross-book merge.
+    assert all(e.id.startswith("hobbit:") for e in result.books[0].events)
+    assert all(e.id.startswith("unfinished_tales:") for e in result.books[1].events)
+
+    # Metadata should be inferred from source titles and carried end-to-end.
+    hobbit_event = result.books[0].events[0]
+    ut_event = result.books[1].events[0]
+
+    assert hobbit_event.source_book == "The Hobbit"
+    assert hobbit_event.editorial_status == "published"
+    assert hobbit_event.source_authority_weight is not None
+
+    assert ut_event.source_book == "Unfinished Tales"
+    assert ut_event.editorial_status == "unfinished"
+    assert ut_event.source_authority_weight is not None


### PR DESCRIPTION
## Summary\n- persist source/editorial metadata end-to-end on spatiotemporal events and timeline conflicts\n- improve cross-book reconciliation integration by accepting both normalized and raw lore event payloads in corpus reconciler\n- namespace imported event IDs by book to avoid cross-book collision\n- add fixture-backed end-to-end integration test for real corpus event files\n- update pipeline docs, RFC phase-4 status, and wiki closeout notes\n\n## Validation\n- python -m pytest -q tests/test_issue48_closeout_integration.py tests/test_spatiotemporal_slice4.py tests/test_spatiotemporal_slice3.py\n\n## Issue\n- Closes part of #48 (closeout slice 7)\n