### PR TITLE
Fix Neo4j Event ID collisions across books

### DIFF
--- a/docs/event-id-book-namespace-migration.md
+++ b/docs/event-id-book-namespace-migration.md
@@ -1,0 +1,39 @@
+# Event ID book-namespace migration (Neo4j)
+
+This change updates Event node identity from `(:Event {id})` to `(:Event {id, source_book})`.
+
+## Why migration is needed
+
+Older data may already contain merged/collided Event nodes where the same `id` appeared in multiple books.
+Those collisions cannot be losslessly separated in-place after the fact, so the safest path is:
+
+1. reset Event graph data,
+2. replace old single-key constraint,
+3. reload from source JSON.
+
+## Safe reset + schema update (recommended)
+
+```cypher
+// 1) Remove event-only relationships first (keeps non-event graph intact)
+MATCH (:Event)-[r]-(:Event) DELETE r;
+MATCH (:Event)-[r]-() DELETE r;
+
+// 2) Delete all Event nodes
+MATCH (e:Event) DELETE e;
+
+// 3) Replace old uniqueness constraint if present
+DROP CONSTRAINT event_id IF EXISTS;
+CREATE CONSTRAINT event_id_book IF NOT EXISTS
+FOR (e:Event) REQUIRE (e.id, e.source_book) IS UNIQUE;
+```
+
+## Reload
+
+Re-run your normal event ingestion per book (example):
+
+```powershell
+python -m book_graph_analyzer.cli lore events data/books/the_hobbit.txt --book "The Hobbit" --neo4j
+python -m book_graph_analyzer.cli lore events data/books/unfinished_tales.txt --book "Unfinished Tales" --neo4j
+```
+
+Or if using pre-extracted JSON, re-run the command/path your pipeline uses to write those JSONs to Neo4j.

--- a/src/book_graph_analyzer/graph/connection.py
+++ b/src/book_graph_analyzer/graph/connection.py
@@ -48,7 +48,7 @@ def init_schema() -> None:
         "CREATE CONSTRAINT char_canonical_id IF NOT EXISTS FOR (c:Character) REQUIRE c.canonical_id IS UNIQUE",
         "CREATE CONSTRAINT place_id IF NOT EXISTS FOR (p:Place) REQUIRE p.id IS UNIQUE",
         "CREATE CONSTRAINT object_id IF NOT EXISTS FOR (o:Object) REQUIRE o.id IS UNIQUE",
-        "CREATE CONSTRAINT event_id IF NOT EXISTS FOR (e:Event) REQUIRE e.id IS UNIQUE",
+        "CREATE CONSTRAINT event_id_book IF NOT EXISTS FOR (e:Event) REQUIRE (e.id, e.source_book) IS UNIQUE",
         "CREATE CONSTRAINT passage_id IF NOT EXISTS FOR (p:Passage) REQUIRE p.id IS UNIQUE",
         "CREATE CONSTRAINT concept_id IF NOT EXISTS FOR (c:Concept) REQUIRE c.id IS UNIQUE",
         "CREATE CONSTRAINT source_id IF NOT EXISTS FOR (s:Source) REQUIRE s.id IS UNIQUE",

--- a/src/book_graph_analyzer/graph/writer.py
+++ b/src/book_graph_analyzer/graph/writer.py
@@ -817,6 +817,12 @@ class GraphWriter:
     # Event Graph Integration (Phase 6+)
     # =========================================================================
 
+    @staticmethod
+    def _resolve_event_book(event, fallback_book: str) -> str:
+        """Resolve source book for an event write operation."""
+        event_book = getattr(event, "source_book", None)
+        return (event_book or fallback_book or "").strip()
+
     def write_event(
         self,
         event,  # Event from lore.events
@@ -829,7 +835,7 @@ class GraphWriter:
             book: The book this event was found in
         """
         query = """
-        MERGE (e:Event {id: $id})
+        MERGE (e:Event {id: $id, source_book: $book})
         SET e.description = $description,
             e.agent = $agent,
             e.action = $action,
@@ -850,7 +856,7 @@ class GraphWriter:
                 patient=event.patient,
                 era=event.era.value if event.era else None,
                 year=event.year,
-                book=book,
+                book=self._resolve_event_book(event, book),
                 confidence=event.confidence,
             )
 
@@ -882,13 +888,14 @@ class GraphWriter:
                 "era": e.era.value if e.era else None,
                 "year": e.year,
                 "confidence": e.confidence,
+                "source_book": self._resolve_event_book(e, book),
             }
             for e in events
         ]
 
         query = """
         UNWIND $batch AS item
-        MERGE (e:Event {id: item.id})
+        MERGE (e:Event {id: item.id, source_book: item.source_book})
         SET e.description = item.description,
             e.agent = item.agent,
             e.action = item.action,
@@ -896,18 +903,19 @@ class GraphWriter:
             e.source_text = item.source_text,
             e.era = item.era,
             e.year = item.year,
-            e.source_book = $book,
             e.confidence = item.confidence
         """
 
         with self.driver.session() as session:
