### PR TITLE
feat: include aggregate severity summary in JSON failure analysis export (#40)

### DIFF
--- a/src/book_graph_analyzer/cli.py
+++ b/src/book_graph_analyzer/cli.py
@@ -5670,8 +5670,22 @@ def workflow_analyze_open_failures(
 
         out_path = Path(out_json)
         out_path.parent.mkdir(parents=True, exist_ok=True)
+
+        severity_counts = {"critical": 0, "high": 0, "medium": 0, "low": 0}
+        for row in csv_rows:
+            sev = row.get("severity", "low")
+            severity_counts[sev] = severity_counts.get(sev, 0) + 1
+
+        payload = {
+            "summary": {
+                "analyzed": len(csv_rows),
+                "severity_counts": severity_counts,
+            },
+            "rows": csv_rows,
+        }
+
         with open(out_path, "w", encoding="utf-8") as f:
-            json.dump(csv_rows, f, ensure_ascii=False, indent=2)
+            json.dump(payload, f, ensure_ascii=False, indent=2)
         console.print(f"[green]Wrote JSON analysis report:[/green] {out_path}")
 
     if out_md:

--- a/tests/test_workflow_failure.py
+++ b/tests/test_workflow_failure.py
@@ -224,6 +224,8 @@ jobs:
 
     assert out_json.exists()
     json_text = out_json.read_text(encoding="utf-8")
+    assert "summary" in json_text
+    assert "severity_counts" in json_text
     assert "issue_number" in json_text
     assert "severity" in json_text
     assert "41" in json_text


### PR DESCRIPTION
## Summary
Issue #40 follow-up: enrich JSON output from workflow-analyze-open-failures with top-level aggregate metrics for easier machine consumption.

## Changes
- Updated JSON export payload (--out-json) to include:
  - summary.analyzed
  - summary.severity_counts (critical/high/medium/low)
  - ows (existing per-issue rows)

This keeps existing row-level data while making dashboards/automation simpler.

## Tests
- Updated 	ests/test_workflow_failure.py
- Verified JSON now contains summary + severity_counts

Run:
`ash
python -m pytest tests/test_workflow_failure.py -v
`
Result: **16 passed**