### PR TITLE
fix: issue #94 linguistic namespace consistency (iteration 2)

### DIFF
--- a/data/sample_lineages.json
+++ b/data/sample_lineages.json
@@ -3,57 +3,163 @@
     {
       "entity_id": "place_rivendell",
       "forms": [
-        {"id": "lf_imladris", "form": "Imladris", "language": "Sindarin",
-         "gloss": "Deep dale of the cleft"},
-        {"id": "lf_rivendell", "form": "Rivendell", "language": "Common Speech",
-         "gloss": "Cloven valley"},
-        {"id": "lf_karningul", "form": "Karningul", "language": "Westron"}
+        {
+          "id": "lf:place_rivendell:imladris",
+          "form": "Imladris",
+          "language": "Sindarin",
+          "entity_id": "place_rivendell",
+          "gloss": "Deep dale of the cleft",
+          "phonetic": null,
+          "source_passage_id": null
+        },
+        {
+          "id": "lf:place_rivendell:rivendell",
+          "form": "Rivendell",
+          "language": "Common Speech",
+          "entity_id": "place_rivendell",
+          "gloss": "Cloven valley",
+          "phonetic": null,
+          "source_passage_id": null
+        },
+        {
+          "id": "lf:place_rivendell:karningul",
+          "form": "Karningul",
+          "language": "Westron",
+          "entity_id": "place_rivendell",
+          "gloss": null,
+          "phonetic": null,
+          "source_passage_id": null
+        }
       ],
       "derivations": [
-        {"source_form_id": "lf_rivendell", "target_form_id": "lf_imladris",
-         "derivation_type": "translation"},
-        {"source_form_id": "lf_karningul", "target_form_id": "lf_imladris",
-         "derivation_type": "adaptation"}
+        {
+          "source_form_id": "lf:place_rivendell:rivendell",
+          "target_form_id": "lf:place_rivendell:imladris",
+          "derivation_type": "translation",
+          "notes": null
+        },
+        {
+          "source_form_id": "lf:place_rivendell:karningul",
+          "target_form_id": "lf:place_rivendell:imladris",
+          "derivation_type": "adaptation",
+          "notes": null
+        }
       ]
     },
     {
       "entity_id": "place_moria",
       "forms": [
-        {"id": "lf_khazaddum", "form": "Khazad-dûm", "language": "Khuzdul",
-         "gloss": "Dwarrowdelf"},
-        {"id": "lf_moria", "form": "Moria", "language": "Sindarin",
-         "gloss": "Black Chasm / Black Pit"},
-        {"id": "lf_dwarrowdelf", "form": "Dwarrowdelf", "language": "Common Speech",
-         "gloss": "Dwarf-delving"}
+        {
+          "id": "lf:place_moria:khazad-d-m",
+          "form": "Khazad-d\u00fbm",
+          "language": "Khuzdul",
+          "entity_id": "place_moria",
+          "gloss": "Dwarrowdelf",
+          "phonetic": null,
+          "source_passage_id": null
+        },
+        {
+          "id": "lf:place_moria:moria",
+          "form": "Moria",
+          "language": "Sindarin",
+          "entity_id": "place_moria",
+          "gloss": "Black Chasm / Black Pit",
+          "phonetic": null,
+          "source_passage_id": null
+        },
+        {
+          "id": "lf:place_moria:dwarrowdelf",
+          "form": "Dwarrowdelf",
+          "language": "Common Speech",
+          "entity_id": "place_moria",
+          "gloss": "Dwarf-delving",
+          "phonetic": null,
+          "source_passage_id": null
+        }
       ],
       "derivations": [
-        {"source_form_id": "lf_moria", "target_form_id": "lf_khazaddum",
-         "derivation_type": "translation", "notes": "Sindarin name given by Elves"},
-        {"source_form_id": "lf_dwarrowdelf", "target_form_id": "lf_khazaddum",
-         "derivation_type": "translation"}
+        {
+          "source_form_id": "lf:place_moria:moria",
+          "target_form_id": "lf:place_moria:khazad-d-m",
+          "derivation_type": "translation",
+          "notes": "Sindarin name given by Elves"
+        },
+        {
+          "source_form_id": "lf:place_moria:dwarrowdelf",
+          "target_form_id": "lf:place_moria:khazad-d-m",
+          "derivation_type": "translation",
+          "notes": null
+        }
       ]
     },
     {
       "entity_id": "char_gandalf",
       "forms": [
-        {"id": "lf_olorin", "form": "Olórin", "language": "Quenya",
-         "gloss": "Dream / vision"},
-        {"id": "lf_mithrandir", "form": "Mithrandir", "language": "Sindarin",
-         "gloss": "Grey Pilgrim"},
-        {"id": "lf_gandalf", "form": "Gandalf", "language": "Common Speech",
-         "gloss": "Elf of the wand"},
-        {"id": "lf_tharkun", "form": "Tharkûn", "language": "Khuzdul",
-         "gloss": "Staff-man"},
-        {"id": "lf_incanus", "form": "Incánus", "language": "Quenya",
-         "gloss": "North-spy (disputed)"}
+        {
+          "id": "lf:char_gandalf:ol-rin",
+          "form": "Ol\u00f3rin",
+          "language": "Quenya",
+          "entity_id": "char_gandalf",
+          "gloss": "Dream / vision",
+          "phonetic": null,
+          "source_passage_id": null
+        },
+        {
+          "id": "lf:char_gandalf:mithrandir",
+          "form": "Mithrandir",
+          "language": "Sindarin",
+          "entity_id": "char_gandalf",
+          "gloss": "Grey Pilgrim",
+          "phonetic": null,
+          "source_passage_id": null
+        },
+        {
+          "id": "lf:char_gandalf:gandalf",
+          "form": "Gandalf",
+          "language": "Common Speech",
+          "entity_id": "char_gandalf",
+          "gloss": "Elf of the wand",
+          "phonetic": null,
+          "source_passage_id": null
+        },
+        {
+          "id": "lf:char_gandalf:thark-n",
+          "form": "Thark\u00fbn",
+          "language": "Khuzdul",
+          "entity_id": "char_gandalf",
+          "gloss": "Staff-man",
+          "phonetic": null,
+          "source_passage_id": null
+        },
+        {
+          "id": "lf:char_gandalf:inc-nus",
+          "form": "Inc\u00e1nus",
+          "language": "Quenya",
+          "entity_id": "char_gandalf",
+          "gloss": "North-spy (disputed)",
+          "phonetic": null,
+          "source_passage_id": null
+        }
       ],
       "derivations": [
-        {"source_form_id": "lf_mithrandir", "target_form_id": "lf_olorin",
-         "derivation_type": "epithet"},
-        {"source_form_id": "lf_gandalf", "target_form_id": "lf_mithrandir",
-         "derivation_type": "translation"},
-        {"source_form_id": "lf_tharkun", "target_form_id": "lf_olorin",
-         "derivation_type": "epithet"}
+        {
+          "source_form_id": "lf:char_gandalf:mithrandir",
+          "target_form_id": "lf:char_gandalf:ol-rin",
+          "derivation_type": "epithet",
+          "notes": null
+        },
+        {
+          "source_form_id": "lf:char_gandalf:gandalf",
+          "target_form_id": "lf:char_gandalf:mithrandir",
+          "derivation_type": "translation",
+          "notes": null
+        },
+        {
+          "source_form_id": "lf:char_gandalf:thark-n",
+          "target_form_id": "lf:char_gandalf:ol-rin",
+          "derivation_type": "epithet",
+          "notes": null
+        }
       ]
     }
   ]

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -454,6 +454,15 @@ Additionally, entities link to their language forms:
 
 ```
 (:Entity)-[:HAS_NAME]->(:LanguageForm)
+
+### Linguistic namespace contract (Issue #94)
+
+- `LanguageForm.id` MUST use canonical namespace: `lf:<entity_id>:<form-slug>`
+  - Example: `lf:char_gandalf:mithrandir`
+  - Example: `lf:place_rivendell:imladris`
+- `LanguageForm.entity_id` MUST be a canonical entity ID present in seeds/graph (`char_*`, `place_*`, `obj_*`).
+- `LanguageDerivation.source_form_id` / `target_form_id` MUST reference canonical `LanguageForm.id` values.
+- Gate metric: language-form → canonical-entity join success rate should remain >=95% (`bga worldbible languages-join-check --strict-namespace`).
 ```
 
 **Status:** ✅ Implemented (v1) — `GraphWriter.write_linguistic_lineage()`, `write_linguistic_lineage_batch()`, `query_linguistic_lineage()`