-            session.run(query, batch=batch_data, book=book)
+            session.run(query, batch=batch_data)
 
         return len(batch_data)
 
     def write_event_relations_batch(
         self,
         relations: list,  # List of EventRelation objects
+        event_book_by_id: dict[str, str] | None = None,
+        default_book: str | None = None,
     ) -> int:
         """Write event temporal relations.
 
@@ -935,6 +943,8 @@ class GraphWriter:
                 {
                     "event1_id": r.event1_id,
                     "event2_id": r.event2_id,
+                    "event1_book": (event_book_by_id or {}).get(r.event1_id, default_book or ""),
+                    "event2_book": (event_book_by_id or {}).get(r.event2_id, default_book or ""),
                     "confidence": r.confidence,
                 }
                 for r in type_rels
@@ -942,8 +952,8 @@ class GraphWriter:
 
             query = f"""
             UNWIND $batch AS item
-            MATCH (e1:Event {{id: item.event1_id}})
-            MATCH (e2:Event {{id: item.event2_id}})
+            MATCH (e1:Event {{id: item.event1_id, source_book: item.event1_book}})
+            MATCH (e2:Event {{id: item.event2_id, source_book: item.event2_book}})
             MERGE (e1)-[r:{rel_type}]->(e2)
             SET r.confidence = item.confidence
             """
@@ -957,6 +967,7 @@ class GraphWriter:
     def link_event_to_entities(
         self,
         event,  # Event object
+        book: str,
     ) -> int:
         """Link an event to its participant entities.
 
