### PR TITLE
Fix #92: enforce editorial provenance invariants and gate divergence output

### DIFF
--- a/src/book_graph_analyzer/cli.py
+++ b/src/book_graph_analyzer/cli.py
@@ -6430,11 +6430,25 @@ def corpus_timeline_divergence(source_a: str, source_b: str, min_sources: int, l
 @click.option("--show-authority", "-a", is_flag=True, help="Show authority weights")
 @click.option("--tag-strata", is_flag=True, help="Apply inferred source/stratum metadata to corpus passage JSON files")
 @click.option("--report-divergence", is_flag=True, help="Run basic cross-strata divergence report from tagged passage JSON")
-def corpus_sources(corpus_name: str, show_authority: bool, tag_strata: bool, report_divergence: bool) -> None:
+@click.option("--max-missing-provenance-ratio", default=0.05, show_default=True, type=float,
+              help="Fail divergence reporting if claim-bearing passages exceed this missing provenance ratio")
+@click.option("--min-authority", default=0.0, show_default=True, type=float,
+              help="Minimum allowed source authority weight for claim-bearing passages")
+def corpus_sources(
+    corpus_name: str,
+    show_authority: bool,
+    tag_strata: bool,
+    report_divergence: bool,
+    max_missing_provenance_ratio: float,
+    min_authority: float,
+) -> None:
     """Show editorial source layers for a corpus."""
     from book_graph_analyzer.models.worldbuilding import TOLKIEN_SOURCES, infer_editorial_layer
     from book_graph_analyzer.models.passage import Passage
-    from book_graph_analyzer.worldbible.editorial import detect_editorial_divergences
+    from book_graph_analyzer.worldbible.editorial import (
+        detect_editorial_divergences,
+        validate_editorial_provenance,
+    )
 
     corpus_dir = Path("data") / "corpora" / corpus_name
     candidates: list[str] = []
@@ -6495,10 +6509,56 @@ def corpus_sources(corpus_name: str, show_authority: bool, tag_strata: bool, rep
                 passages.append(Passage(**row))
             except Exception:
                 continue
+
+        validation = validate_editorial_provenance(
+            passages,
+            max_missing_ratio=max_missing_provenance_ratio,
+            min_authority_weight=min_authority,
+        )
+        if not validation.is_valid:
+            raise click.ClickException(
+                "Editorial divergence report gated: provenance validation failed "
+                f"(checked={validation.checked_count}, missing={validation.missing_count}, "
+                f"missing_ratio={validation.missing_ratio:.2%}, "
+                f"invalid_authority={validation.invalid_authority_count})."
+            )
+
         divergences = detect_editorial_divergences(passages)
         console.print(f"\n[bold]Editorial divergence signals:[/bold] {len(divergences)}")
         for d in divergences[:15]:
             console.print(f"  [{d.kind}] {d.signal} (conf={d.confidence:.2f}, passages={len(d.involved_passage_ids)})")
+
+        out_path = Path("data") / "output" / f"{corpus_name}_editorial_divergence_report.json"
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(out_path, "w", encoding="utf-8") as f:
+            json.dump(
+                {
+                    "provenance_validation": {
+                        "checked_count": validation.checked_count,
+                        "missing_count": validation.missing_count,
+                        "missing_ratio": round(validation.missing_ratio, 4),
+                        "invalid_authority_count": validation.invalid_authority_count,
+                        "max_missing_ratio": validation.max_missing_ratio,
+                        "min_authority_weight": validation.min_authority_weight,
+                        "is_valid": validation.is_valid,
+                    },
+                    "divergence_count": len(divergences),
+                    "divergences": [
+                        {
+                            "kind": d.kind,
+                            "signal": d.signal,
+                            "key": d.key,
+                            "involved_passage_ids": d.involved_passage_ids,
+                            "involved_sources": d.involved_sources,
+                            "confidence": d.confidence,
+                        }
+                        for d in divergences
+                    ],
+                },
+                f,
+                indent=2,
+            )
+        console.print(f"[green]OK[/green] Saved divergence artifact: {out_path}")
 
 
 @pipeline.command(name="worldbuilding")

--- a/src/book_graph_analyzer/worldbible/editorial.py
+++ b/src/book_graph_analyzer/worldbible/editorial.py
@@ -21,6 +21,76 @@ class EditorialDivergence:
     confidence: float = 0.0
 
 
+@dataclass
+class ProvenanceValidationResult:
+    """Validation summary for editorial provenance completeness."""
+
+    checked_count: int = 0
+    missing_count: int = 0
+    invalid_authority_count: int = 0
+    max_missing_ratio: float = 0.05
+    min_authority_weight: float = 0.0
+
+    @property
+    def missing_ratio(self) -> float:
+        if self.checked_count == 0:
+            return 0.0
+        return self.missing_count / self.checked_count
+
+    @property
+    def is_valid(self) -> bool:
+        return (
+            self.missing_ratio <= self.max_missing_ratio
+            and self.invalid_authority_count == 0
+        )
+
+
+def validate_editorial_provenance(
+    passages: list[Passage],
+    *,
+    max_missing_ratio: float = 0.05,
+    min_authority_weight: float = 0.0,
+) -> ProvenanceValidationResult:
+    """Validate provenance invariants for passages carrying factual claims.
+
+    Required fields for claim-bearing passages:
+    - source_id
+    - source_stratum
+    - source_authority_weight (0..1 and >= min_authority_weight)
+    - provenance_tags (non-empty)
+    """
+
+    checked = 0
+    missing = 0
+    invalid_authority = 0
+
+    for p in passages:
+        if not (p.factual_claims or {}):
+            continue
+        checked += 1
+        has_required = bool(
+            p.source_id
+            and p.source_stratum
+            and p.provenance_tags
+            and p.source_authority_weight is not None
+        )
+        if not has_required:
+            missing += 1
+            continue
+
+        w = float(p.source_authority_weight)
+        if w < min_authority_weight or w < 0.0 or w > 1.0:
+            invalid_authority += 1
+
+    return ProvenanceValidationResult(
+        checked_count=checked,
+        missing_count=missing,
+        invalid_authority_count=invalid_authority,
+        max_missing_ratio=max_missing_ratio,
+        min_authority_weight=min_authority_weight,
+    )
+
+
 def detect_editorial_divergences(passages: list[Passage]) -> list[EditorialDivergence]:
     """Detect lightweight cross-strata divergence signals.
 

--- a/tests/test_editorial_layer_slice1.py
+++ b/tests/test_editorial_layer_slice1.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 from book_graph_analyzer.models.passage import Passage
 from book_graph_analyzer.models.worldbuilding import EditorialLayer, EditorialStatus, AuthorPeriod, SourceStratum
-from book_graph_analyzer.worldbible.editorial import detect_editorial_divergences
+from click.testing import CliRunner
+import json
+from book_graph_analyzer.worldbible.editorial import (
+    detect_editorial_divergences,
+    validate_editorial_provenance,
+)
 
 
 def _p(**overrides) -> Passage:
@@ -65,3 +70,62 @@ def test_detect_editorial_divergences_factual_and_style():
     kinds = {d.kind for d in out}
     assert "factual" in kinds
     assert "style" in kinds
+
+
+def test_validate_editorial_provenance_fails_when_required_fields_missing():
+    p = _p(
+        id="p1",
+        factual_claims={"balrog_wings": "literal"},
+        source_id=None,
+        source_stratum=None,
+        source_authority_weight=None,
+        provenance_tags=[],
+    )
+    result = validate_editorial_provenance([p], max_missing_ratio=0.0)
+    assert result.checked_count == 1
+    assert result.missing_count == 1
+    assert result.is_valid is False
+
+
+def test_validate_editorial_provenance_respects_authority_threshold():
+    p = _p(
+        id="p1",
+        factual_claims={"balrog_wings": "literal"},
+        source_id="src_x",
+        source_stratum="annotation",
+        source_authority_weight=0.4,
+        provenance_tags=["annotation"],
+    )
+    result = validate_editorial_provenance([p], min_authority_weight=0.5)
+    assert result.invalid_authority_count == 1
+    assert result.is_valid is False
+
+
+def test_corpus_sources_report_divergence_gated_on_missing_provenance():
+    from book_graph_analyzer.cli import main
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        corpus_dir = "data/corpora/hobbit"
+        import os
+        os.makedirs(corpus_dir, exist_ok=True)
+        with open(f"{corpus_dir}/passages.json", "w", encoding="utf-8") as f:
+            json.dump([
+                {
+                    "id": "p1",
+                    "text": "test",
+                    "book": "The Hobbit",
+                    "chapter": "1",
+                    "chapter_num": 1,
+                    "paragraph_num": 1,
+                    "sentence_num": 1,
+                    "char_offset": 0,
+                    "factual_claims": {"x": "y"},
+                }
+            ], f)
+
+        result = runner.invoke(main, [
+            "corpus", "sources", "hobbit", "--report-divergence", "--max-missing-provenance-ratio", "0",
+        ])
+        assert result.exit_code != 0
+        assert "gated" in result.output.lower()


### PR DESCRIPTION
## Summary\n- add alidate_editorial_provenance() with mandatory-field checks for claim-bearing passages\n- enforce validator thresholds (max_missing_ratio, min_authority_weight)\n- gate corpus sources --report-divergence when provenance completeness fails\n- materialize divergence artifacts to data/output/<corpus>_editorial_divergence_report.json\n- add tests for provenance validator + gated CLI behavior\n\n## Validation\n- python -m pytest tests/test_editorial_layer_slice1.py -q\n- python -m pytest tests/test_milestone_47_49_50_51_acceptance.py tests/test_spatiotemporal_slice5.py -q\n\nCloses #92