### PR TITLE
Fix event→entity linking for Event graph writes

### DIFF
--- a/src/book_graph_analyzer/graph/writer.py
+++ b/src/book_graph_analyzer/graph/writer.py
@@ -2,6 +2,7 @@
 
 from typing import Iterator
 from collections import defaultdict
+import re
 
 from neo4j import Driver
 
@@ -877,6 +878,7 @@ class GraphWriter:
                 "agent": e.agent,
                 "action": e.action,
                 "patient": e.patient,
+                "source_text": e.source_text,
                 "era": e.era.value if e.era else None,
                 "year": e.year,
                 "confidence": e.confidence,
@@ -891,6 +893,7 @@ class GraphWriter:
             e.agent = item.agent,
             e.action = item.action,
             e.patient = item.patient,
+            e.source_text = item.source_text,
             e.era = item.era,
             e.year = item.year,
             e.source_book = $book,
@@ -967,43 +970,33 @@ class GraphWriter:
         """
         links = 0
 
-        if event.agent:
-            # Try to find matching character
-            query = """
-            MATCH (c:Character)
-            WHERE toLower(c.canonical_name) CONTAINS toLower($name)
-               OR toLower(c.name) CONTAINS toLower($name)
-            WITH c LIMIT 1
-            MATCH (e:Event {id: $event_id})
-            MERGE (c)-[r:PARTICIPATED_IN]->(e)
-            SET r.role = 'agent'
-            RETURN count(r) as cnt
-            """
-            with self.driver.session() as session:
-                result = session.run(query, name=event.agent, event_id=event.id)
-                record = result.single()
-                if record:
-                    links += record["cnt"]
+        links += self._link_event_role(
+            event_id=event.id,
+            raw_value=event.agent,
+            labels=["Character"],
+            rel_type="PARTICIPATED_IN",
+            role="agent",
+        )
 
-        if event.patient:
-            # Try to find matching entity (could be character, place, or object)
-            for label in ["Character", "Place", "Object"]:
-                query = f"""
-                MATCH (n:{label})
-                WHERE toLower(n.canonical_name) CONTAINS toLower($name)
-                   OR toLower(n.name) CONTAINS toLower($name)
-                WITH n LIMIT 1
-                MATCH (e:Event {{id: $event_id}})
-                MERGE (n)-[r:INVOLVED_IN]->(e)
-                SET r.role = 'patient'
-                RETURN count(r) as cnt
-                """
-                with self.driver.session() as session:
-                    result = session.run(query, name=event.patient, event_id=event.id)
-                    record = result.single()
-                    if record and record["cnt"] > 0:
-                        links += record["cnt"]
-                        break  # Found a match, stop looking
+        # Patient may be Character / Place / Object. Choose one best hit only.
+        links += self._link_event_role(
+            event_id=event.id,
+            raw_value=event.patient,
+            labels=["Character", "Place", "Object"],
+            rel_type="INVOLVED_IN",
+            role="patient",
+        )
+
+        # Conservative place cue fallback from event prose if no explicit patient match.
+        if not event.patient and (event.description or event.source_text):
+            cue_text = f"{event.description or ''} {event.source_text or ''}".strip()
+            links += self._link_event_role(
+                event_id=event.id,
+                raw_value=cue_text,
+                labels=["Place"],
+                rel_type="TOOK_PLACE_AT",
+                role="location_cue",
+            )
 
         return links
 
@@ -2355,3 +2348,107 @@ class GraphWriter:
             for record in session.run(query, source_a=source_a, source_b=source_b, limit=limit):
                 results.append(dict(record))
         return results
+    _STOPWORDS = {
+        "the", "a", "an", "of", "and", "or", "to", "for", "in", "on", "at", "by", "with",
+        "from", "into", "onto", "upon", "his", "her", "their", "its", "him", "them",
+    }
+
+    @staticmethod
+    def _normalize_entity_text(value: str | None) -> str:
+        if not value:
+            return ""
+        text = value.lower().strip()
+        text = re.sub(r"[\"'`]+", "", text)
+        text = re.sub(r"[^a-z0-9\s-]", " ", text)
+        text = re.sub(r"\s+", " ", text).strip()
+        return text
+
+    @classmethod
+    def _meaningful_tokens(cls, value: str | None) -> list[str]:
+        text = cls._normalize_entity_text(value)
+        if not text:
+            return []
+        return [t for t in text.split(" ") if t and t not in cls._STOPWORDS and len(t) > 2]
+
+    @classmethod
+    def _expand_candidate_strings(cls, value: str | None) -> list[str]:
+        """Generate conservative candidate strings for entity matching."""
+        text = cls._normalize_entity_text(value)
+        if not text:
+            return []
+
+        variants = {text}
+        # Split simple conjunction/apposition forms: "Bilbo and dwarves", "Bilbo, Gandalf"
+        for part in re.split(r"\b(?:and|or)\b|,|/", text):
+            p = part.strip()
+            if p:
+                variants.add(p)
+
+        # Add compact token-only variants for noisy spans
+        tokens = cls._meaningful_tokens(text)
+        if len(tokens) >= 2:
+            variants.add(" ".join(tokens))
+        for t in tokens:
+            variants.add(t)
+
+        # Prefer longer strings first for better precision
+        return sorted((v for v in variants if v), key=len, reverse=True)
+
+    def _link_event_role(
+        self,
+        *,
+        event_id: str,
+        raw_value: str | None,
+        labels: list[str],
+        rel_type: str,
+        role: str,
+    ) -> int:
+        """Link one event role to a best-matching canonical entity.
+
+        Returns 1 when a link exists after MERGE, else 0.
+        """
+        candidates = self._expand_candidate_strings(raw_value)
+        if not candidates:
+            return 0
+
+        query = f"""
+        MATCH (e:Event {{id: $event_id}})
+        WITH e, [c IN $candidates WHERE c IS NOT NULL AND trim(c) <> ''] AS candidates
+        UNWIND candidates AS cand
+        MATCH (n)
+        WHERE any(lbl IN $labels WHERE lbl IN labels(n))
+        WITH e, n, cand,
+             toLower(coalesce(n.canonical_name, n.name, '')) AS cname,
+             [a IN coalesce(n.aliases, []) | toLower(a)] AS aliases
+        WHERE cname <> ''
+          AND (
+            cname = cand
+            OR cand IN aliases
+            OR cname CONTAINS cand
+            OR cand CONTAINS cname
+            OR any(a IN aliases WHERE a CONTAINS cand OR cand CONTAINS a)
+          )
+        WITH e, n, cand,
+             CASE
+               WHEN cname = cand OR cand IN aliases THEN 100
+               WHEN any(a IN aliases WHERE a = cand) THEN 95
+               WHEN cname CONTAINS cand OR cand CONTAINS cname THEN 70
+               ELSE 50
+             END AS score,
+             size(cname) AS name_len
+        ORDER BY score DESC, name_len DESC
+        LIMIT 1
+        MERGE (n)-[r:{rel_type}]->(e)
+        SET r.role = $role
+        RETURN count(r) AS cnt
+        """
+
+        with self.driver.session() as session:
+            row = session.run(
+                query,
+                event_id=event_id,
+                candidates=candidates,
+                labels=labels,
+                role=role,
+            ).single()
+            return int(row["cnt"]) if row else 0

--- a/tests/test_event_entity_linking.py
+++ b/tests/test_event_entity_linking.py
@@ -1,0 +1,146 @@
+from dataclasses import dataclass
+
+from book_graph_analyzer.graph.writer import GraphWriter
+from book_graph_analyzer.lore.events import Event, EventGraph
+
+
+class _FakeResult:
+    def __init__(self, rows=None, single_row=None):
+        self._rows = rows or []
+        self._single = single_row
+
+    def __iter__(self):
+        return iter(self._rows)
+
+    def single(self):
+        return self._single
+
+
+@dataclass
+class _Node:
+    id: str
+    labels: set[str]
+    canonical_name: str
+    aliases: list[str]
+
+
+class _FakeSession:
+    def __init__(self, state):
+        self.state = state
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+    def run(self, query, **kwargs):
+        if "MERGE (e:Event {id: item.id})" in query:
+            for item in kwargs["batch"]:
+                self.state["events"].add(item["id"])
+            return _FakeResult()
+
+        if "MATCH (e1:Event {id: item.event1_id})" in query:
+            return _FakeResult()
+
+        if "MERGE (n)-[r:" in query and "RETURN count(r) AS cnt" in query:
+            event_id = kwargs["event_id"]
+            labels = set(kwargs["labels"])
+            candidates = [c.lower() for c in kwargs["candidates"]]
+            role = kwargs["role"]
+            rel_type = query.split("MERGE (n)-[r:")[1].split("]->(e)")[0]
+
+            best = None
+            best_score = -1
+            for node in self.state["nodes"]:
+                if not (node.labels & labels):
+                    continue
+                cname = node.canonical_name.lower()
+                aliases = [a.lower() for a in node.aliases]
+                for cand in candidates:
+                    if not cand:
+                        continue
+                    matched = (
+                        cname == cand
+                        or cand in aliases
+                        or cand in cname
+                        or cname in cand
+                        or any((cand in a or a in cand) for a in aliases)
+                    )
+                    if not matched:
+                        continue
+                    score = 100 if (cname == cand or cand in aliases) else 70
+                    if score > best_score:
+                        best = node
+                        best_score = score
+
+            if best is None or event_id not in self.state["events"]:
+                return _FakeResult(single_row={"cnt": 0})
+
+            self.state["rels"].add((best.id, rel_type, event_id, role))
+            return _FakeResult(single_row={"cnt": 1})
+
+        return _FakeResult()
+
+
+class _FakeDriver:
+    def __init__(self):
+        self.state = {
+            "events": set(),
+            "rels": set(),
+            "nodes": [
+                _Node(id="char_bilbo", labels={"Character"}, canonical_name="Bilbo", aliases=["Bilbo Baggins"]),
+                _Node(id="obj_ring", labels={"Object"}, canonical_name="The One Ring", aliases=["the ring", "ring"]),
+                _Node(id="place_riv", labels={"Place"}, canonical_name="Rivendell", aliases=[]),
+            ],
+        }
+
+    def session(self):
+        return _FakeSession(self.state)
+
+
+def test_event_entity_linking_regression_produces_links(monkeypatch):
+    writer = GraphWriter(driver=_FakeDriver())
+    monkeypatch.setattr(writer, "initialize", lambda: None)
+
+    g = EventGraph()
+    g.add_event(
+        Event(
+            id="hobbit:e1",
+            description="Bilbo found the Ring in the dark",
+            agent="Bilbo Baggins",
+            action="found",
+            patient="the ring",
+        )
+    )
+
+    stats = writer.write_event_graph(g, book="The Hobbit", link_entities=True)
+
+    assert stats["events_written"] == 1
+    assert stats["entity_links"] > 0
+
+
+def test_event_entity_linking_idempotent_on_rerun(monkeypatch):
+    driver = _FakeDriver()
+    writer = GraphWriter(driver=driver)
+    monkeypatch.setattr(writer, "initialize", lambda: None)
+
+    g = EventGraph()
+    g.add_event(
+        Event(
+            id="hobbit:e2",
+            description="Bilbo came to Rivendell",
+            agent="Bilbo Baggins",
+            action="arrived",
+            patient="Rivendell",
+        )
+    )
+
+    writer.write_event_graph(g, book="The Hobbit", link_entities=True)
+    first_rel_count = len(driver.state["rels"])
+
+    writer.write_event_graph(g, book="The Hobbit", link_entities=True)
+    second_rel_count = len(driver.state["rels"])
+
+    assert first_rel_count > 0
+    assert second_rel_count == first_rel_count


### PR DESCRIPTION
## Summary
- fix event entity linking in GraphWriter.write_event_graph() by replacing brittle one-sided CONTAINS matching with candidate normalization + alias-aware matching
- add conservative multi-candidate resolver for event gent and patient roles and fallback location cue linking
- persist source_text on Event nodes (for future location cue extraction)
- add regression tests proving links are created and re-runs remain idempotent (no relationship explosion)

## Root cause
link_event_to_entities() only matched when canonical_name CONTAINS event_field (one direction) and ignored aliases, so common cases like Bilbo Baggins vs canonical Bilbo failed. It also issued narrowly-scoped label-specific lookups with weak assumptions about exact string forms.

## Tests
- pytest -q tests/test_event_entity_linking.py
- pytest -q tests/test_lore_events_finalization.py tests/test_issue48_closeout_integration.py
