### PR TITLE
Add OpenAI provider for lore/corpus events extraction

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -164,6 +164,8 @@ BGA_NEO4J_URI=bolt://localhost:7687
 BGA_NEO4J_USER=neo4j
 BGA_NEO4J_PASSWORD=bookgraph123
 BGA_OLLAMA_MODEL=llama3.1:8b
+# Optional provider override: ollama | huggingface | openai
+BGA_LLM_PROVIDER=ollama
 ```
 
 See `config.py` for all available settings.
@@ -263,6 +265,24 @@ ollama list
 ```
 
 The application will auto-detect Ollama at `http://localhost:11434`.
+
+### OpenAI provider (for faster API-backed event extraction)
+
+Set these in `.env`:
+
+```env
+BGA_LLM_PROVIDER=openai
+BGA_OPENAI_API_KEY=sk-...
+
+# Optional
+BGA_OPENAI_MODEL=gpt-4o-mini
+BGA_OPENAI_BASE_URL=https://api.openai.com/v1
+```
+
+Notes:
+- Expect provider rate limits (RPM/TPM). The client retries transient `429`/`5xx` automatically with exponential backoff.
+- Event extraction is chunked; failed chunks are skipped with warnings so long runs continue.
+- API usage is billable by tokens. Start with smaller models and smaller chunk sizes while tuning quality/cost.
 
 ---
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -19,3 +19,17 @@ BGA_NEO4J_URI=bolt://localhost:7687
 BGA_NEO4J_USER=neo4j
 BGA_NEO4J_PASSWORD=bookgraph123
 ```
+
+LLM provider defaults to Ollama. To use OpenAI for lore/corpus event extraction:
+
+```env
+# Choose provider: ollama | huggingface | openai
+BGA_LLM_PROVIDER=openai
+
+# Required for OpenAI provider
+BGA_OPENAI_API_KEY=sk-...
+
+# Optional (defaults shown)
+BGA_OPENAI_MODEL=gpt-4o-mini
+BGA_OPENAI_BASE_URL=https://api.openai.com/v1
+```

--- a/src/book_graph_analyzer/cli.py
+++ b/src/book_graph_analyzer/cli.py
@@ -1958,6 +1958,7 @@ def corpus_events(corpus_name: str, output: str | None, neo4j: bool, chunk_size:
     from book_graph_analyzer.corpus import CorpusManager
     from book_graph_analyzer.lore import EventExtractor, EventGraph, Event, EventRelation
     from book_graph_analyzer.ingest.loader import load_book
+    from book_graph_analyzer.llm import LLMClient
     
     manager = CorpusManager(corpus_name)
     books = manager.get_processed_books()
@@ -1991,6 +1992,8 @@ def corpus_events(corpus_name: str, output: str | None, neo4j: bool, chunk_size:
     processed_books = 0
     
     console.print(f"[bold]Extracting events from {corpus_name}[/bold]")
+    llm = LLMClient()
+    console.print(f"[dim]LLM provider: {llm.provider} | model: {llm.model}[/dim]")
     console.print(f"Books to process: {total_books}")
     
     for book in books:
@@ -2406,11 +2409,15 @@ def lore_events(path: str, output: str, neo4j: bool, chunk_size: int, no_llm: bo
     """
     from book_graph_analyzer.lore import EventExtractor
     from book_graph_analyzer.ingest.loader import load_book
+    from book_graph_analyzer.llm import LLMClient
     
     file_path = Path(path)
     book_name = file_path.stem.replace("_", " ").replace("-", " ").title()
     
     console.print(f"[bold]Extracting events from:[/bold] {file_path.name}")
+    if not no_llm:
+        llm = LLMClient()
+        console.print(f"[dim]LLM provider: {llm.provider} | model: {llm.model}[/dim]")
     
     with console.status("Loading text..."):
         text = load_book(file_path)

--- a/src/book_graph_analyzer/config.py
+++ b/src/book_graph_analyzer/config.py
@@ -28,7 +28,13 @@ class Settings(BaseSettings):
     # Hugging Face Inference API
     hf_api_key: str = Field(default="")
     hf_model: str = Field(default="meta-llama/Llama-3.1-70B-Instruct")
-    llm_provider: str = Field(default="ollama", description="ollama or huggingface")
+
+    # OpenAI API
+    openai_api_key: str = Field(default="")
+    openai_model: str = Field(default="gpt-4o-mini")
+    openai_base_url: str = Field(default="https://api.openai.com/v1")
+
+    llm_provider: str = Field(default="ollama", description="ollama, huggingface, or openai")
 
     # Paths
     data_dir: Path = Field(default=Path("data"))

--- a/src/book_graph_analyzer/llm.py
+++ b/src/book_graph_analyzer/llm.py
@@ -3,10 +3,16 @@
 Supports multiple backends:
 - Ollama (local)
 - Hugging Face Inference API (cloud)
+- OpenAI API (cloud)
 """
 
+from __future__ import annotations
+
 import json
+import logging
+import random
 import re
+import time
 from typing import Optional
 
 import httpx
@@ -14,38 +20,40 @@ import httpx
 from .config import get_settings
 
 
+logger = logging.getLogger(__name__)
+
+
 class LLMClient:
-    """Unified LLM client supporting multiple providers.
-    
-    Usage:
-        client = LLMClient()  # Uses config defaults
-        response = client.generate("What is the capital of France?")
-        
-        # Or specify provider
-        client = LLMClient(provider="huggingface")
-    """
-    
+    """Unified LLM client supporting multiple providers."""
+
     def __init__(
         self,
         provider: Optional[str] = None,
         model: Optional[str] = None,
     ):
         """Initialize LLM client.
-        
+
         Args:
-            provider: "ollama" or "huggingface" (default from config)
+            provider: "ollama", "huggingface", or "openai" (default from config)
             model: Model name (default from config)
         """
         self.settings = get_settings()
-        self.provider = provider or self.settings.llm_provider
-        
+        self.provider = (provider or self.settings.llm_provider).lower().strip()
+
+        if self.provider not in {"ollama", "huggingface", "openai"}:
+            raise ValueError(
+                f"Unknown LLM provider '{self.provider}'. Expected one of: ollama, huggingface, openai"
+            )
+
         if model:
             self.model = model
         elif self.provider == "huggingface":
             self.model = self.settings.hf_model
+        elif self.provider == "openai":
+            self.model = self.settings.openai_model
         else:
             self.model = self.settings.ollama_model
-    
+
     def generate(
         self,
         prompt: str,
@@ -54,21 +62,98 @@ class LLMClient:
         timeout: float = 120.0,
     ) -> str:
         """Generate text from prompt.
-        
-        Args:
-            prompt: The prompt text
-            temperature: Sampling temperature (0-1)
-            max_tokens: Maximum tokens to generate
-            timeout: Request timeout in seconds
-            
-        Returns:
-            Generated text, or empty string on error
+
+        Returns generated text, or empty string on error.
         """
         if self.provider == "huggingface":
             return self._generate_hf(prompt, temperature, max_tokens, timeout)
-        else:
-            return self._generate_ollama(prompt, temperature, max_tokens, timeout)
-    
+        if self.provider == "openai":
+            return self._generate_openai(prompt, temperature, max_tokens, timeout)
+        return self._generate_ollama(prompt, temperature, max_tokens, timeout)
+
+    @property
+    def provider_label(self) -> str:
+        """Human-friendly provider/model label for logs."""
+        return f"{self.provider}:{self.model}"
+
+    def _post_json_with_retry(
+        self,
+        *,
+        url: str,
+        headers: Optional[dict] = None,
+        payload: Optional[dict] = None,
+        timeout: float,
+        max_attempts: int = 5,
+        base_delay: float = 1.0,
+        max_delay: float = 12.0,
+    ) -> Optional[httpx.Response]:
+        """POST JSON with retry/backoff for transient failures (429/5xx/network)."""
+        for attempt in range(1, max_attempts + 1):
+            try:
+                response = httpx.post(url, headers=headers, json=payload, timeout=timeout)
+
+                if response.status_code == 200:
+                    return response
+
+                retryable = response.status_code == 429 or 500 <= response.status_code < 600
+                if not retryable:
+                    logger.warning(
+                        "LLM API non-retryable error status=%s provider=%s body=%s",
+                        response.status_code,
+                        self.provider,
+                        response.text[:200],
+                    )
+                    return response
+
+                if attempt == max_attempts:
+                    logger.warning(
+                        "LLM API retry exhausted status=%s provider=%s",
+                        response.status_code,
+                        self.provider,
+                    )
+                    return response
+
+                # Respect Retry-After if present
+                retry_after = response.headers.get("Retry-After")
+                if retry_after:
+                    try:
+                        delay = min(max_delay, max(0.1, float(retry_after)))
+                    except ValueError:
+                        delay = min(max_delay, base_delay * (2 ** (attempt - 1)) + random.uniform(0, 0.5))
+                else:
+                    delay = min(max_delay, base_delay * (2 ** (attempt - 1)) + random.uniform(0, 0.5))
+
+                logger.info(
+                    "Retrying LLM request provider=%s status=%s attempt=%d/%d delay=%.2fs",
+                    self.provider,
+                    response.status_code,
+                    attempt,
+                    max_attempts,
+                    delay,
+                )
+                time.sleep(delay)
+
+            except (httpx.RequestError, httpx.TimeoutException) as e:
+                if attempt == max_attempts:
+                    logger.warning(
+                        "LLM request failed after retries provider=%s error=%s",
+                        self.provider,
+                        e,
+                    )
+                    return None
+                delay = min(max_delay, base_delay * (2 ** (attempt - 1)) + random.uniform(0, 0.5))
+                logger.info(
+                    "Retrying LLM request after transport error provider=%s attempt=%d/%d delay=%.2fs error=%s",
+                    self.provider,
+                    attempt,
+                    max_attempts,
+                    delay,
+                    e,
+                )
+                time.sleep(delay)
+
+        return None
+
     def _generate_ollama(
         self,
         prompt: str,
@@ -77,29 +162,23 @@ class LLMClient:
         timeout: float,
     ) -> str:
         """Generate using Ollama."""
-        try:
-            response = httpx.post(
-                f"{self.settings.ollama_base_url}/api/generate",
-                json={
-                    "model": self.model,
-                    "prompt": prompt,
-                    "stream": False,
-                    "options": {
-                        "temperature": temperature,
-                        "num_predict": max_tokens,
-                    },
+        response = self._post_json_with_retry(
+            url=f"{self.settings.ollama_base_url}/api/generate",
+            payload={
+                "model": self.model,
+                "prompt": prompt,
+                "stream": False,
+                "options": {
+                    "temperature": temperature,
+                    "num_predict": max_tokens,
                 },
-                timeout=timeout,
-            )
-            
-            if response.status_code == 200:
-                return response.json().get("response", "").strip()
-            
-        except (httpx.RequestError, httpx.TimeoutException) as e:
-            print(f"Ollama error: {e}")
-        
+            },
+            timeout=timeout,
+        )
+        if response and response.status_code == 200:
+            return response.json().get("response", "").strip()
         return ""
-    
+
     def _generate_hf(
         self,
         prompt: str,
@@ -109,118 +188,118 @@ class LLMClient:
     ) -> str:
         """Generate using Hugging Face Inference API (OpenAI-compatible)."""
         if not self.settings.hf_api_key:
-            print("HF API key not set - falling back to Ollama")
+            logger.warning("HF API key not set - falling back to Ollama")
             return self._generate_ollama(prompt, temperature, max_tokens, timeout)
-        
-        try:
-            # HF Inference API - OpenAI-compatible chat endpoint (new router)
-            api_url = "https://router.huggingface.co/v1/chat/completions"
-            
-            headers = {
+
+        response = self._post_json_with_retry(
+            url="https://router.huggingface.co/v1/chat/completions",
+            headers={
                 "Authorization": f"Bearer {self.settings.hf_api_key}",
                 "Content-Type": "application/json",
-            }
-            
-            payload = {
+            },
+            payload={
                 "model": self.model,
-                "messages": [
-                    {"role": "user", "content": prompt}
-                ],
+                "messages": [{"role": "user", "content": prompt}],
                 "temperature": temperature,
                 "max_tokens": max_tokens,
-            }
-            
-            response = httpx.post(
-                api_url,
-                headers=headers,
-                json=payload,
-                timeout=timeout,
-            )
-            
-            if response.status_code == 200:
-                result = response.json()
-                # OpenAI-compatible response format
-                if "choices" in result and len(result["choices"]) > 0:
-                    return result["choices"][0].get("message", {}).get("content", "").strip()
-                # Legacy format fallback
-                if isinstance(result, list) and len(result) > 0:
-                    return result[0].get("generated_text", "").strip()
-                elif isinstance(result, dict) and "generated_text" in result:
-                    return result.get("generated_text", "").strip()
-            
-            elif response.status_code == 503:
-                # Model loading - wait and retry
-                print(f"HF model loading, retrying...")
-                import time
-                time.sleep(20)
-                return self._generate_hf(prompt, temperature, max_tokens, timeout)
-            
-            else:
-                print(f"HF API error {response.status_code}: {response.text[:200]}")
-                
-        except (httpx.RequestError, httpx.TimeoutException) as e:
-            print(f"HF API error: {e}")
-        
+            },
+            timeout=timeout,
+        )
+        if not response or response.status_code != 200:
+            return ""
+
+        result = response.json()
+        if "choices" in result and len(result["choices"]) > 0:
+            return result["choices"][0].get("message", {}).get("content", "").strip()
+        if isinstance(result, list) and len(result) > 0:
+            return result[0].get("generated_text", "").strip()
+        if isinstance(result, dict) and "generated_text" in result:
+            return result.get("generated_text", "").strip()
         return ""
-    
+
+    def _generate_openai(
+        self,
+        prompt: str,
+        temperature: float,
+        max_tokens: int,
+        timeout: float,
+    ) -> str:
+        """Generate using OpenAI Chat Completions API."""
+        if not self.settings.openai_api_key:
+            logger.warning("OpenAI API key not set - returning empty response")
+            return ""
+
+        base_url = (self.settings.openai_base_url or "https://api.openai.com/v1").rstrip("/")
+        response = self._post_json_with_retry(
+            url=f"{base_url}/chat/completions",
+            headers={
+                "Authorization": f"Bearer {self.settings.openai_api_key}",
+                "Content-Type": "application/json",
+            },
+            payload={
+                "model": self.model,
+                "messages": [{"role": "user", "content": prompt}],
+                "temperature": temperature,
+                "max_tokens": max_tokens,
+            },
+            timeout=timeout,
+        )
+        if not response or response.status_code != 200:
+            return ""
+
+        result = response.json()
+        choices = result.get("choices", [])
+        if choices:
+            return choices[0].get("message", {}).get("content", "").strip()
+        return ""
+
     def extract_json(self, response: str) -> list | dict | None:
-        """Extract JSON from LLM response.
-        
-        Handles markdown code blocks and stray text.
-        
-        Args:
-            response: Raw LLM response
-            
-        Returns:
-            Parsed JSON or None
-        """
+        """Extract JSON from LLM response."""
         if not response:
             return None
-        
-        # Try to extract from code block
+
         if "```" in response:
             match = re.search(r"```(?:json)?\s*([\s\S]*?)\s*```", response)
             if match:
                 response = match.group(1)