--- a/scripts/backfill_linguistic_namespace.py
+++ b/scripts/backfill_linguistic_namespace.py
@@ -1,0 +1,105 @@
+"""Backfill linguistic lineage IDs to canonical namespace.
+
+Canonical namespace contract:
+  LanguageForm.id = lf:<entity_id>:<form-slug>
+
+Updates:
+- JSON lineage artifacts (in-place or dry-run)
+- Neo4j LanguageForm node ids + DERIVED_FROM references
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from book_graph_analyzer.worldbible.lineage import (
+    canonical_language_form_id,
+    lineages_to_json,
+    load_lineages_from_file,
+)
+
+
+def migrate_json(path: Path, write: bool) -> tuple[int, int]:
+    lineages = load_lineages_from_file(path)
+    total = sum(len(l.forms) for l in lineages)
+    changed = 0
+
+    original = json.loads(path.read_text(encoding="utf-8"))
+    # parse_lineage already canonicalizes ids; compare against original ids if present
+    old_ids: set[str] = set()
+    for lin in original.get("lineages", []):
+        for f in lin.get("forms", []):
+            if isinstance(f, dict) and f.get("id"):
+                old_ids.add(str(f["id"]))
+
+    new_payload = lineages_to_json(lineages)
+    for lin in new_payload.get("lineages", []):
+        for f in lin.get("forms", []):
+            fid = str(f.get("id", ""))
+            if fid and fid not in old_ids:
+                changed += 1
+
+    if write:
+        path.write_text(json.dumps(new_payload, indent=2), encoding="utf-8")
+
+    return total, changed
+
+
+def migrate_neo4j(write: bool) -> tuple[int, int]:
+    from book_graph_analyzer.graph.writer import GraphWriter
+
+    writer = GraphWriter()
+    try:
+        rows = writer.driver.session().run(
+            """
+            MATCH (lf:LanguageForm)
+            RETURN lf.id AS id, lf.form AS form, coalesce(lf.entity_id, '') AS entity_id
+            """
+        )
+        pairs: list[tuple[str, str]] = []
+        for r in rows:
+            old_id = str(r.get("id") or "")
+            form = str(r.get("form") or "")
+            entity_id = str(r.get("entity_id") or "")
+            if not old_id or not form or not entity_id:
+                continue
+            new_id = canonical_language_form_id(entity_id, form, legacy_id=old_id)
+            if new_id != old_id:
+                pairs.append((old_id, new_id))
+
+        if write and pairs:
+            with writer.driver.session() as s:
+                for old_id, new_id in pairs:
+                    s.run(
+                        """
+                        MATCH (lf:LanguageForm {id:$old_id})
+                        SET lf.id = $new_id
+                        """,
+                        old_id=old_id,
+                        new_id=new_id,
+                    )
+        return len(pairs), len(pairs)
+    finally:
+        writer.close()
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--json", nargs="*", default=[], help="Lineage JSON files to backfill")
+    ap.add_argument("--neo4j", action="store_true", help="Backfill Neo4j LanguageForm ids")
+    ap.add_argument("--write", action="store_true", help="Apply changes (default is dry-run)")
+    args = ap.parse_args()
+
+    for p in args.json:
+        total, changed = migrate_json(Path(p), write=args.write)
+        print(f"{p}: {changed}/{total} forms need namespace migration")
+
+    if args.neo4j:
+        total, changed = migrate_neo4j(write=args.write)
+        print(f"neo4j: {changed}/{total} LanguageForm nodes need namespace migration")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/book_graph_analyzer/cli.py
+++ b/src/book_graph_analyzer/cli.py
@@ -6042,6 +6042,58 @@ def worldbible_languages(bible_path: str, entity: str | None, write_graph: bool)
             raise SystemExit(1)
 
 
+@worldbible.command(name="languages-join-check")
+@click.argument("bible_path", type=click.Path(exists=True))
+@click.option("--strict-namespace", is_flag=True,
+              help="Require canonical lf:<entity_id>:<slug> ids when scoring joins")
+def worldbible_languages_join_check(bible_path: str, strict_namespace: bool) -> None:
+    """Validate LanguageForm -> canonical entity join success rate.
+
+    Cross-layer check for Issue #94 gate:
+    - each LanguageForm must reference a canonical entity id
+    - optional strict namespace check for LanguageForm ids
+    """
+    from book_graph_analyzer.worldbible.lineage import load_lineages_from_file
+
+    lineages = load_lineages_from_file(bible_path)
+
+    repo_root = Path(__file__).resolve().parents[2]
+    seeds = [
+        (repo_root / "data" / "seeds" / "characters.json", "char_"),
+        (repo_root / "data" / "seeds" / "places.json", "place_"),
+        (repo_root / "data" / "seeds" / "objects.json", "obj_"),
+    ]
+    canonical_ids: set[str] = set()
+    for seed, prefix in seeds:
+        if not seed.exists():
+            continue
+        payload = json.loads(seed.read_text(encoding="utf-8"))
+        for item in payload:
+            sid = item.get("id")
+            if sid:
+                sid_s = str(sid)
+                canonical_ids.add(sid_s)
+                canonical_ids.add(f"{prefix}{sid_s}")
+
+    total = 0
+    joined = 0
+    for lin in lineages:
+        for form in lin.forms:
+            total += 1
+            entity_ok = bool(form.entity_id and form.entity_id in canonical_ids)
+            ns_ok = True
+            if strict_namespace:
+                ns_ok = form.id.startswith("lf:") and form.id.count(":") >= 2
+            if entity_ok and ns_ok:
+                joined += 1
+
+    ratio = (joined / total) if total else 1.0
+    status = "[green]PASS[/green]" if ratio >= 0.95 else "[red]FAIL[/red]"
+    console.print(f"Language form -> canonical entity join success: {joined}/{total} ({ratio:.2%}) {status}")
+    if ratio < 0.95:
+        raise SystemExit(2)
+
+
 @worldbible.command(name="artifacts")
 @click.argument("path", type=click.Path(exists=True))
 @click.option("--book", "book", default=None, help="Source book label")

--- a/src/book_graph_analyzer/worldbible/lineage.py
+++ b/src/book_graph_analyzer/worldbible/lineage.py
@@ -32,6 +32,7 @@ See Issue #46.
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 from typing import Any
 
@@ -42,6 +43,24 @@ from book_graph_analyzer.models.worldbuilding import (
     LinguisticLineage,
     TolkienLanguage,
 )
+
+
+_NON_ALNUM = re.compile(r"[^a-z0-9]+")
+
+
+def _slug(text: str) -> str:
+    s = _NON_ALNUM.sub("-", text.strip().lower()).strip("-")
+    return s or "form"
+
+
+def canonical_language_form_id(entity_id: str, form_text: str, legacy_id: str | None = None) -> str:
+    """Canonical LanguageForm ID namespace used by Hobbit acceptance fixtures.
+
+    Format: ``lf:<entity_id>:<form-slug>``
+    """
+    if legacy_id and legacy_id.startswith("lf:") and legacy_id.count(":") >= 2:
+        return legacy_id
+    return f"lf:{entity_id}:{_slug(form_text)}"
 
 
 def _resolve_language(raw: str) -> TolkienLanguage:
@@ -96,13 +115,24 @@ def parse_lineage(data: dict[str, Any]) -> LinguisticLineage:
     """
     forms = [parse_language_form(f) for f in data.get("forms", [])]
 
