### PR TITLE
Fix corpus events crash when relation IDs are list/object

### DIFF
--- a/src/book_graph_analyzer/lore/events.py
+++ b/src/book_graph_analyzer/lore/events.py
@@ -7,6 +7,7 @@ Extracts structured events from text:
 """
 
 import json
+import logging
 import re
 from dataclasses import dataclass, field
 from typing import Optional
@@ -14,6 +15,9 @@ from collections import defaultdict
 
 from ..llm import LLMClient
 from .temporal import Era
+
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -398,6 +402,27 @@ class EventExtractor:
             return " ".join(str(v) for v in val if v)
         return str(val)
 
+    @staticmethod
+    def _stable_id_token(val) -> str:
+        """Normalize potentially-structured IDs to stable string tokens.
+
+        LLM payloads occasionally return relation refs as list/object instead of plain
+        strings. This normalizes those values so they can be safely used for dict
+        lookups and relation IDs.
+        """
+        if val is None:
+            return ""
+        if isinstance(val, str):
+            return val.strip()
+        if isinstance(val, (int, float, bool)):
+            return str(val)
+        if isinstance(val, (list, dict)):
+            try:
+                return json.dumps(val, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+            except (TypeError, ValueError):
+                return str(val)
+        return str(val)
+
     def _normalize_event_key(self, event: Event) -> str:
         """Create a normalized key for deduplication."""
         parts = []
@@ -596,10 +621,14 @@ JSON:"""
         if response:
             data = llm.extract_json(response)
             if data and isinstance(data, dict):
+                dropped_events = 0
+                dropped_relations = 0
+
                 for i, e in enumerate(data.get("events", [])):
                     if isinstance(e, dict) and "description" in e:
                         # Create unique ID incorporating chunk index
                         base_id = e.get("id", f"event_{i}")
+                        base_id = self._stable_id_token(base_id) or f"event_{i}"
                         event_id = f"c{chunk_index}_{base_id}" if chunk_index > 0 else base_id
                         era = None
                         if e.get("era"):
@@ -616,25 +645,44 @@ JSON:"""
                             source_book=source_book,
                             confidence=0.8,
                         ))
+                    else:
+                        dropped_events += 1
                 
                 # Build ID map for relations (LLM returns original IDs, we need our prefixed ones)
                 id_map = {}
                 for i, e in enumerate(data.get("events", [])):
                     if isinstance(e, dict):
                         original_id = e.get("id", f"event_{i}")
+                        original_id = self._stable_id_token(original_id) or f"event_{i}"
                         prefixed_id = f"c{chunk_index}_{original_id}" if chunk_index > 0 else original_id
                         id_map[original_id] = prefixed_id
                 
                 for r in data.get("relations", []):
                     if isinstance(r, dict) and "event1" in r and "event2" in r:
-                        e1_id = id_map.get(r["event1"], r["event1"])
-                        e2_id = id_map.get(r["event2"], r["event2"])
+                        e1_raw = self._stable_id_token(r.get("event1"))
+                        e2_raw = self._stable_id_token(r.get("event2"))
+                        if not e1_raw or not e2_raw:
+                            dropped_relations += 1
+                            continue
+                        e1_id = id_map.get(e1_raw, e1_raw)
+                        e2_id = id_map.get(e2_raw, e2_raw)
                         relations.append(EventRelation(
                             event1_id=e1_id,
                             relation=r.get("relation", "before"),
                             event2_id=e2_id,
                             confidence=0.7,
                         ))
+                    else:
+                        dropped_relations += 1
+
+                if dropped_events or dropped_relations:
+                    logger.warning(
+                        "Dropped malformed LLM payload rows in event extraction: "
+                        "events=%d relations=%d (chunk=%d)",
+                        dropped_events,
+                        dropped_relations,
+                        chunk_index,
+                    )
         
         return events, relations
     

--- a/tests/test_lore_events_extractor.py
+++ b/tests/test_lore_events_extractor.py
@@ -1,0 +1,64 @@
+import logging
+
+from book_graph_analyzer.lore import events as events_module
+from book_graph_analyzer.lore.events import EventExtractor
+
+
+class _DummyLLM:
+    def generate(self, prompt, temperature=0.2, max_tokens=2000):
+        return "ok"
+
+    def extract_json(self, response):
+        return self.payload
+
+
+def test_extract_llm_normalizes_list_relation_ids_before_lookup(monkeypatch):
+    dummy = _DummyLLM()
+    dummy.payload = {
+        "events": [
+            {"id": "e1", "description": "Event one"},
+            {"id": ["e2"], "description": "Event two"},
+        ],
+        "relations": [
+            {"event1": "e1", "relation": "before", "event2": ["e2"]}
+        ],
+    }
+
+    monkeypatch.setattr(events_module, "LLMClient", lambda: dummy)
+
+    extractor = EventExtractor()
+    extracted_events, relations = extractor._extract_llm("text", "book", chunk_index=2)
+
+    assert len(extracted_events) == 2
+    assert len(relations) == 1
+    assert relations[0].event1_id == "c2_e1"
+    # List id is normalized deterministically and mapped via id_map
+    assert relations[0].event2_id == 'c2_["e2"]'
+
+
+def test_extract_llm_drops_malformed_rows_with_warning(monkeypatch, caplog):
+    dummy = _DummyLLM()
+    dummy.payload = {
+        "events": [
+            {"id": "ok", "description": "valid"},
+            {"id": "bad-no-description"},
+            "not-a-dict",
+        ],
+        "relations": [
+            {"event1": "ok", "relation": "before", "event2": "ok"},  # valid
+            {"event1": "ok", "relation": "before"},  # missing event2
+            {"event1": None, "event2": "ok"},  # invalid id
+            "not-a-dict",
+        ],
+    }
+
+    monkeypatch.setattr(events_module, "LLMClient", lambda: dummy)
+
+    extractor = EventExtractor()
+    with caplog.at_level(logging.WARNING):
+        extracted_events, relations = extractor._extract_llm("text", "book")
+
+    assert len(extracted_events) == 1
+    assert len(relations) == 1
+    assert "Dropped malformed LLM payload rows" in caplog.text
+    assert "events=2 relations=3" in caplog.text


### PR DESCRIPTION
## Root cause
`EventExtractor._extract_llm` assumed relation refs (`event1`/`event2`) and event IDs were hashable strings. Some LLM payloads return lists/objects, causing dictionary lookups like `id_map.get(r["event2"], ...)` and `id_map[original_id] = ...` to raise `TypeError: unhashable type: 'list'`.

## Fix
- Normalize any ID-like value (str/int/list/dict/None) to a deterministic stable string token before map insert/lookup.
- Apply normalization consistently for:
  - event `id` when building event IDs
  - `id_map` keys
  - relation `event1`/`event2` refs before lookup
- Add defensive validation in `_extract_llm`:
  - skip malformed event rows (non-dict or missing `description`)
  - skip malformed relation rows (non-dict, missing refs, empty normalized refs)
  - log warning counters (`events=... relations=...`) instead of crashing.

## Tests
Added regression tests:
1. `event1`/`event2` as list values are normalized and correctly mapped via `id_map`
2. malformed payload rows are dropped with warning counters and no crash

## Verification
- `pytest -q tests/test_lore_events_extractor.py`
- command smoke: `bga corpus events tolkien_test --neo4j` (runs past previous crash point in this environment)