-        
-        # Try direct parse
+
         try:
             return json.loads(response)
         except json.JSONDecodeError:
             pass
-        
-        # Try to find array or object
+
         array_match = re.search(r"\[[\s\S]*\]", response)
         if array_match:
             try:
                 return json.loads(array_match.group(0))
             except json.JSONDecodeError:
                 pass
-        
+
         obj_match = re.search(r"\{[\s\S]*\}", response)
         if obj_match:
             try:
                 return json.loads(obj_match.group(0))
             except json.JSONDecodeError:
                 pass
-        
+
         return None
-    
+
     @property
     def is_available(self) -> bool:
         """Check if the LLM backend is available."""
         if self.provider == "huggingface":
             return bool(self.settings.hf_api_key)
-        else:
-            # Check Ollama
-            try:
-                response = httpx.get(
-                    f"{self.settings.ollama_base_url}/api/tags",
-                    timeout=5.0,
-                )
-                return response.status_code == 200
-            except (httpx.RequestError, httpx.TimeoutException):
-                return False
+        if self.provider == "openai":
+            return bool(self.settings.openai_api_key)
+
+        try:
+            response = httpx.get(
+                f"{self.settings.ollama_base_url}/api/tags",
+                timeout=5.0,
+            )
+            return response.status_code == 200
+        except (httpx.RequestError, httpx.TimeoutException):
+            return False
 
 
 # Convenience function

