### PR TITLE
feat: reusable resilient chunk extraction runner + resume ledger

### DIFF
--- a/docs/wiki/resilient-chunk-extraction-runbook.md
+++ b/docs/wiki/resilient-chunk-extraction-runbook.md
@@ -1,0 +1,63 @@
+# Resilient Chunk Extraction Mode (Runbook)
+
+## What it does
+
+For chunked LLM extraction flows (currently lore events + corpus events), resilient mode applies this policy per chunk:
+
+1. Try parse/normalize + persist normally.
+2. If malformed/failed: retry once on the same model.
+3. If still failing: retry once on a stronger fallback model.
+4. If still failing: mark chunk `failed_unprocessed` and continue the run.
+
+This prevents long runs from aborting on a few bad chunks.
+
+## Artifacts
+
+Given checkpoint file `X.checkpoint.json`, resilient mode writes:
+
+- `X.checkpoint.json` → periodic safe-write checkpoint (partial extracted events/relations)
+- `X.checkpoint.json.ledger.json` → chunk ledger with status per chunk
+- `X.checkpoint.json.payloads/` → payload snippets for failed chunks (debug/audit)
+
+Ledger statuses:
+
+- `ok`
+- `retry_success`
+- `fallback_success`
+- `failed_unprocessed`
+
+## Resume behavior
+
+On rerun with the same checkpoint/ledger:
+
+- Completed chunks (`ok/retry_success/fallback_success`) are skipped.
+- Only failed/unprocessed chunks are retried.
+- End-of-run summary reports: `ok`, `retried`, `fallback_success`, `failed`.
+
+## CLI usage
+
+### Single book events
+
+```bash
+bga lore events data/texts/the_hobbit.txt \
+  -o data/output/hobbit_events.json \
+  --chunk-size 3000 \
+  --checkpoint data/checkpoints/hobbit_events.checkpoint.json \
+  --resilient
+```
+
+### Corpus events
+
+```bash
+bga corpus events tolkien_works \
+  -o data/output/tolkien_events.json \
+  --chunk-size 3000 \
+  --resilient \
+  --checkpoint-dir data/checkpoints
+```
+
+## Operational notes
+
+- Defaults remain backward-compatible (`--resilient` is opt-in).
+- Failed chunks are never silently dropped: ledger reason + payload snippet path are persisted.
+- You can inspect failed chunks quickly via `*.ledger.json` and rerun with same checkpoint to retry only those chunks.

--- a/src/book_graph_analyzer/cli.py
+++ b/src/book_graph_analyzer/cli.py
@@ -1945,7 +1945,9 @@ def corpus_compare(corpus_name: str) -> None:
 @click.option("--neo4j", is_flag=True, help="Also write to Neo4j")
 @click.option("--chunk-size", default=3000, help="Characters per chunk (default: 3000)")
 @click.option("--skip-processed", is_flag=True, help="Skip books already in events file")
