### PR TITLE
fix(issue-93): add lore-depth quality gates and candidate-linking audit buckets

### DIFF
--- a/docs/wiki/issue-93-lore-depth-quality-gates.md
+++ b/docs/wiki/issue-93-lore-depth-quality-gates.md
@@ -1,0 +1,31 @@
+# Issue #93 — Lore Depth Precision/Quality Gates
+
+## Scope
+Adds quality gates for unresolved-reference extraction and candidate-linking audit buckets.
+
+## What shipped
+- `evaluate_unresolved_quality_gates(...)` in `lore.depth`
+  - computes unresolved context coverage
+  - computes unresolved candidate coverage
+  - returns pass/fail with failure IDs
+- `build_candidate_linking_audit_buckets(...)` in `lore.depth`
+  - buckets unresolved references into:
+    - `no_candidates`
+    - `weak_top_candidate`
+    - `ambiguous_top_candidates`
+    - `high_confidence_top_candidate`
+- `bga worldbible artifacts` quality-gate controls:
+  - `--quality-gate/--no-quality-gate` (default: on)
+  - `--min-context-coverage` (default: `0.85`)
+  - `--min-candidate-coverage` (default: `0.60`)
+  - exits with code `2` when gate fails
+- JSON output now includes `quality_gate` report payload when output is requested.
+
+## Why
+This provides a hard stop when unresolved-reference extraction quality drops, and a structured audit surface for candidate-linking triage.
+
+## Tests
+- `tests/test_issue_93_lore_depth_quality.py`
+  - audit bucket classification
+  - gate failure reporting
+  - CLI non-zero exit behavior when gate fails

--- a/src/book_graph_analyzer/cli.py
+++ b/src/book_graph_analyzer/cli.py
@@ -6021,6 +6021,12 @@ def worldbible_languages(bible_path: str, entity: str | None, write_graph: bool)
               help="Attach resolver-backed candidate links to unresolved refs")
 @click.option("--llm-fallback", is_flag=True,
               help="Optional model-assisted unresolved-reference fallback")
