### PR TITLE
Wave A: genealogy depth hardening for Two Towers/Return

### DIFF
--- a/scripts/genealogy_depth_report.py
+++ b/scripts/genealogy_depth_report.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from book_graph_analyzer.worldbible.genealogy import extract_genealogy_from_text
+from book_graph_analyzer.worldbible.genealogy_validation import evaluate_genealogy_threshold
+
+DATA_OUT = ROOT / "data" / "output"
+
+BOOK_FILES = {
+    "The Fellowship of the Ring": DATA_OUT / "fellowship_events.json",
+    "The Two Towers": DATA_OUT / "twotowers_events.json",
+    "The Return of the King": DATA_OUT / "return_events.json",
+}
+
+
+def _event_text(path: Path) -> str:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    events = payload.get("events", {})
+    chunks: list[str] = []
+    for ev in events.values() if isinstance(events, dict) else []:
+        if not isinstance(ev, dict):
+            continue
+        desc = str(ev.get("description") or "").strip()
+        src = str(ev.get("source_text") or "").strip()
+        if desc:
+            chunks.append(desc)
+        if src:
+            chunks.append(src)
+    return ". ".join(chunks)
+
+
+def _baseline_count(text: str) -> int:
+    # Approximate pre-wave behavior using legacy rule subset.
+    import re
+
+    name = r"([A-Z][A-Za-z'\-]+(?: [A-Z][A-Za-z'\-]+)*)"
+    legacy = [
+        re.compile(rf"\b{name}\s+son of\s+{name}\b"),
+        re.compile(rf"\b{name}\s+daughter of\s+{name}\b"),
+        re.compile(rf"\b{name}\s+child of\s+{name}\b"),
+        re.compile(rf"\b{name}\s+father of\s+{name}\b"),
+        re.compile(rf"\b{name}\s+mother of\s+{name}\b"),
+        re.compile(rf"\b{name}\s+brother of\s+{name}\b"),
+        re.compile(rf"\b{name}\s+sister of\s+{name}\b"),
+        re.compile(rf"\b{name}\s+wed\s+{name}\b"),
+        re.compile(rf"\b{name}\s+married\s+{name}\b"),
+        re.compile(rf"\b{name}\s*,\s*son of\s+{name}\b"),
+        re.compile(rf"\b{name}\s*,\s*daughter of\s+{name}\b"),
+    ]
+    pairs = set()
+    for pat in legacy:
+        for m in pat.finditer(text):
+            pairs.add((m.group(1), m.group(2), pat.pattern))
+            pairs.add((m.group(2), m.group(1), pat.pattern))
+    return len(pairs)
+
+
+def _after_count(text: str) -> int:
+    rels = extract_genealogy_from_text(text, llm_client=None, min_relations_for_fallback=2)
+    return len(rels)
+
+
+def main() -> None:
+    rows = []
+    for book, path in BOOK_FILES.items():
+        if not path.exists():
+            rows.append({"book": book, "before": 0, "after": 0, "threshold": None, "passed": False})
+            continue
+        text = _event_text(path)
+        before = _baseline_count(text)
+        after = _after_count(text)
+        gate = evaluate_genealogy_threshold(book, after)
+        rows.append(
+            {
+                "book": book,
+                "before": before,
+                "after": after,
+                "threshold": gate.threshold,
+                "passed": gate.passed,
+            }
+        )
+
+    print("book,before,after,threshold,passed")
+    for r in rows:
+        print(f"{r['book']},{r['before']},{r['after']},{r['threshold']},{r['passed']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/book_graph_analyzer/cli.py
+++ b/src/book_graph_analyzer/cli.py
@@ -6727,6 +6727,7 @@ def pipeline_worldbuilding(path: str, title: str | None, pillars: tuple[str], ou
     from book_graph_analyzer.ingest.loader import load_book
     from book_graph_analyzer.worldbible.extractor import ExtractionConfig, WorldBibleExtractor
     from book_graph_analyzer.worldbible.genealogy import extract_genealogy_from_text, genealogy_to_json
+    from book_graph_analyzer.worldbible.genealogy_validation import evaluate_genealogy_threshold
 
     file_path = Path(path)
     book_title = title or file_path.stem.replace("_", " ").replace("-", " ").title()
@@ -6755,8 +6756,17 @@ def pipeline_worldbuilding(path: str, title: str | None, pillars: tuple[str], ou
                 json.dump(payload, f, indent=2)
 
             count = len(payload.get("relations", []))
-            metrics["pillars"]["genealogy"] = payload.get("metrics", {"relation_count": count})
-            console.print(f"  [green]✓[/green] Genealogy — extracted {count} relations → {output_path}")
+            threshold_eval = evaluate_genealogy_threshold(book_title, count)
+            metrics["pillars"]["genealogy"] = {
+                **payload.get("metrics", {"relation_count": count}),
+                "threshold": threshold_eval.threshold,
+                "passed_threshold": threshold_eval.passed,
+            }
+            status = "PASS" if threshold_eval.passed else "FAIL"
+            console.print(
+                f"  [green]✓[/green] Genealogy — extracted {count} relations "
+                f"(threshold {threshold_eval.threshold}: {status}) → {output_path}"
+            )
 
             if hobbit_gate and count == 0:
                 raise click.ClickException(

--- a/src/book_graph_analyzer/worldbible/genealogy.py
+++ b/src/book_graph_analyzer/worldbible/genealogy.py
@@ -247,7 +247,56 @@ _RULES: list[tuple[re.Pattern[str], GenealogyRelationType, float]] = [
     # Appositive form common in Hobbit prose: "Bilbo, son of Bungo Baggins, ..."
     (re.compile(rf"\b{_NAME}\s*,\s*son of\s+{_NAME}\b"), GenealogyRelationType.CHILD_OF, 0.92),
     (re.compile(rf"\b{_NAME}\s*,\s*daughter of\s+{_NAME}\b"), GenealogyRelationType.CHILD_OF, 0.92),
+    (re.compile(rf"\b{_NAME}\s*,\s*the son of\s+{_NAME}\b"), GenealogyRelationType.CHILD_OF, 0.92),
+    (re.compile(rf"\b{_NAME}\s*,\s*the daughter of\s+{_NAME}\b"), GenealogyRelationType.CHILD_OF, 0.92),
+    (re.compile(rf"\b{_NAME}\s+was\s+the son of\s+{_NAME}\b"), GenealogyRelationType.CHILD_OF, 0.9),
+    (re.compile(rf"\b{_NAME}\s+was\s+the daughter of\s+{_NAME}\b"), GenealogyRelationType.CHILD_OF, 0.9),
+    (re.compile(rf"\b{_NAME}\s+grandson of\s+{_NAME}\b"), GenealogyRelationType.DESCENDANT_OF, 0.86),
+    (re.compile(rf"\b{_NAME}\s+granddaughter of\s+{_NAME}\b"), GenealogyRelationType.DESCENDANT_OF, 0.86),
+    (re.compile(rf"\b{_NAME}\s+heir of\s+{_NAME}\b"), GenealogyRelationType.DESCENDANT_OF, 0.78),
 ]
+
+
+_KINSHIP_CUES = re.compile(
+    r"\b(son of|daughter of|child of|father of|mother of|brother of|sister of|"
+    r"married|wed|wedded|grandson of|granddaughter of|heir of|line of|descended from)\b",
+    re.I,
+)
+
+
+def _safe_llm_genealogy_fallback(
+    text: str,
+    passage_id: str | None,
+    house: str | None,
+    llm_client: Any | None,
+) -> list[GenealogyRelation]:
+    if llm_client is None:
+        return []
+
+    prompt = (
+        "Extract genealogy relations from this passage as strict JSON. Return ONLY JSON array with objects "
+        "{source_name,target_name,relation_type}. relation_type must be one of: "
+        "PARENT_OF,CHILD_OF,SIBLING_OF,SPOUSE_OF,ANCESTOR_OF,DESCENDANT_OF. "
+        "Ignore uncertain guesses.\n\n"
+        f"Passage:\n{text}"
+    )
+    out: list[GenealogyRelation] = []
+    try:
+        raw = llm_client.generate(prompt)
+        payload = json.loads(raw)
+        if isinstance(payload, dict):
+            payload = payload.get("relations", [])
+        for item in payload if isinstance(payload, list) else []:
+            rel_type = normalize_relation_type(str(item.get("relation_type", "")))
+            source_name = _normalize_person_name(str(item.get("source_name", "")).strip())
+            target_name = _normalize_person_name(str(item.get("target_name", "")).strip())
+            if not source_name or not target_name or source_name == target_name:
+                continue
+            rel = _make_relation(source_name, target_name, rel_type, house, passage_id, 0.6)
+            _add_with_inverse(out, rel)
+    except Exception:
+        return []
+    return out
 
 
 def extract_genealogy_from_text(
@@ -255,6 +304,7 @@ def extract_genealogy_from_text(
     passage_id: str | None = None,
     house: str | None = None,
     llm_client: Any | None = None,
+    min_relations_for_fallback: int = 2,
 ) -> list[GenealogyRelation]:
     """Extract family relations from free text.
 
@@ -274,33 +324,11 @@ def extract_genealogy_from_text(
             rel = _make_relation(source_name, target_name, relation_type, inferred_house, passage_id, confidence)
             _add_with_inverse(relations, rel)
 
-    if relations or llm_client is None:
-        return infer_generation_depths(_dedupe_relations(relations))
+    deduped = _dedupe_relations(relations)
+    if llm_client is not None and _KINSHIP_CUES.search(text) and len(deduped) < min_relations_for_fallback:
+        deduped.extend(_safe_llm_genealogy_fallback(text, passage_id, house, llm_client))
 
-    # Optional fallback: extremely defensive JSON contract.
-    prompt = (
-        "Extract genealogy relations from this passage as JSON array with objects "
-        "{source_name,target_name,relation_type}. relation_type must be one of: "
-        "PARENT_OF,CHILD_OF,SIBLING_OF,SPOUSE_OF,ANCESTOR_OF,DESCENDANT_OF.\n\n"
-        f"Passage:\n{text}"
-    )
-    try:
-        raw = llm_client.generate(prompt)
-        payload = json.loads(raw)
-        if isinstance(payload, dict):
-            payload = payload.get("relations", [])
-        for item in payload if isinstance(payload, list) else []:
-            rel_type = normalize_relation_type(str(item.get("relation_type", "")))
-            source_name = str(item.get("source_name", "")).strip()
-            target_name = str(item.get("target_name", "")).strip()
-            if not source_name or not target_name or source_name == target_name:
-                continue
-            rel = _make_relation(source_name, target_name, rel_type, house, passage_id, 0.6)
-            _add_with_inverse(relations, rel)
-    except Exception:
-        pass
-
-    return infer_generation_depths(_dedupe_relations(relations))
+    return infer_generation_depths(_dedupe_relations(deduped))
 
 
 def _dedupe_relations(relations: list[GenealogyRelation]) -> list[GenealogyRelation]:

--- a/src/book_graph_analyzer/worldbible/genealogy_validation.py
+++ b/src/book_graph_analyzer/worldbible/genealogy_validation.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+BOOK_GENEALOGY_THRESHOLDS: dict[str, int] = {
+    "the hobbit": 2,
+    "the fellowship of the ring": 6,
+    "the two towers": 4,
+    "the return of the king": 4,
+    "the silmarillion": 20,
+}
+
+
+@dataclass
+class GenealogyThresholdResult:
+    book: str
+    observed: int
+    threshold: int
+
+    @property
+    def passed(self) -> bool:
+        return self.observed >= self.threshold
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "book": self.book,
+            "observed": self.observed,
+            "threshold": self.threshold,
+            "passed": self.passed,
+        }
+
+
+def threshold_for_book(book: str, default_threshold: int = 1) -> int:
+    return BOOK_GENEALOGY_THRESHOLDS.get((book or "").strip().lower(), default_threshold)
+
+
+def evaluate_genealogy_threshold(book: str, observed: int, default_threshold: int = 1) -> GenealogyThresholdResult:
+    threshold = threshold_for_book(book, default_threshold=default_threshold)
+    return GenealogyThresholdResult(book=book, observed=observed, threshold=threshold)

--- a/tests/test_genealogy.py
+++ b/tests/test_genealogy.py
@@ -51,6 +51,37 @@ def test_extract_genealogy_appositive_hobbit_style_clause():
     assert ("Bungo Baggins", "Bilbo", "PARENT_OF") in rel_types
 
 
+def test_extract_genealogy_was_the_son_of_pattern():
+    relations = extract_genealogy_from_text("Faramir was the son of Denethor.")
+    rel_types = {(r.source_name, r.target_name, r.relation_type.value) for r in relations}
+    assert ("Faramir", "Denethor", "CHILD_OF") in rel_types
+
+
+def test_extract_genealogy_grandson_pattern():
+    relations = extract_genealogy_from_text("Eldarion grandson of Arathorn.")
+    rel_types = {(r.source_name, r.target_name, r.relation_type.value) for r in relations}
+    assert ("Eldarion", "Arathorn", "DESCENDANT_OF") in rel_types
+
+
+def test_extract_genealogy_safe_llm_fallback_triggers_when_low_yield():
+    class _LLM:
+        def generate(self, _prompt: str) -> str:
+            return json.dumps([
+                {"source_name": "Theoden", "target_name": "Thengel", "relation_type": "CHILD_OF"}
+            ])
+
+    relations = extract_genealogy_from_text(
+        "It is said Theoden heir of Thengel.",
+        llm_client=_LLM(),
+        min_relations_for_fallback=3,
+    )
+    rel_types = {(r.source_name, r.target_name, r.relation_type.value) for r in relations}
+    assert any(
+        {a, b} == {"Theoden", "Thengel"} and rel == "CHILD_OF"
+        for a, b, rel in rel_types
+    )
+
+
 def test_infer_generation_depths_for_ancestor_relation_via_traversal():
     from book_graph_analyzer.models.worldbuilding import GenealogyRelation
 

--- a/tests/test_genealogy_validation.py
+++ b/tests/test_genealogy_validation.py
@@ -1,0 +1,11 @@
+from book_graph_analyzer.worldbible.genealogy_validation import evaluate_genealogy_threshold
+
+
+def test_genealogy_thresholds_are_book_specific():
+    two_towers = evaluate_genealogy_threshold("The Two Towers", observed=3)
+    return_king = evaluate_genealogy_threshold("The Return of the King", observed=5)
+
+    assert two_towers.threshold == 4
+    assert two_towers.passed is False
+    assert return_king.threshold == 4
+    assert return_king.passed is True

--- a/tests/test_pipeline_worldbuilding_genealogy.py
+++ b/tests/test_pipeline_worldbuilding_genealogy.py
@@ -62,6 +62,31 @@ def test_pipeline_worldbuilding_hobbit_gate_produces_non_zero_genealogy(tmp_path
     assert payload["metrics"]["relation_count"] > 0
 
 
+def test_pipeline_worldbuilding_genealogy_includes_threshold_status(tmp_path):
+    text_file = tmp_path / "twotowers.txt"
+    text_file.write_text("Aragorn son of Arathorn.", encoding="utf-8")
+
+    out_dir = tmp_path / "out"
+    result = CliRunner().invoke(
+        main,
+        [
+            "pipeline",
+            "worldbuilding",
+            str(text_file),
+            "--title",
+            "The Two Towers",
+            "--pillars",
+            "genealogy",
+            "--output-dir",
+            str(out_dir),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "threshold" in result.output.lower()
+    assert "FAIL" in result.output
+
+
 def test_pipeline_worldbuilding_cultural_pillar_outputs_metrics(tmp_path):
     hobbit_text = tmp_path / "the_hobbit.txt"
     hobbit_text.write_text(


### PR DESCRIPTION
## Summary
- add explicit per-book genealogy thresholds and include threshold status in pipeline worldbuilding metrics/reporting
- expand deterministic genealogy patterns (e.g., "was the son of", "grandson of", "heir of")
- add safe JSON-only model fallback that only triggers on kinship cues and low-yield extraction
- retain idempotent Neo4j materialization via `GraphWriter.write_genealogy_batch` MERGE semantics
- add a genealogy depth report script for before/after counts + threshold pass/fail
- add tests for new patterns and per-book threshold gating behavior

## Validation
- pytest -q tests/test_genealogy.py tests/test_pipeline_worldbuilding_genealogy.py tests/test_genealogy_validation.py