-def corpus_events(corpus_name: str, output: str | None, neo4j: bool, chunk_size: int, skip_processed: bool) -> None:
+@click.option("--resilient/--no-resilient", default=False, show_default=True, help="Enable resilient chunk extraction with ledger/resume")
+@click.option("--checkpoint-dir", type=click.Path(), default="data/checkpoints", show_default=True, help="Directory for resilient checkpoint/ledger files")
+def corpus_events(corpus_name: str, output: str | None, neo4j: bool, chunk_size: int, skip_processed: bool, resilient: bool, checkpoint_dir: str) -> None:
     """Extract events from all books in corpus with cross-book linking.
     
     Creates a unified event graph with temporal ordering across books.
@@ -2030,7 +2032,17 @@ def corpus_events(corpus_name: str, output: str | None, neo4j: bool, chunk_size:
             
             # Extract events
             if len(text) > chunk_size * 2:
-                book_graph = extractor.extract_from_book(text, source_book=book.title, chunk_size=chunk_size)
+                checkpoint_file = None
+                if resilient:
+                    slug = re.sub(r"[^a-z0-9]+", "_", book.title.lower()).strip("_")
+                    checkpoint_file = str(Path(checkpoint_dir) / f"corpus_events_{corpus_name}_{slug}.checkpoint.json")
+                book_graph = extractor.extract_from_book(
+                    text,
+                    source_book=book.title,
+                    chunk_size=chunk_size,
+                    checkpoint_file=checkpoint_file,
+                    resilient=resilient,
+                )
             else:
                 book_graph = extractor.extract_from_text(text, source_book=book.title)
         
@@ -2394,7 +2406,8 @@ def lore_check(claim: str, bible: str | None, corpus: str | None, timeline: str 
 @click.option("--chunk-size", default=3000, help="Characters per chunk (default: 3000)")
 @click.option("--no-llm", is_flag=True, help="Use pattern matching instead of LLM")
 @click.option("--checkpoint", "-c", type=click.Path(), help="Checkpoint file for resume support")
-def lore_events(path: str, output: str, neo4j: bool, chunk_size: int, no_llm: bool, checkpoint: str) -> None:
+@click.option("--resilient/--no-resilient", default=False, show_default=True, help="Enable resilient chunk extraction with ledger + fallback retries")
+def lore_events(path: str, output: str, neo4j: bool, chunk_size: int, no_llm: bool, checkpoint: str, resilient: bool) -> None:
     """Extract events from a text file.
     
     Identifies key events with participants and temporal ordering.
@@ -2446,9 +2459,19 @@ def lore_events(path: str, output: str, neo4j: bool, chunk_size: int, no_llm: bo
                 source_book=book_name, 
                 chunk_size=chunk_size,
                 checkpoint_file=checkpoint,
+                resilient=resilient,
             )
         else:
             graph = extractor.extract_from_text(text, source_book=book_name)
+
+    if resilient and checkpoint:
+        summary = extractor.get_resilient_summary(checkpoint)
+        if summary:
+            console.print(
+                "[dim]Resilient summary: "
+                f"ok={summary.get('ok', 0)} | retried={summary.get('retried', 0)} | "
+                f"fallback_success={summary.get('fallback_success', 0)} | failed={summary.get('failed', 0)}[/dim]"
+            )
     
     # Summary
     console.print(f"\n[bold]Events extracted:[/bold]")

