### PR TITLE
Fix lore-events finalization ordering to prevent checkpoint data loss

### DIFF
--- a/src/book_graph_analyzer/cli.py
+++ b/src/book_graph_analyzer/cli.py
@@ -2497,6 +2497,20 @@ def lore_events(path: str, output: str, neo4j: bool, chunk_size: int, no_llm: bo
             e2_name = e2.description if e2 else rel.event2_id
             console.print(f"  - {e1_name} --{rel.relation}--> {e2_name}")
     
+    # Resilient safety: never overwrite durable output with an empty graph when
+    # checkpoint data exists from a previous successful chunk run.
+    if resilient and checkpoint and not graph.events:
+        checkpoint_data = extractor._load_checkpoint(checkpoint)
+        if checkpoint_data:
+            cp_events = checkpoint_data.get("events", [])
+            cp_relations = checkpoint_data.get("relations", [])
+            if cp_events:
+                console.print(
+                    "[yellow]Recovered non-empty graph from checkpoint after empty in-memory result; "
+                    "preserving durable data.[/yellow]"
+                )
+                graph = extractor.graph_from_checkpoint_payload(cp_events, cp_relations)
+
     # Save to JSON
     output_path = Path(output)
     with open(output_path, 'w', encoding='utf-8') as f:
@@ -2505,6 +2519,7 @@ def lore_events(path: str, output: str, neo4j: bool, chunk_size: int, no_llm: bo
     console.print(f"\n[green]OK[/green] Events saved to {output_path}")
     
     # Write to Neo4j if requested
+    neo4j_write_succeeded = not neo4j
     if neo4j:
         from book_graph_analyzer.graph.writer import GraphWriter
         from book_graph_analyzer.graph.connection import check_neo4j_connection
@@ -2516,17 +2531,23 @@ def lore_events(path: str, output: str, neo4j: bool, chunk_size: int, no_llm: bo
         console.print("\n[bold]Writing to Neo4j...[/bold]")
         
         writer = GraphWriter()
-        stats = writer.write_event_graph(
-            graph,
-            book=book_name,
-            link_entities=True,
-        )
-        writer.close()
+        try:
+            stats = writer.write_event_graph(
+                graph,
+                book=book_name,
+                link_entities=True,
+            )
+            neo4j_write_succeeded = True
+        finally:
+            writer.close()
         
         console.print(f"  Events written: {stats['events_written']}")
         console.print(f"  Relations written: {stats['relations_written']}")
         console.print(f"  Entity links created: {stats['entity_links']}")
         console.print(f"[green]OK[/green] Events written to Neo4j")
+
+    if checkpoint and (not neo4j or neo4j_write_succeeded):
+        extractor.finalize_checkpoint(checkpoint)
 
 
 @lore.command(name="query-events")

--- a/src/book_graph_analyzer/lore/events.py
+++ b/src/book_graph_analyzer/lore/events.py
@@ -394,10 +394,6 @@ class EventExtractor:
                 if checkpoint_file:
                     self._save_checkpoint(checkpoint_file, i + 1, total_chunks, all_events, all_relations)
         
-        # Clear checkpoint on completion
-        if checkpoint_file:
-            self._clear_checkpoint(checkpoint_file)
-        
         # Add all events to graph
         for event in all_events:
             graph.add_event(event)
@@ -421,6 +417,15 @@ class EventExtractor:
         
         return graph
 
+    def finalize_checkpoint(self, checkpoint_file: str) -> None:
+        """Clear checkpoint + resilient artifacts after durable finalization.
+
+        This must only be called *after* durable outputs are persisted
+        (JSON output and optional Neo4j write).
+        """
+        self._clear_checkpoint(checkpoint_file)
+        self._clear_resilient_artifacts(checkpoint_file)
+
     def get_resilient_summary(self, checkpoint_file: str) -> dict:
         ledger_path = Path(checkpoint_file).with_suffix(Path(checkpoint_file).suffix + ".ledger.json")
         try:
@@ -428,6 +433,20 @@ class EventExtractor:
             return data.get("metrics", {})
         except (FileNotFoundError, json.JSONDecodeError):
             return {}
+
+    def graph_from_checkpoint_payload(self, events_payload: list[dict], relations_payload: list[dict]) -> EventGraph:
+        """Build an EventGraph from checkpoint payload data."""
+        graph = EventGraph()
+        all_events = [Event(**e) for e in events_payload]
+        all_relations = [EventRelation(**r) for r in relations_payload]
+
+        for event in all_events:
+            graph.add_event(event)
+        for rel in all_relations:
+            if rel.event1_id in graph.events and rel.event2_id in graph.events:
+                graph.add_relation(rel)
+        self._infer_temporal_ordering(graph)
+        return graph
 
     def _run_resilient_chunks(
         self,
@@ -570,6 +589,24 @@ class EventExtractor:
             print(f"  Checkpoint cleared: {checkpoint_file}", flush=True)
         except OSError:
             pass
+
+    def _clear_resilient_artifacts(self, checkpoint_file: str) -> None:
+        """Remove resilient ledger and payload artifacts when finalization succeeds."""
+        base = Path(checkpoint_file)
+        ledger_file = base.with_suffix(base.suffix + ".ledger.json")
+        payload_dir = base.with_suffix(base.suffix + ".payloads")
+
+        try:
+            ledger_file.unlink(missing_ok=True)
+        except OSError:
+            pass
+
+        if payload_dir.exists() and payload_dir.is_dir():
+            import shutil
+            try:
+                shutil.rmtree(payload_dir)
+            except OSError:
+                pass
     
     def _infer_temporal_ordering(self, graph: EventGraph) -> None:
         """Infer ordering relationships from year/era data."""

--- a/tests/test_lore_events_finalization.py
+++ b/tests/test_lore_events_finalization.py
@@ -1,0 +1,135 @@
+import json
+
+from click.testing import CliRunner
+
+from book_graph_analyzer.cli import main
+from book_graph_analyzer.lore.events import Event, EventGraph
+
+
+class _ExtractorBase:
+    instances = []
+
+    def __init__(self, use_llm=True, progress_callback=None):
+        self.use_llm = use_llm
+        self.progress_callback = progress_callback
+        self.finalized = []
+        type(self).instances.append(self)
+
+    def get_resilient_summary(self, _checkpoint):
+        return {"ok": 1, "retried": 0, "fallback_success": 0, "failed": 0}
+
+    def _load_checkpoint(self, checkpoint_file):
+        try:
+            with open(checkpoint_file, "r", encoding="utf-8") as f:
+                return json.load(f)
+        except FileNotFoundError:
+            return None
+
+    def graph_from_checkpoint_payload(self, events_payload, relations_payload):
+        g = EventGraph()
+        for e in events_payload:
+            g.add_event(Event(**e))
+        return g
+
+    def finalize_checkpoint(self, checkpoint_file):
+        self.finalized.append(checkpoint_file)
+
+
+class _ExtractorWithData(_ExtractorBase):
+    def extract_from_book(self, *_args, **_kwargs):
+        g = EventGraph()
+        g.add_event(Event(id="e1", description="Bilbo found ring"))
+        return g
+
+
+class _ExtractorEmpty(_ExtractorBase):
+    def extract_from_book(self, *_args, **_kwargs):
+        return EventGraph()
+
+
+def _patch_common(monkeypatch, text):
+    monkeypatch.setattr("book_graph_analyzer.ingest.loader.load_book", lambda *_args, **_kwargs: text)
+
+
+def test_lore_events_checkpoint_not_finalized_when_neo4j_write_fails(tmp_path, monkeypatch):
+    _ExtractorWithData.instances = []
+    input_file = tmp_path / "hobbit.txt"
+    input_file.write_text("x", encoding="utf-8")
+    checkpoint = tmp_path / "hobbit.checkpoint.json"
+
+    _patch_common(monkeypatch, "A" * 9000)
+    monkeypatch.setattr("book_graph_analyzer.lore.EventExtractor", _ExtractorWithData)
+    monkeypatch.setattr("book_graph_analyzer.graph.connection.check_neo4j_connection", lambda: True)
+
+    class _FailingWriter:
+        def write_event_graph(self, *args, **kwargs):
+            raise RuntimeError("neo4j write failed")
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr("book_graph_analyzer.graph.writer.GraphWriter", _FailingWriter)
+    monkeypatch.setattr("book_graph_analyzer.llm.LLMClient", lambda: type("L", (), {"provider": "openai", "model": "gpt-4o-mini"})())
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "lore",
+            "events",
+            str(input_file),
+            "-o",
+            str(tmp_path / "out.json"),
+            "--resilient",
+            "-c",
+            str(checkpoint),
+            "--neo4j",
+            "--chunk-size",
+            "1000",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert _ExtractorWithData.instances[-1].finalized == []
+
+
+def test_lore_events_recovers_nonempty_checkpoint_before_finalization(tmp_path, monkeypatch):
+    _ExtractorEmpty.instances = []
+    input_file = tmp_path / "hobbit.txt"
+    input_file.write_text("x", encoding="utf-8")
+    output = tmp_path / "out.json"
+    checkpoint = tmp_path / "hobbit.checkpoint.json"
+    checkpoint.write_text(
+        json.dumps(
+            {
+                "events": [{"id": "cp1", "description": "Recovered event"}],
+                "relations": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    _patch_common(monkeypatch, "A" * 9000)
+    monkeypatch.setattr("book_graph_analyzer.lore.EventExtractor", _ExtractorEmpty)
+    monkeypatch.setattr("book_graph_analyzer.llm.LLMClient", lambda: type("L", (), {"provider": "openai", "model": "gpt-4o-mini"})())
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "lore",
+            "events",
+            str(input_file),
+            "-o",
+            str(output),
+            "--resilient",
+            "-c",
+            str(checkpoint),
+            "--chunk-size",
+            "1000",
+        ],
+    )
+
+    assert result.exit_code == 0
+    data = json.loads(output.read_text(encoding="utf-8"))
+    assert len(data["events"]) == 1
+    assert data["events"]["cp1"]["id"] == "cp1"
+    assert _ExtractorEmpty.instances[-1].finalized == [str(checkpoint)]


### PR DESCRIPTION
## Root cause
`EventExtractor.extract_from_book()` cleared checkpoint state immediately after chunk extraction completed, before the CLI wrote durable JSON output and before optional Neo4j persistence. If the process crashed in that finalization window, expensive extraction work was lost and reruns started from scratch.

A second failure mode could overwrite output with an empty graph in resilient mode when in-memory post-processing failed while checkpoint payload still had recovered data.

## Fix
- Stop auto-clearing checkpoint inside `extract_from_book()`.
- Add explicit `EventExtractor.finalize_checkpoint()` that clears checkpoint + resilient ledger/payload artifacts only after durable finalization succeeds.
- In `lore events` CLI, call `finalize_checkpoint()` only after:
  1) JSON output write succeeds, and
  2) Neo4j write succeeds when `--neo4j` is requested.
- Add resilient safety guard: if resilient mode yields an empty graph but checkpoint payload contains events, rebuild graph from checkpoint payload and persist that (prevents silent empty overwrite).

## Tests
- `test_lore_events_checkpoint_not_finalized_when_neo4j_write_fails`
- `test_lore_events_recovers_nonempty_checkpoint_before_finalization`
- existing resilient tests still pass

Ran:
`pytest -q tests/test_lore_events_resilient.py tests/test_lore_events_finalization.py`