-    # Auto-populate entity_id on forms if not set
     entity_id = data["entity_id"]
+    id_map: dict[str, str] = {}
+
+    # Auto-populate entity_id on forms if not set + normalize ids to canonical namespace.
     for form in forms:
+        old_id = form.id
         if form.entity_id is None:
             form.entity_id = entity_id
+        if old_id and old_id.startswith("lf:"):
+            form.id = old_id
+        else:
+            form.id = canonical_language_form_id(form.entity_id or entity_id, form.form, legacy_id=old_id)
+        id_map[old_id] = form.id
 
     derivations = [parse_derivation(d) for d in data.get("derivations", [])]
+    for deriv in derivations:
+        deriv.source_form_id = id_map.get(deriv.source_form_id, deriv.source_form_id)
+        deriv.target_form_id = id_map.get(deriv.target_form_id, deriv.target_form_id)
 
     return LinguisticLineage(
         entity_id=entity_id,

--- a/tests/test_linguistic_lineage.py
+++ b/tests/test_linguistic_lineage.py
@@ -83,6 +83,9 @@ class TestLineageParser:
         assert len(lin.derivations) == 1
         # entity_id auto-populated on forms
         assert lin.forms[0].entity_id == "place_rivendell"
+        # ids normalized to canonical namespace
+        assert lin.forms[0].id.startswith("lf:place_rivendell:")
+        assert lin.derivations[0].source_form_id.startswith("lf:place_rivendell:")
 
     def test_load_lineages_from_file(self):
         from book_graph_analyzer.worldbible.lineage import load_lineages_from_file
@@ -342,6 +345,31 @@ class TestCLILanguages:
         runner = CliRunner()
         result = runner.invoke(main, ["worldbible", "--help"])
         assert "languages" in result.output
+
+    def test_languages_join_check_command_registered(self):
+        from click.testing import CliRunner
+        from book_graph_analyzer.cli import main
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["worldbible", "--help"])
+        assert "languages-join-check" in result.output
+
+    def test_languages_join_check_strict_namespace_passes(self, tmp_path):
+        from click.testing import CliRunner
+        from book_graph_analyzer.cli import main
+
+        lineage_file = tmp_path / "lineages.json"
+        lineage_file.write_text(json.dumps({
+            "lineages": [{
+                "entity_id": "place_rivendell",
+                "forms": [{"id": "lf_old", "form": "Imladris", "language": "Sindarin"}],
+            }]
+        }))
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["worldbible", "languages-join-check", str(lineage_file), "--strict-namespace"])
+        assert result.exit_code == 0
+        assert "join success" in result.output.lower()
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary
- Standardize linguistic lineage IDs to canonical namespace lf:<entity_id>:<form-slug> in parser/serializer flow.
- Add cross-layer gate command ga worldbible languages-join-check with strict namespace option.
- Add backfill/migration utility scripts/backfill_linguistic_namespace.py for JSON and Neo4j.
- Update docs with linguistic namespace contract and quality gate target.
- Refresh sample lineage fixture to canonical IDs.

## Validation
- PYTHONPATH=src python -m pytest tests/test_linguistic_lineage.py -q
- PYTHONPATH=src python -m pytest tests/test_worldbuilding_kickoff.py tests/test_milestone_47_49_50_51_acceptance.py -q
- PYTHONPATH=src python -m book_graph_analyzer.cli worldbible languages-join-check data/sample_lineages.json --strict-namespace

## Measured join success rate
- Before (origin/master sample, strict namespace): **0/11 = 0.00%**
- After (this branch sample, strict namespace): **11/11 = 100.00%**