--- a/src/book_graph_analyzer/extract/resilient_chunk_runner.py
+++ b/src/book_graph_analyzer/extract/resilient_chunk_runner.py
@@ -1,0 +1,181 @@
+"""Reusable resilient chunk processing runner.
+
+Implements a small state machine for chunked LLM extraction with:
+- retry on same model
+- retry on fallback model
+- ledger persistence for resume
+- periodic artifact writes
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Callable, Optional
+
+
+class ChunkStatus(str, Enum):
+    OK = "ok"
+    RETRY_SUCCESS = "retry_success"
+    FALLBACK_SUCCESS = "fallback_success"
+    FAILED_UNPROCESSED = "failed_unprocessed"
+
+
+@dataclass
+class ChunkAttemptResult:
+    success: bool
+    reason: str = ""
+    model: str = ""
+    payload_snippet_path: Optional[str] = None
+
+
+@dataclass
+class ChunkLedgerEntry:
+    chunk_index: int
+    status: ChunkStatus
+    attempts: int
+    final_model: str
+    reason: str = ""
+    payload_snippet_path: Optional[str] = None
+
+    def to_dict(self) -> dict:
+        return {
+            "chunk_index": self.chunk_index,
+            "status": self.status.value,
+            "attempts": self.attempts,
+            "final_model": self.final_model,
+            "reason": self.reason,
+            "payload_snippet_path": self.payload_snippet_path,
+        }
+
+
+@dataclass
+class ChunkRunMetrics:
+    ok: int = 0
+    retried: int = 0
+    fallback_success: int = 0
+    failed: int = 0
+
+    def to_dict(self) -> dict:
+        return {
+            "ok": self.ok,
+            "retried": self.retried,
+            "fallback_success": self.fallback_success,
+            "failed": self.failed,
+        }
+
+
+@dataclass
+class ChunkRunState:
+    ledger: dict[int, ChunkLedgerEntry] = field(default_factory=dict)
+
+
+class ResilientChunkRunner:
+    """Reusable resilient runner for chunk-based extraction."""
+
+    def __init__(self, ledger_file: str | Path, artifact_write_every: int = 1):
+        self.ledger_file = Path(ledger_file)
+        self.ledger_file.parent.mkdir(parents=True, exist_ok=True)
+        self.artifact_write_every = max(1, artifact_write_every)
+        self.state = ChunkRunState()
+        self.metrics = ChunkRunMetrics()
+        self._load_ledger()
+
+    def _atomic_write_json(self, path: Path, data: dict) -> None:
+        tmp = path.with_suffix(path.suffix + ".tmp")
+        tmp.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+        tmp.replace(path)
+
+    def _load_ledger(self) -> None:
+        if not self.ledger_file.exists():
+            return
+        try:
+            raw = json.loads(self.ledger_file.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            return
+        for row in raw.get("chunks", []):
+            try:
+                entry = ChunkLedgerEntry(
+                    chunk_index=int(row["chunk_index"]),
+                    status=ChunkStatus(row["status"]),
+                    attempts=int(row.get("attempts", 0)),
+                    final_model=str(row.get("final_model", "")),
+                    reason=str(row.get("reason", "")),
+                    payload_snippet_path=row.get("payload_snippet_path"),
+                )
+                self.state.ledger[entry.chunk_index] = entry
+            except Exception:
+                continue
+
+    def _persist_ledger(self) -> None:
+        rows = [self.state.ledger[i].to_dict() for i in sorted(self.state.ledger.keys())]
+        self._atomic_write_json(self.ledger_file, {"chunks": rows, "metrics": self.metrics.to_dict()})
+
+    def is_done(self, chunk_index: int) -> bool:
+        e = self.state.ledger.get(chunk_index)
+        return bool(e and e.status in {ChunkStatus.OK, ChunkStatus.RETRY_SUCCESS, ChunkStatus.FALLBACK_SUCCESS})
+
+    def run(
+        self,
+        *,
+        chunks: list[str],
+        primary_model: str,
+        fallback_model: str,
+        process_attempt: Callable[[int, str, str, int], ChunkAttemptResult],
+        persist_artifact: Callable[[], None],
+    ) -> dict[int, ChunkLedgerEntry]:
+        for i, chunk in enumerate(chunks):
+            if self.is_done(i):
+                continue
+
+            attempts = [primary_model, primary_model, fallback_model]
+            final_entry: Optional[ChunkLedgerEntry] = None
+
+            for attempt_no, model in enumerate(attempts, start=1):
+                result = process_attempt(i, chunk, model, attempt_no)
+                if result.success:
+                    status = ChunkStatus.OK
+                    if attempt_no == 2:
+                        status = ChunkStatus.RETRY_SUCCESS
+                    elif attempt_no == 3:
+                        status = ChunkStatus.FALLBACK_SUCCESS
+                    final_entry = ChunkLedgerEntry(
+                        chunk_index=i,
+                        status=status,
+                        attempts=attempt_no,
+                        final_model=result.model or model,
+                        reason=result.reason,
+                        payload_snippet_path=result.payload_snippet_path,
+                    )
+                    break
+
+                final_entry = ChunkLedgerEntry(
+                    chunk_index=i,
+                    status=ChunkStatus.FAILED_UNPROCESSED,
+                    attempts=attempt_no,
+                    final_model=result.model or model,
+                    reason=result.reason,
+                    payload_snippet_path=result.payload_snippet_path,
+                )
+
+            assert final_entry is not None
+            self.state.ledger[i] = final_entry
+
+            if final_entry.status == ChunkStatus.OK:
+                self.metrics.ok += 1
+            elif final_entry.status == ChunkStatus.RETRY_SUCCESS:
+                self.metrics.retried += 1
+            elif final_entry.status == ChunkStatus.FALLBACK_SUCCESS:
+                self.metrics.fallback_success += 1
+            else:
+                self.metrics.failed += 1
+
+            if (i + 1) % self.artifact_write_every == 0:
+                persist_artifact()
+            self._persist_ledger()
+
+        persist_artifact()
+        self._persist_ledger()
+        return self.state.ledger

--- a/src/book_graph_analyzer/lore/events.py
+++ b/src/book_graph_analyzer/lore/events.py
@@ -9,11 +9,17 @@ Extracts structured events from text:
 import json
 import logging
 import re
+from pathlib import Path
 from dataclasses import dataclass, field
 from typing import Optional
 from collections import defaultdict
 
 from ..llm import LLMClient
+from ..extract.resilient_chunk_runner import (
+    ResilientChunkRunner,
+    ChunkAttemptResult,
+    ChunkStatus,
+)
 from .temporal import Era
 
 
@@ -302,6 +308,8 @@ class EventExtractor:
         chunk_size: int = 3000,
         overlap: int = 200,
         checkpoint_file: Optional[str] = None,
+        resilient: bool = False,
+        fallback_model: Optional[str] = None,
     ) -> EventGraph:
         """Extract events from a full book using chunked processing.
         