--- a/src/book_graph_analyzer/lore/events.py
+++ b/src/book_graph_analyzer/lore/events.py
@@ -613,6 +613,12 @@ Focus on significant plot events, not minor actions. Include 5-15 events.
 JSON:"""
 
         llm = LLMClient()
+        logger.info(
+            "Event extraction LLM provider=%s model=%s chunk=%d",
+            getattr(llm, "provider", "unknown"),
+            getattr(llm, "model", "unknown"),
+            chunk_index,
+        )
         response = llm.generate(prompt, temperature=0.2, max_tokens=2000)
         
         events = []
@@ -683,7 +689,17 @@ JSON:"""
                         dropped_relations,
                         chunk_index,
                     )
-        
+            else:
+                logger.warning(
+                    "LLM response did not contain valid JSON payload; skipping chunk=%d",
+                    chunk_index,
+                )
+        else:
+            logger.warning(
+                "LLM request returned empty response; skipping chunk=%d",
+                chunk_index,
+            )
+
         return events, relations
     
     def _extract_patterns(self, text: str, source_book: str) -> list[Event]:

--- a/tests/test_llm_openai_provider.py
+++ b/tests/test_llm_openai_provider.py
@@ -1,0 +1,77 @@
+from types import SimpleNamespace
+
+import httpx
+
+from book_graph_analyzer import llm as llm_module
+from book_graph_analyzer.llm import LLMClient
+
+
+class _Resp:
+    def __init__(self, status_code: int, data: dict | None = None, text: str = "", headers: dict | None = None):
+        self.status_code = status_code
+        self._data = data or {}
+        self.text = text
+        self.headers = headers or {}
+
+    def json(self):
+        return self._data
+
+
+def _settings(**overrides):
+    base = dict(
+        llm_provider="openai",
+        openai_api_key="test-key",
+        openai_model="gpt-4o-mini",
+        openai_base_url="https://api.openai.com/v1",
+        hf_api_key="",
+        hf_model="hf-model",
+        ollama_model="llama3.1:8b",
+        ollama_base_url="http://localhost:11434",
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def test_openai_provider_selected_from_settings(monkeypatch):
+    monkeypatch.setattr(llm_module, "get_settings", lambda: _settings())
+    client = LLMClient()
+    assert client.provider == "openai"
+    assert client.model == "gpt-4o-mini"
+
+
+def test_openai_generate_parses_chat_completion(monkeypatch):
+    monkeypatch.setattr(llm_module, "get_settings", lambda: _settings())
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        assert url == "https://api.openai.com/v1/chat/completions"
+        assert headers["Authorization"] == "Bearer test-key"
+        assert json["model"] == "gpt-4o-mini"
+        return _Resp(
+            200,
+            data={"choices": [{"message": {"content": '{"events": [], "relations": []}'}}]},
+        )
+
+    monkeypatch.setattr(httpx, "post", fake_post)
+    client = LLMClient()
+    out = client.generate("prompt")
+    assert '"events"' in out
+
+
+def test_openai_retries_on_429_then_succeeds(monkeypatch):
+    monkeypatch.setattr(llm_module, "get_settings", lambda: _settings())
+
+    calls = {"n": 0}
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return _Resp(429, text="rate limited", headers={"Retry-After": "0"})
+        return _Resp(200, data={"choices": [{"message": {"content": "ok"}}]})
+
+    monkeypatch.setattr(httpx, "post", fake_post)
+    monkeypatch.setattr(llm_module.time, "sleep", lambda *_: None)
+
+    client = LLMClient()
+    out = client.generate("prompt")
+    assert out == "ok"
+    assert calls["n"] == 2

--- a/tests/test_lore_events_extractor.py
+++ b/tests/test_lore_events_extractor.py
@@ -12,6 +12,17 @@ class _DummyLLM:
         return self.payload
 
 
+class _EmptyLLM:
+    provider = "openai"
+    model = "gpt-4o-mini"
+
+    def generate(self, prompt, temperature=0.2, max_tokens=2000):
+        return ""
+
+    def extract_json(self, response):
+        return None
+
+
 def test_extract_llm_normalizes_list_relation_ids_before_lookup(monkeypatch):
     dummy = _DummyLLM()
     dummy.payload = {
@@ -62,3 +73,15 @@ def test_extract_llm_drops_malformed_rows_with_warning(monkeypatch, caplog):
     assert len(relations) == 1
     assert "Dropped malformed LLM payload rows" in caplog.text
     assert "events=2 relations=3" in caplog.text
+
+
+def test_extract_llm_warns_and_skips_on_empty_response(monkeypatch, caplog):
+    monkeypatch.setattr(events_module, "LLMClient", lambda: _EmptyLLM())
+
+    extractor = EventExtractor()
+    with caplog.at_level(logging.WARNING):
+        extracted_events, relations = extractor._extract_llm("text", "book", chunk_index=4)
+
+    assert extracted_events == []
+    assert relations == []
+    assert "empty response" in caplog.text


### PR DESCRIPTION
## Summary\n- add openai as an llm_provider with config/env support (BGA_OPENAI_API_KEY, BGA_OPENAI_MODEL, BGA_OPENAI_BASE_URL)\n- extend LLMClient with OpenAI chat-completions adapter while keeping Ollama/HuggingFace compatibility\n- add robust retry/backoff for transient 429/5xx + transport errors\n- log provider/model in ga lore events and ga corpus events output for observability\n- preserve malformed payload handling and add explicit warning/skip behavior when LLM response is empty/invalid\n- add focused tests for provider selection, OpenAI adapter, and retry behavior\n- document OpenAI .env setup + RPM/TPM/cost notes\n\n## Testing\n- pytest -q tests/test_llm_openai_provider.py tests/test_lore_events_extractor.py\n