+@click.option("--quality-gate/--no-quality-gate", default=True,
+              help="Evaluate unresolved-reference precision/quality gates")
+@click.option("--min-context-coverage", default=0.85, show_default=True, type=float,
+              help="Required unresolved refs coverage with usable context")
+@click.option("--min-candidate-coverage", default=0.60, show_default=True, type=float,
+              help="Required unresolved refs coverage with >=1 candidate link")
 def worldbible_artifacts(
     path: str,
     book: str | None,
@@ -6029,9 +6035,16 @@ def worldbible_artifacts(
     context_window: int,
     link_candidates: bool,
     llm_fallback: bool,
+    quality_gate: bool,
+    min_context_coverage: float,
+    min_candidate_coverage: float,
 ) -> None:
     """Extract lore artifacts and broken references from raw text."""
-    from book_graph_analyzer.lore.depth import extract_lore_depth, link_broken_reference_candidates
+    from book_graph_analyzer.lore.depth import (
+        extract_lore_depth,
+        link_broken_reference_candidates,
+        evaluate_unresolved_quality_gates,
+    )
 
     file_path = Path(path)
     text = file_path.read_text(encoding="utf-8", errors="replace")
@@ -6055,9 +6068,27 @@ def worldbible_artifacts(
     if link_candidates:
         link_broken_reference_candidates(result.broken_references, book=source_book)
 
+    quality_report = None
+    if quality_gate:
+        quality_report = evaluate_unresolved_quality_gates(
+            result.broken_references,
+            min_context_coverage=min_context_coverage,
+            min_candidate_coverage=min_candidate_coverage,
+        )
+
     console.print(f"[bold]Lore depth extraction:[/bold] {file_path.name}")
     console.print(f"  Artifacts: [green]{len(result.artifacts)}[/green]")
     console.print(f"  Unresolved refs: [yellow]{len(result.broken_references)}[/yellow]")
+    if quality_report:
+        summary = quality_report["summary"]
+        passed = quality_report["passed"]
+        status = "[green]PASS[/green]" if passed else "[red]FAIL[/red]"
+        console.print(
+            "  Quality gate: "
+            f"{status} "
+            f"(context={summary['context_coverage']:.2f}/{summary['min_context_coverage']:.2f}, "
+            f"candidates={summary['candidate_coverage']:.2f}/{summary['min_candidate_coverage']:.2f})"
+        )
 
     if result.artifacts:
         table = Table(title="Artifacts", show_lines=False)
@@ -6074,6 +6105,8 @@ def worldbible_artifacts(
             "artifacts": [a.model_dump() for a in result.artifacts],
             "broken_references": [b.model_dump() for b in result.broken_references],
         }
+        if quality_report is not None:
+            data["quality_gate"] = quality_report
         Path(output).write_text(json.dumps(data, indent=2), encoding="utf-8")
         console.print(f"[green]OK[/green] Saved to {output}")
 
@@ -6084,6 +6117,9 @@ def worldbible_artifacts(
         b_count = writer.write_broken_references_batch(result.broken_references)
         writer.close()
         console.print(f"[green]OK[/green] Wrote {a_count} artifacts and {b_count} unresolved references to Neo4j")
+
+    if quality_report and not quality_report["passed"]:
+        raise SystemExit(2)
 
 
 @lore.command(name="unresolved-refs")

--- a/src/book_graph_analyzer/lore/depth.py
+++ b/src/book_graph_analyzer/lore/depth.py
@@ -254,3 +254,91 @@ def link_broken_reference_candidates(
             ref.conflict_weight = max(ref.conflict_weight, min(0.6, candidates[0].confidence * 0.5))
 
     return broken_references
+
+
+def build_candidate_linking_audit_buckets(
+    broken_references: list[BrokenReference],
+    *,
+    weak_candidate_threshold: float = 0.70,
+    ambiguous_delta: float = 0.08,
+) -> dict[str, list[str]]:
+    """Bucket unresolved references for candidate-linking review workflows."""
+    buckets: dict[str, list[str]] = {
+        "no_candidates": [],
+        "weak_top_candidate": [],
+        "ambiguous_top_candidates": [],
+        "high_confidence_top_candidate": [],
+    }
+
+    for ref in broken_references:
+        if ref.resolved_entity_id:
+            continue
+        if not ref.candidates:
+            buckets["no_candidates"].append(ref.id)
+            continue
+
+        top = ref.candidates[0]
+        if top.confidence < weak_candidate_threshold:
+            buckets["weak_top_candidate"].append(ref.id)
+            continue
+
+        if len(ref.candidates) > 1:
+            delta = top.confidence - ref.candidates[1].confidence
+            if delta <= ambiguous_delta:
+                buckets["ambiguous_top_candidates"].append(ref.id)
+                continue
+
+        buckets["high_confidence_top_candidate"].append(ref.id)
+
+    return buckets
+
+
+def evaluate_unresolved_quality_gates(
+    broken_references: list[BrokenReference],
+    *,
+    min_context_chars: int = 8,
+    min_context_coverage: float = 0.85,
+    min_candidate_coverage: float = 0.60,
+) -> dict[str, Any]:
+    """Evaluate precision/quality gates for unresolved references."""
+    unresolved = [r for r in broken_references if not r.resolved_entity_id]
+    total = len(unresolved)
+
+    context_ok = 0
+    candidate_ok = 0
+    low_context_ids: list[str] = []
+    no_candidate_ids: list[str] = []
+
+    for ref in unresolved:
+        before = (ref.context_before or "").strip()
+        after = (ref.context_after or "").strip()
+        if len(before) >= min_context_chars or len(after) >= min_context_chars:
+            context_ok += 1
+        else:
+            low_context_ids.append(ref.id)
+
+        if ref.candidates:
+            candidate_ok += 1
+        else:
+            no_candidate_ids.append(ref.id)
+
+    context_coverage = (context_ok / total) if total else 1.0
+    candidate_coverage = (candidate_ok / total) if total else 1.0
+
+    candidate_audit_buckets = build_candidate_linking_audit_buckets(unresolved)
+
+    return {
+        "passed": (context_coverage >= min_context_coverage and candidate_coverage >= min_candidate_coverage),
+        "summary": {
+            "total_unresolved": total,
+            "context_coverage": round(context_coverage, 4),
+            "candidate_coverage": round(candidate_coverage, 4),
+            "min_context_coverage": min_context_coverage,
+            "min_candidate_coverage": min_candidate_coverage,
+        },
+        "failures": {
+            "low_context": low_context_ids,
+            "no_candidates": no_candidate_ids,
+        },
+        "candidate_linking_audit_buckets": candidate_audit_buckets,
+    }

--- a/tests/test_issue_50_lore_depth_slice2.py
+++ b/tests/test_issue_50_lore_depth_slice2.py
@@ -71,7 +71,7 @@ def test_cli_artifacts_accepts_slice2_flags(tmp_path):
     runner = CliRunner()
     result = runner.invoke(
         main,
-        ["worldbible", "artifacts", str(text_path), "--context-window", "60", "--no-link-candidates"],
+        ["worldbible", "artifacts", str(text_path), "--context-window", "60", "--no-link-candidates", "--no-quality-gate"],
     )
 
     assert result.exit_code == 0

--- a/tests/test_issue_93_lore_depth_quality.py
+++ b/tests/test_issue_93_lore_depth_quality.py
@@ -1,0 +1,61 @@
+from click.testing import CliRunner
+
+
+def test_candidate_linking_audit_buckets_classify_unresolved_refs():
+    from book_graph_analyzer.lore.depth import (
+        build_candidate_linking_audit_buckets,
+        extract_lore_depth,
+        link_broken_reference_candidates,
+    )
+
+    text = "[[the Enemy]] met [[zzz unknown token]] near the pass."
+    result = extract_lore_depth(text, source_book="The Silmarillion", passage_id="p93-1")
+    link_broken_reference_candidates(result.broken_references, book="The Silmarillion")
+
+    buckets = build_candidate_linking_audit_buckets(result.broken_references)
+
+    assert "no_candidates" in buckets
+    assert "high_confidence_top_candidate" in buckets
+    assert sum(len(v) for v in buckets.values()) == len(result.unresolved_queue)
+
+
+def test_unresolved_quality_gate_reports_failures_when_coverage_low():
+    from book_graph_analyzer.lore.depth import evaluate_unresolved_quality_gates, extract_lore_depth
+
+    # Deliberately no candidate linking pass to keep candidate coverage low.
+    result = extract_lore_depth("[[mystery sigil]]", source_book="LOTR", passage_id="p93-2", context_window=2)
+
+    report = evaluate_unresolved_quality_gates(
+        result.broken_references,
+        min_context_coverage=1.0,
+        min_candidate_coverage=1.0,
+    )
+
+    assert report["passed"] is False
+    assert report["summary"]["total_unresolved"] == 1
+    assert report["failures"]["no_candidates"]
+
+
+def test_cli_worldbible_artifacts_fails_when_quality_gate_fails(tmp_path):
+    from book_graph_analyzer.cli import main
+
+    text_path = tmp_path / "quality_fail.txt"
+    text_path.write_text("[[mystery sigil]]", encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "worldbible",
+            "artifacts",
+            str(text_path),
+            "--no-link-candidates",
+            "--min-context-coverage",
+            "1.0",
+            "--min-candidate-coverage",
+            "1.0",
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert "Quality gate:" in result.output


### PR DESCRIPTION
## Summary
- add unresolved-reference quality gate evaluation (evaluate_unresolved_quality_gates)
- add candidate-linking audit buckets (uild_candidate_linking_audit_buckets)
- wire ga worldbible artifacts quality-gate controls and non-zero exit on failure
- include quality gate report in JSON output payload
- add issue #93 tests and documentation

## CLI changes
- --quality-gate/--no-quality-gate (default on)
- --min-context-coverage (default 