@@ -348,32 +356,43 @@ class EventExtractor:
                 self._seen_events = set(checkpoint.get("seen_keys", []))
                 print(f"  Resuming from checkpoint: chunk {start_chunk}/{total_chunks} ({len(all_events)} events)", flush=True)
         
-        for i, chunk in enumerate(chunks):
+        if resilient and checkpoint_file and self.use_llm:
+            self._run_resilient_chunks(
+                chunks=chunks,
+                source_book=source_book,
+                checkpoint_file=checkpoint_file,
+                all_events=all_events,
+                all_relations=all_relations,
+                fallback_model=fallback_model,
+                total_chunks=total_chunks,
+            )
+        else:
+            for i, chunk in enumerate(chunks):
             # Skip already processed chunks
-            if i < start_chunk:
-                continue
+                if i < start_chunk:
+                    continue
                 
-            if self.progress_callback:
-                self.progress_callback(i + 1, total_chunks, f"Processing chunk {i + 1}/{total_chunks}")
+                if self.progress_callback:
+                    self.progress_callback(i + 1, total_chunks, f"Processing chunk {i + 1}/{total_chunks}")
             
             # Simple progress print every 10 chunks (visible even without Rich)
-            if (i + 1) % 10 == 0 or i == start_chunk:
-                print(f"  [chunk {i + 1}/{total_chunks}]", flush=True)
+                if (i + 1) % 10 == 0 or i == start_chunk:
+                    print(f"  [chunk {i + 1}/{total_chunks}]", flush=True)
             
-            events, relations = self._extract_llm(chunk, source_book, chunk_index=i)
+                events, relations = self._extract_llm(chunk, source_book, chunk_index=i)
             
-            for event in events:
+                for event in events:
                 # Deduplicate based on normalized description
-                event_key = self._normalize_event_key(event)
-                if event_key not in self._seen_events:
-                    self._seen_events.add(event_key)
-                    all_events.append(event)
+                    event_key = self._normalize_event_key(event)
+                    if event_key not in self._seen_events:
+                        self._seen_events.add(event_key)
+                        all_events.append(event)
             
-            all_relations.extend(relations)
+                all_relations.extend(relations)
             
             # Save checkpoint after each chunk
-            if checkpoint_file:
-                self._save_checkpoint(checkpoint_file, i + 1, total_chunks, all_events, all_relations)
+                if checkpoint_file:
+                    self._save_checkpoint(checkpoint_file, i + 1, total_chunks, all_events, all_relations)
         
         # Clear checkpoint on completion
         if checkpoint_file:
@@ -390,8 +409,85 @@ class EventExtractor:
         
         # Infer additional ordering from year/era
         self._infer_temporal_ordering(graph)
+
+        if resilient and checkpoint_file and self.use_llm:
+            summary = self.get_resilient_summary(checkpoint_file)
+            print(
+                "  Resilient summary: "
+                f"ok={summary.get('ok', 0)} retried={summary.get('retried', 0)} "
+                f"fallback_success={summary.get('fallback_success', 0)} failed={summary.get('failed', 0)}",
+                flush=True,
+            )
         
         return graph
