### PR TITLE
Fix #90: run genealogy in canonical worldbuilding pipeline + Hobbit non-zero gate

### DIFF
--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -19,7 +19,7 @@ Then use `bga worldbible --help` and `bga generate --help` for generation workfl
     deep-lore layers. Each pillar is being implemented incrementally.
     See the [World-Building RFC](tolkien-worldbuilding-rfc.md) for the full design.
 
-### Available Commands (Placeholder)
+### Available Commands
 
 ```bash
 # Run all world-building pillars on a text
@@ -27,6 +27,9 @@ bga pipeline worldbuilding the_silmarillion.txt -t "The Silmarillion"
 
 # Run specific pillars only
 bga pipeline worldbuilding lotr.txt --pillars linguistic --pillars genealogy
+
+# Persist genealogy artifact from canonical world-building pipeline
+bga pipeline worldbuilding data/texts/the_hobbit.txt --pillars genealogy -o data/output
 
 # Linguistic lineage (etymology chains)
 bga worldbible languages hobbit_bible.json
@@ -44,7 +47,7 @@ bga corpus sources tolkien_works --show-authority
 |--------|-----------|-------|--------|
 | Linguistic Lineage | `worldbible languages` | #46 | ✅ v1 |
 | Sociolinguistic Registers | `lore socioreg-profile`, `lore socioreg-drift`, `lore socioreg-corpus` | #47 | 🟡 closeout evidence added |
-| Genealogical Layer | `lore genealogy` | #49 | 🟡 closeout evidence added |
+| Genealogical Layer | `pipeline worldbuilding --pillars genealogy`, `lore genealogy` | #49 | ✅ canonical pipeline stage active |
 | Impression-of-Depth | `worldbible artifacts`, `lore unresolved-refs` | #50 | 🟡 closeout evidence added |
 | Editorial Meta-Layer | `corpus sources`, `corpus timeline-divergence` | #51 | 🟡 closeout evidence added |
 | Spatiotemporal Engine | `lore timeline-reconcile`, `lore timeline-bridge` | #48 | ✅ v2 (era mismatch + extraction bridge) |

--- a/src/book_graph_analyzer/cli.py
+++ b/src/book_graph_analyzer/cli.py
@@ -6507,37 +6507,64 @@ def corpus_sources(corpus_name: str, show_authority: bool, tag_strata: bool, rep
 @click.option("--pillars", "-p", multiple=True,
               type=click.Choice(["linguistic", "genealogy", "editorial", "cultural", "cosmological"]),
               help="Which world-building pillars to run (default: all)")
-def pipeline_worldbuilding(path: str, title: str | None, pillars: tuple[str]) -> None:
+@click.option("--output-dir", "-o", type=click.Path(), help="Output directory for pillar artifacts")
+def pipeline_worldbuilding(path: str, title: str | None, pillars: tuple[str], output_dir: str | None) -> None:
     """Run world-building analysis pipeline on a text.
 
     Extends the standard pipeline with Tolkien-specific world-building
     extraction: linguistic lineage, genealogy, editorial layers,
     cultural rules, and cosmological timeline.
 
-    TODO(#45): Implement as pillars become available (#46–#50).
-
     Example:
         bga pipeline worldbuilding the_silmarillion.txt -t "The Silmarillion"
         bga pipeline worldbuilding lotr.txt --pillars linguistic --pillars genealogy
     """
+    from book_graph_analyzer.ingest.loader import load_book
+    from book_graph_analyzer.worldbible.genealogy import extract_genealogy_from_text, genealogy_to_json
+
+    file_path = Path(path)
+    book_title = title or file_path.stem.replace("_", " ").replace("-", " ").title()
     selected = list(pillars) if pillars else ["linguistic", "genealogy", "editorial", "cultural", "cosmological"]
+    out_dir = Path(output_dir) if output_dir else Path("data/output")
+    out_dir.mkdir(parents=True, exist_ok=True)
 
     console.print(f"[bold]World-Building Pipeline[/bold]")
     console.print(f"  Source: {path}")
+    console.print(f"  Title: {book_title}")
     console.print(f"  Pillars: {', '.join(selected)}")
     console.print()
 
+    with console.status("Loading text..."):
+        text = load_book(file_path)
+
+    hobbit_gate = "hobbit" in (book_title + " " + file_path.name).lower()
+
     for pillar in selected:
+        if pillar == "genealogy":
+            relations = extract_genealogy_from_text(text, passage_id=str(file_path))
+            payload = genealogy_to_json(relations)
+            output_path = out_dir / f"{file_path.stem}_genealogy.json"
+            with open(output_path, "w", encoding="utf-8") as f:
+                json.dump(payload, f, indent=2)
+
+            count = len(payload.get("relations", []))
+            console.print(f"  [green]✓[/green] Genealogy — extracted {count} relations → {output_path}")
+
+            if hobbit_gate and count == 0:
+                raise click.ClickException(
+                    "Hobbit acceptance gate failed: genealogy extraction produced zero relations."
+                )
+            continue
+
         issue_map = {
             "linguistic": "#46",
-            "genealogy": "#47",
-            "editorial": "#48",
-            "cultural": "#49",
-            "cosmological": "#50",
+            "editorial": "#51",
+            "cultural": "#50",
+            "cosmological": "#48",
         }
         console.print(f"  [yellow]⏳[/yellow] {pillar.title()} — not yet implemented (Issue {issue_map[pillar]})")
 
-    console.print(f"\n[dim]Each pillar will be implemented incrementally. See docs/tolkien-worldbuilding-rfc.md[/dim]")
+    console.print("\n[dim]See docs/tolkien-worldbuilding-rfc.md for pillar-by-pillar status.[/dim]")
 
 
 @main.command(name="workflow-post-open-failures-summary")

--- a/tests/test_pipeline_worldbuilding_genealogy.py
+++ b/tests/test_pipeline_worldbuilding_genealogy.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import json
+
+from click.testing import CliRunner
+
+from book_graph_analyzer.cli import main
+
+
+def test_pipeline_worldbuilding_runs_genealogy_stage_and_writes_artifact(tmp_path):
+    text_file = tmp_path / "silmarillion_lineage.txt"
+    text_file.write_text("Elendil father of Isildur. Isildur father of Valandil.", encoding="utf-8")
+
+    out_dir = tmp_path / "out"
+    result = CliRunner().invoke(
+        main,
+        [
+            "pipeline",
+            "worldbuilding",
+            str(text_file),
+            "--pillars",
+            "genealogy",
+            "--output-dir",
+            str(out_dir),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    output_path = out_dir / "silmarillion_lineage_genealogy.json"
+    assert output_path.exists()
+
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    assert len(payload.get("relations", [])) > 0
+
+
+def test_pipeline_worldbuilding_hobbit_gate_requires_non_zero_genealogy(tmp_path):
+    hobbit_text = tmp_path / "the_hobbit.txt"
+    hobbit_text.write_text(
+        "Bilbo, son of Bungo Baggins, lived in the Shire.",
+        encoding="utf-8",
+    )
+
+    out_dir = tmp_path / "out"
+    result = CliRunner().invoke(
+        main,
+        [
+            "pipeline",
+            "worldbuilding",
+            str(hobbit_text),
+            "--title",
+            "The Hobbit",
+            "--pillars",
+            "genealogy",
+            "--output-dir",
+            str(out_dir),
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "Hobbit acceptance gate failed" in result.output


### PR DESCRIPTION
## Summary\n- implement genealogy execution in the canonical ga pipeline worldbuilding command when --pillars genealogy is selected\n- write extracted genealogy artifact to JSON (<stem>_genealogy.json) via --output-dir (or data/output by default)\n- add Hobbit acceptance gate: if title/path indicates Hobbit and genealogy extraction yields zero relations, exit non-zero with a clear error\n- update pipeline docs to reflect genealogy stage availability in canonical pipeline\n\n## Tests\n- added 	ests/test_pipeline_worldbuilding_genealogy.py\n  - verifies genealogy stage runs and emits non-empty relations artifact\n  - verifies Hobbit non-zero gate fails when extraction yields zero relations\n- ran: python -m pytest -q tests/test_pipeline_worldbuilding_genealogy.py tests/test_milestone_47_49_50_51_acceptance.py tests/test_genealogy.py\n\n## Issue\nCloses #90