### PR TITLE
feat: include unresolved counts in JSON failure analysis summary (#40)

### DIFF
--- a/src/book_graph_analyzer/cli.py
+++ b/src/book_graph_analyzer/cli.py
@@ -5672,14 +5672,25 @@ def workflow_analyze_open_failures(
         out_path.parent.mkdir(parents=True, exist_ok=True)
 
         severity_counts = {"critical": 0, "high": 0, "medium": 0, "low": 0}
+        unresolved_by_severity = {"critical": 0, "high": 0, "medium": 0, "low": 0}
+        unresolved_total = 0
+
         for row in csv_rows:
             sev = row.get("severity", "low")
             severity_counts[sev] = severity_counts.get(sev, 0) + 1
 
+            missing = row.get("missing_secrets", "")
+            has_missing = bool(missing and str(missing).strip() and str(missing).strip().lower() != "none")
+            if has_missing:
+                unresolved_total += 1
+                unresolved_by_severity[sev] = unresolved_by_severity.get(sev, 0) + 1
+
         payload = {
             "summary": {
                 "analyzed": len(csv_rows),
+                "unresolved": unresolved_total,
                 "severity_counts": severity_counts,
+                "unresolved_by_severity": unresolved_by_severity,
             },
             "rows": csv_rows,
         }

--- a/tests/test_workflow_failure.py
+++ b/tests/test_workflow_failure.py
@@ -226,6 +226,8 @@ jobs:
     json_text = out_json.read_text(encoding="utf-8")
     assert "summary" in json_text
     assert "severity_counts" in json_text
+    assert "unresolved" in json_text
+    assert "unresolved_by_severity" in json_text
     assert "issue_number" in json_text
     assert "severity" in json_text
     assert "41" in json_text


### PR DESCRIPTION
## Summary
Issue #40 follow-up: enrich JSON export summary with unresolved counters.

## Changes
ga workflow-analyze-open-failures --out-json ... now includes in summary:
- unresolved (total issues with missing secrets)
- unresolved_by_severity (critical/high/medium/low)

Existing fields retained:
- nalyzed
- severity_counts
- ows

## Tests
- Updated 	ests/test_workflow_failure.py
- Verified JSON contains unresolved and unresolved_by_severity

Run:
`ash
python -m pytest tests/test_workflow_failure.py -v
`
Result: **16 passed**