+
+    def get_resilient_summary(self, checkpoint_file: str) -> dict:
+        ledger_path = Path(checkpoint_file).with_suffix(Path(checkpoint_file).suffix + ".ledger.json")
+        try:
+            data = json.loads(ledger_path.read_text(encoding="utf-8"))
+            return data.get("metrics", {})
+        except (FileNotFoundError, json.JSONDecodeError):
+            return {}
+
+    def _run_resilient_chunks(
+        self,
+        *,
+        chunks: list[str],
+        source_book: str,
+        checkpoint_file: str,
+        all_events: list[Event],
+        all_relations: list[EventRelation],
+        fallback_model: Optional[str],
+        total_chunks: int,
+    ) -> None:
+        base = Path(checkpoint_file)
+        ledger_file = base.with_suffix(base.suffix + ".ledger.json")
+        payload_dir = base.with_suffix(base.suffix + ".payloads")
+        payload_dir.mkdir(parents=True, exist_ok=True)
+
+        default_llm = LLMClient()
+        primary_model = getattr(default_llm, "model", "")
+        if not fallback_model:
+            fallback_model = "gpt-4o" if default_llm.provider == "openai" else "llama3.1:70b"
+
+        runner = ResilientChunkRunner(ledger_file)
+
+        def persist_artifact() -> None:
+            completed = len(runner.state.ledger)
+            self._save_checkpoint(checkpoint_file, completed, total_chunks, all_events, all_relations)
+
+        def process_attempt(chunk_index: int, chunk: str, model: str, attempt_no: int) -> ChunkAttemptResult:
+            if self.progress_callback:
+                self.progress_callback(
+                    min(chunk_index + 1, total_chunks),
+                    total_chunks,
+                    f"Processing chunk {chunk_index + 1}/{total_chunks} (attempt {attempt_no}, model {model})",
+                )
+
+            events, relations, reason, raw = self._extract_llm_once(chunk, source_book, chunk_index=chunk_index, model=model)
+            snippet_path = None
+            if reason and raw:
+                snippet_path = str(payload_dir / f"chunk_{chunk_index:04d}_attempt_{attempt_no}.txt")
+                Path(snippet_path).write_text(raw[:3000], encoding="utf-8")
+
+            if reason:
+                return ChunkAttemptResult(False, reason=reason, model=model, payload_snippet_path=snippet_path)
+
+            for event in events:
+                event_key = self._normalize_event_key(event)
+                if event_key not in self._seen_events:
+                    self._seen_events.add(event_key)
+                    all_events.append(event)
+            all_relations.extend(relations)
+            return ChunkAttemptResult(True, model=model)
+
+        runner.run(
+            chunks=chunks,
+            primary_model=primary_model,
+            fallback_model=fallback_model,
+            process_attempt=process_attempt,
+            persist_artifact=persist_artifact,
+        )
     
     @staticmethod
     def _coerce_str(val) -> str:
@@ -612,7 +708,59 @@ Focus on significant plot events, not minor actions. Include 5-15 events.
 
 JSON:"""
 
-        llm = LLMClient()
+        events, relations, _reason, _raw = self._extract_llm_once(
+            text,
+            source_book,
+            chunk_index=chunk_index,
+            model=None,
+        )
+        return events, relations
+
+    def _extract_llm_once(
+        self,
+        text: str,
+        source_book: str,
+        chunk_index: int = 0,
+        model: Optional[str] = None,
+    ) -> tuple[list[Event], list[EventRelation], str, str]:
+        # Limit text for prompt (should already be chunked but ensure limit)
+        text = text[:4000]
+
+        prompt = f"""Extract key events from this fantasy text. For each event identify:
+- description: Short description (e.g., "Bilbo found the Ring")
+- agent: Who did it (e.g., "Bilbo")
+- action: The verb/action (e.g., "found")
+- patient: What was acted upon (e.g., "the Ring")
+- year: Year if mentioned (e.g., 2941)
+- era: Age if mentioned (first_age, second_age, third_age, fourth_age)
+
+Also identify temporal relationships between events:
+- If one event clearly happened before another
+- If one event caused another
+
+Text:
+{text}
+
+Return JSON with two arrays:
+{{
+  "events": [
+    {{"id": "unique_id", "description": "...", "agent": "...", "action": "...", "patient": "...", "year": null, "era": null}},
+    ...
+  ],
+  "relations": [
+    {{"event1": "id1", "relation": "before", "event2": "id2"}},
+    ...
+  ]
+}}
+
+Focus on significant plot events, not minor actions. Include 5-15 events.
+
+JSON:"""
+
+        try:
+            llm = LLMClient(model=model)
+        except TypeError:
+            llm = LLMClient()
         logger.info(
             "Event extraction LLM provider=%s model=%s chunk=%d",
             getattr(llm, "provider", "unknown"),
@@ -694,13 +842,15 @@ JSON:"""
                     "LLM response did not contain valid JSON payload; skipping chunk=%d",
                     chunk_index,
                 )