@@ -972,6 +983,7 @@ class GraphWriter:
 
         links += self._link_event_role(
             event_id=event.id,
+            source_book=self._resolve_event_book(event, book),
             raw_value=event.agent,
             labels=["Character"],
             rel_type="PARTICIPATED_IN",
@@ -981,6 +993,7 @@ class GraphWriter:
         # Patient may be Character / Place / Object. Choose one best hit only.
         links += self._link_event_role(
             event_id=event.id,
+            source_book=self._resolve_event_book(event, book),
             raw_value=event.patient,
             labels=["Character", "Place", "Object"],
             rel_type="INVOLVED_IN",
@@ -992,6 +1005,7 @@ class GraphWriter:
             cue_text = f"{event.description or ''} {event.source_text or ''}".strip()
             links += self._link_event_role(
                 event_id=event.id,
+                source_book=self._resolve_event_book(event, book),
                 raw_value=cue_text,
                 labels=["Place"],
                 rel_type="TOOK_PLACE_AT",
@@ -1042,7 +1056,12 @@ class GraphWriter:
         if progress_callback:
             progress_callback(current_step, total_steps, "Writing temporal relations...")
 
-        stats["relations_written"] = self.write_event_relations_batch(event_graph.relations)
+        event_book_by_id = {e.id: self._resolve_event_book(e, book) for e in events}
+        stats["relations_written"] = self.write_event_relations_batch(
+            event_graph.relations,
+            event_book_by_id=event_book_by_id,
+            default_book=book,
+        )
 
         # Step 3: Link to entities
         if link_entities:
@@ -1051,7 +1070,7 @@ class GraphWriter:
                 progress_callback(current_step, total_steps, "Linking to entities...")
 
             for event in events:
-                stats["entity_links"] += self.link_event_to_entities(event)
+                stats["entity_links"] += self.link_event_to_entities(event, book=book)
 
         return stats
 
@@ -2453,6 +2472,7 @@ class GraphWriter:
         self,
         *,
         event_id: str,
+        source_book: str,
         raw_value: str | None,
         labels: list[str],
         rel_type: str,
@@ -2468,7 +2488,7 @@ class GraphWriter:
             return 0
 
         query = f"""
-        MATCH (e:Event {{id: $event_id}})
+        MATCH (e:Event {{id: $event_id, source_book: $source_book}})
         WITH e, [c IN $candidates WHERE c IS NOT NULL AND trim(c) <> ''] AS candidates
         UNWIND candidates AS cand
         MATCH (n)
@@ -2507,6 +2527,7 @@ class GraphWriter:
             row = session.run(
                 query,
                 event_id=event_id,
+                source_book=source_book,
                 candidates=candidates,
                 candidate_ids=candidate_ids,
                 labels=labels,

--- a/tests/test_event_entity_linking.py
+++ b/tests/test_event_entity_linking.py
@@ -36,16 +36,17 @@ class _FakeSession:
         return False
 
     def run(self, query, **kwargs):
-        if "MERGE (e:Event {id: item.id})" in query:
+        if "MERGE (e:Event {id: item.id, source_book: item.source_book})" in query:
             for item in kwargs["batch"]:
-                self.state["events"].add(item["id"])
+                self.state["events"].add((item["id"], item["source_book"]))
             return _FakeResult()
 
-        if "MATCH (e1:Event {id: item.event1_id})" in query:
+        if "MATCH (e1:Event {id: item.event1_id, source_book: item.event1_book})" in query:
             return _FakeResult()
 
         if "MERGE (n)-[r:" in query and "RETURN count(r) AS cnt" in query:
             event_id = kwargs["event_id"]
+            source_book = kwargs["source_book"]
             labels = set(kwargs["labels"])
             candidates = [c.lower() for c in kwargs["candidates"]]
             candidate_ids = [c.lower() for c in kwargs.get("candidate_ids", [])]
@@ -79,10 +80,10 @@ class _FakeSession:
                         best = node
                         best_score = score
 
-            if best is None or event_id not in self.state["events"]:
+            if best is None or (event_id, source_book) not in self.state["events"]:
                 return _FakeResult(single_row={"cnt": 0})
 
-            self.state["rels"].add((best.id, rel_type, event_id, role))
+            self.state["rels"].add((best.id, rel_type, event_id, source_book, role))
             return _FakeResult(single_row={"cnt": 1})
 
         return _FakeResult()

--- a/tests/test_event_id_book_namespace.py
+++ b/tests/test_event_id_book_namespace.py
@@ -1,0 +1,79 @@
+from book_graph_analyzer.graph.writer import GraphWriter
+from book_graph_analyzer.lore.events import Event, EventGraph, EventRelation
+
+
+class _FakeResult:
+    def __init__(self, single_row=None):
+        self._single = single_row
+
+    def single(self):
+        return self._single
+
+
+class _FakeSession:
+    def __init__(self, state):
+        self.state = state
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+    def run(self, query, **kwargs):
+        if "MERGE (e:Event {id: item.id, source_book: item.source_book})" in query:
+            for item in kwargs["batch"]:
+                self.state["events"].add((item["id"], item["source_book"]))
+            return _FakeResult()
+
+        if "MATCH (e1:Event {id: item.event1_id, source_book: item.event1_book})" in query:
+            for item in kwargs["batch"]:
+                a = (item["event1_id"], item["event1_book"])
+                b = (item["event2_id"], item["event2_book"])
+                if a in self.state["events"] and b in self.state["events"]:
+                    self.state["rels"].add((a, b))
+            return _FakeResult()
+
+        return _FakeResult(single_row={"cnt": 0})
+
+
+class _FakeDriver:
+    def __init__(self):
+        self.state = {"events": set(), "rels": set()}
+
+    def session(self):
+        return _FakeSession(self.state)
+
+
+def _build_graph(book: str) -> EventGraph:
+    g = EventGraph()
+    g.add_event(Event(id="event1", description=f"Start in {book}", source_book=book))
+    g.add_event(Event(id="event2", description=f"End in {book}", source_book=book))
+    g.add_relation(EventRelation(event1_id="event1", event2_id="event2", relation="before", confidence=0.9))
+    return g
+
+
+def test_same_event_ids_from_different_books_do_not_collide(monkeypatch):
+    driver = _FakeDriver()
+    writer = GraphWriter(driver=driver)
+    monkeypatch.setattr(writer, "initialize", lambda: None)
+
+    writer.write_event_graph(_build_graph("The Hobbit"), book="The Hobbit", link_entities=False)
+    writer.write_event_graph(_build_graph("Unfinished Tales"), book="Unfinished Tales", link_entities=False)
+
+    assert ("event1", "The Hobbit") in driver.state["events"]
+    assert ("event1", "Unfinished Tales") in driver.state["events"]
+    assert len(driver.state["events"]) == 4
+
+
+def test_relations_bind_to_book_scoped_event_nodes(monkeypatch):
+    driver = _FakeDriver()
+    writer = GraphWriter(driver=driver)
+    monkeypatch.setattr(writer, "initialize", lambda: None)
+
+    writer.write_event_graph(_build_graph("The Hobbit"), book="The Hobbit", link_entities=False)
+    writer.write_event_graph(_build_graph("Unfinished Tales"), book="Unfinished Tales", link_entities=False)
+
+    assert (("event1", "The Hobbit"), ("event2", "The Hobbit")) in driver.state["rels"]
+    assert (("event1", "Unfinished Tales"), ("event2", "Unfinished Tales")) in driver.state["rels"]
+    assert len(driver.state["rels"]) == 2


### PR DESCRIPTION
## Summary
- namespace Event identity in Neo4j using (id, source_book) instead of id only
- update Event relation writes to match both event id and source book
- scope entity-linking to the correct book-specific Event node
- add regression tests for overlapping event IDs across books
- add migration/reset+reload guide for existing DBs

## Problem fixed
Multiple books can emit reused event IDs (e.g. event1, event2). With MERGE (e:Event {id}), writes from later books overwrite/merge earlier books.

## Validation
- pytest -q tests/test_event_entity_linking.py tests/test_event_id_book_namespace.py
- pytest -q tests/test_issue48_closeout_integration.py
