### PR TITLE
fix: enforce editorial provenance consistency for Hobbit divergence reporting

### DIFF
--- a/src/book_graph_analyzer/cli.py
+++ b/src/book_graph_analyzer/cli.py
@@ -6612,7 +6612,8 @@ def corpus_sources(
                 "Editorial divergence report gated: provenance validation failed "
                 f"(checked={validation.checked_count}, missing={validation.missing_count}, "
                 f"missing_ratio={validation.missing_ratio:.2%}, "
-                f"invalid_authority={validation.invalid_authority_count})."
+                f"invalid_authority={validation.invalid_authority_count}, "
+                f"inconsistent={validation.inconsistent_count})."
             )
 
         divergences = detect_editorial_divergences(passages)

--- a/src/book_graph_analyzer/worldbible/editorial.py
+++ b/src/book_graph_analyzer/worldbible/editorial.py
@@ -7,6 +7,7 @@ from collections import defaultdict
 from statistics import mean
 
 from ..models.passage import Passage
+from ..models.worldbuilding import infer_editorial_layer
 
 
 @dataclass
@@ -28,6 +29,7 @@ class ProvenanceValidationResult:
     checked_count: int = 0
     missing_count: int = 0
     invalid_authority_count: int = 0
+    inconsistent_count: int = 0
     max_missing_ratio: float = 0.05
     min_authority_weight: float = 0.0
 
@@ -42,6 +44,7 @@ class ProvenanceValidationResult:
         return (
             self.missing_ratio <= self.max_missing_ratio
             and self.invalid_authority_count == 0
+            and self.inconsistent_count == 0
         )
 
 
@@ -63,6 +66,7 @@ def validate_editorial_provenance(
     checked = 0
     missing = 0
     invalid_authority = 0
+    inconsistent = 0
 
     for p in passages:
         if not (p.factual_claims or {}):
@@ -82,10 +86,30 @@ def validate_editorial_provenance(
         if w < min_authority_weight or w < 0.0 or w > 1.0:
             invalid_authority += 1
 
+        inferred = (
+            infer_editorial_layer(str(p.source_id or ""))
+            or infer_editorial_layer(str(p.source_title or ""))
+            or infer_editorial_layer(str(p.book or ""))
+        )
+        if inferred:
+            source_id = str(p.source_id or "").strip().lower()
+            source_title = str(p.source_title or "").strip().lower()
+            source_stratum = str(p.source_stratum or "").strip().lower()
+            if source_id != inferred.source_id.strip().lower():
+                inconsistent += 1
+                continue
+            if source_title != inferred.source_title.strip().lower():
+                inconsistent += 1
+                continue
+            if source_stratum != str(getattr(inferred.default_stratum, "value", "core_text")).strip().lower():
+                inconsistent += 1
+                continue
+
     return ProvenanceValidationResult(
         checked_count=checked,
         missing_count=missing,
         invalid_authority_count=invalid_authority,
+        inconsistent_count=inconsistent,
         max_missing_ratio=max_missing_ratio,
         min_authority_weight=min_authority_weight,
     )

--- a/tests/test_editorial_layer_slice1.py
+++ b/tests/test_editorial_layer_slice1.py
@@ -101,6 +101,22 @@ def test_validate_editorial_provenance_respects_authority_threshold():
     assert result.is_valid is False
 
 
+def test_validate_editorial_provenance_detects_inconsistent_hobbit_source_fields():
+    p = _p(
+        id="p-hobbit",
+        book="The Hobbit",
+        factual_claims={"smaug_location": "erebor"},
+        source_id="src_unfinished_tales",
+        source_title="Unfinished Tales",
+        source_stratum="annotation",
+        source_authority_weight=1.0,
+        provenance_tags=["annotation"],
+    )
+    result = validate_editorial_provenance([p], max_missing_ratio=0.0)
+    assert result.inconsistent_count == 1
+    assert result.is_valid is False
+
+
 def test_corpus_sources_report_divergence_gated_on_missing_provenance():
     from book_graph_analyzer.cli import main
 
@@ -129,3 +145,38 @@ def test_corpus_sources_report_divergence_gated_on_missing_provenance():
         ])
         assert result.exit_code != 0
         assert "gated" in result.output.lower()
+
+
+def test_corpus_sources_report_divergence_gated_on_inconsistent_hobbit_provenance():
+    from book_graph_analyzer.cli import main
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        corpus_dir = "data/corpora/hobbit"
+        import os
+        os.makedirs(corpus_dir, exist_ok=True)
+        with open(f"{corpus_dir}/passages.json", "w", encoding="utf-8") as f:
+            json.dump([
+                {
+                    "id": "p1",
+                    "text": "test",
+                    "book": "The Hobbit",
+                    "chapter": "1",
+                    "chapter_num": 1,
+                    "paragraph_num": 1,
+                    "sentence_num": 1,
+                    "char_offset": 0,
+                    "factual_claims": {"x": "y"},
+                    "source_id": "src_unfinished_tales",
+                    "source_title": "Unfinished Tales",
+                    "source_stratum": "annotation",
+                    "source_authority_weight": 1.0,
+                    "provenance_tags": ["annotation"],
+                }
+            ], f)
+
+        result = runner.invoke(main, [
+            "corpus", "sources", "hobbit", "--report-divergence", "--max-missing-provenance-ratio", "0",
+        ])
+        assert result.exit_code != 0
+        assert "inconsistent" in result.output.lower() or "gated" in result.output.lower()


### PR DESCRIPTION
## Summary
- tighten editorial provenance validation to enforce consistency against known inferred source layers
- flag and fail claim-bearing passages whose source_id/source_title/source_stratum disagree with inferred layer metadata (including Hobbit mismatches)
- include inconsistent-count details in corpus divergence gate error output
- add tests covering direct validator inconsistency detection and CLI gating on inconsistent Hobbit provenance

## Validation
- pytest -q tests/test_editorial_layer_slice1.py
- pytest -q tests/test_issue48_closeout_integration.py tests/test_milestone_47_49_50_51_acceptance.py