+                return [], [], "malformed_json", response
         else:
             logger.warning(
                 "LLM request returned empty response; skipping chunk=%d",
                 chunk_index,
             )
+            return [], [], "empty_response", ""
 
-        return events, relations
+        return events, relations, "", response
     
     def _extract_patterns(self, text: str, source_book: str) -> list[Event]:
         """Extract events using pattern matching."""

--- a/tests/test_lore_events_resilient.py
+++ b/tests/test_lore_events_resilient.py
@@ -1,0 +1,86 @@
+import json
+
+from book_graph_analyzer.lore import events as events_module
+from book_graph_analyzer.lore.events import EventExtractor
+
+
+class _FakeLLM:
+    def __init__(self, model=None):
+        self.model = model or "primary"
+        self.provider = "openai"
+        self._calls = 0
+
+    def generate(self, *_args, **_kwargs):
+        self._calls += 1
+        if self.model == "gpt-4o-mini":
+            return "not-json"
+        return '{"events":[{"id":"e1","description":"Bilbo found ring","agent":"Bilbo","action":"found","patient":"Ring"}],"relations":[]}'
+
+    def extract_json(self, response):
+        try:
+            return json.loads(response)
+        except json.JSONDecodeError:
+            return None
+
+
+def test_resilient_escalates_to_fallback_and_persists_ledger(tmp_path, monkeypatch):
+    def _factory(provider=None, model=None):
+        return _FakeLLM(model=model or "gpt-4o-mini")
+
+    monkeypatch.setattr(events_module, "LLMClient", _factory)
+
+    text = "A" * 7000
+    checkpoint = tmp_path / "hobbit.checkpoint.json"
+    extractor = EventExtractor(use_llm=True)
+
+    graph = extractor.extract_from_book(
+        text,
+        source_book="Hobbit",
+        chunk_size=3000,
+        checkpoint_file=str(checkpoint),
+        resilient=True,
+        fallback_model="gpt-4o",
+    )
+
+    assert len(graph.events) >= 1
+    ledger = json.loads((tmp_path / "hobbit.checkpoint.json.ledger.json").read_text(encoding="utf-8"))
+    statuses = {row["status"] for row in ledger["chunks"]}
+    assert "fallback_success" in statuses
+
+
+def test_resilient_resume_skips_completed_chunks(tmp_path, monkeypatch):
+    class _AlwaysGood(_FakeLLM):
+        def generate(self, *_args, **_kwargs):
+            return '{"events":[{"id":"e1","description":"x"}],"relations":[]}'
+
+    calls = {"n": 0}
+
+    def _factory(provider=None, model=None):
+        calls["n"] += 1
+        return _AlwaysGood(model=model or "gpt-4o-mini")
+
+    monkeypatch.setattr(events_module, "LLMClient", _factory)
+
+    checkpoint = tmp_path / "resume.checkpoint.json"
+    ledger_path = tmp_path / "resume.checkpoint.json.ledger.json"
+    ledger_path.write_text(
+        json.dumps({
+            "chunks": [
+                {"chunk_index": 0, "status": "ok", "attempts": 1, "final_model": "gpt-4o-mini"}
+            ]
+        }),
+        encoding="utf-8",
+    )
+
+    extractor = EventExtractor(use_llm=True)
+    extractor.extract_from_book(
+        "B" * 7000,
+        source_book="Hobbit",
+        chunk_size=3000,
+        checkpoint_file=str(checkpoint),
+        resilient=True,
+        fallback_model="gpt-4o",
+    )
+
+    # Should not process all chunks from scratch because one was already marked ok
+    assert calls["n"] < 4

--- a/tests/test_resilient_chunk_runner.py
+++ b/tests/test_resilient_chunk_runner.py
@@ -1,0 +1,70 @@
+import json
+
+from book_graph_analyzer.extract.resilient_chunk_runner import (
+    ResilientChunkRunner,
+    ChunkAttemptResult,
+    ChunkStatus,
+)
+
+
+def test_runner_retries_then_fallback_success(tmp_path):
+    ledger = tmp_path / "ledger.json"
+    runner = ResilientChunkRunner(ledger)
+
+    calls = []
+
+    def process_attempt(i, chunk, model, attempt_no):
+        calls.append((i, model, attempt_no))
+        if attempt_no < 3:
+            return ChunkAttemptResult(False, reason="malformed_json", model=model)
+        return ChunkAttemptResult(True, model=model)
+
+    persisted = {"count": 0}
+
+    def persist_artifact():
+        persisted["count"] += 1
+
+    state = runner.run(
+        chunks=["a"],
+        primary_model="m1",
+        fallback_model="m2",
+        process_attempt=process_attempt,
+        persist_artifact=persist_artifact,
+    )
+
+    assert calls == [(0, "m1", 1), (0, "m1", 2), (0, "m2", 3)]
+    assert state[0].status == ChunkStatus.FALLBACK_SUCCESS
+    data = json.loads(ledger.read_text(encoding="utf-8"))
+    assert data["metrics"]["fallback_success"] == 1
+
+
+def test_runner_resume_only_failed_chunks(tmp_path):
+    ledger = tmp_path / "ledger.json"
+    ledger.write_text(
+        json.dumps(
+            {
+                "chunks": [
+                    {"chunk_index": 0, "status": "ok", "attempts": 1, "final_model": "m1"},
+                    {"chunk_index": 1, "status": "failed_unprocessed", "attempts": 3, "final_model": "m2"},
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    runner = ResilientChunkRunner(ledger)
+    seen = []
+
+    def process_attempt(i, chunk, model, attempt_no):
+        seen.append(i)
+        return ChunkAttemptResult(True, model=model)
+
+    runner.run(
+        chunks=["a", "b"],
+        primary_model="m1",
+        fallback_model="m2",
+        process_attempt=process_attempt,
+        persist_artifact=lambda: None,
+    )
+
+    assert seen == [1]


### PR DESCRIPTION
## Summary\n- add shared ResilientChunkRunner utility with chunk state machine, retry/fallback policy, status enum, and metrics\n- integrate resilient mode into lore events chunk extraction\n- integrate resilient mode into corpus events chunk extraction call-site\n- add periodic safe artifact writes + ledger persistence for resume-only failed chunks\n- add docs runbook for resilient mode and artifacts\n\n## Behavior\nChunk retry policy for chunked LLM extraction:\n1. parse/normalize/write attempt\n2. retry same model once\n3. retry fallback model\n4. if still failing, mark ailed_unprocessed and continue\n\nResume behavior:\n- completed chunks (ok/retry_success/fallback_success) are skipped on rerun\n- only failed/unprocessed chunks are retried\n\n## CLI\n- ga lore events ... --resilient --checkpoint <file>\n- ga corpus events ... --resilient --checkpoint-dir <dir>\n\nDefaults remain backward-compatible (--resilient is opt-in).\n\n## Tests\n- 	ests/test_resilient_chunk_runner.py\n  - state machine + retry/fallback transitions\n  - resume skipping completed chunks\n- 	ests/test_lore_events_resilient.py\n  - malformed payload triggers fallback escalation\n  - resume behavior only reruns unprocessed chunks\n- existing 	ests/test_lore_events_extractor.py still passes\n\n## Notes\n- failed chunks persist reason + payload snippet path in ledger/payload artifact directory\n- summary counters emitted at end: ok, retried, fallback_success, failed\n