### PR TITLE
feat: graph-native statistical shadow-graph story synth MVP

### DIFF
--- a/docs/story-workflow-cli.md
+++ b/docs/story-workflow-cli.md
@@ -1,6 +1,6 @@
 # Story Workflow CLI (Product UX)
 
-The `story` command group provides a friendly workflow for project setup, auto-planning, and validation.
+The `story` command group provides a friendly workflow for project setup, planning, validation, and graph-grounded chapter synthesis.
 
 ## 1) Initialize a project
 
@@ -57,8 +57,69 @@ You can also override JSON output path:
 bga story validate --project mithrandir-east --json-out artifacts/mithrandir-validate.json
 ```
 
+## 4) Build graph-native context stats
+
+```bash
+bga story context --project mithrandir-east --graph-stats
+```
+
+Generates:
+
+- `data/projects/<slug>/context_stats.json`
+
+Stats include:
+
+- event transition probabilities
+- motif/reference density priors
+- character participation priors
+- register/style budgets
+
+## 5) Grow probabilistic shadow graph
+
+```bash
+bga story grow-shadow --project mithrandir-east --auto
+```
+
+Generates:
+
+- `data/projects/<slug>/shadow_graph.json`
+- `data/projects/<slug>/shadow_candidates.json`
+
+## 6) Solve best valid trajectory
+
+```bash
+bga story solve --project mithrandir-east
+```
+
+Generates:
+
+- `data/projects/<slug>/shadow_solution.json`
+
+## 7) Draft grounded chapter prose
+
+```bash
+bga story draft --project mithrandir-east --chapter 1 --grounded
+```
+
+Generates:
+
+- `data/projects/<slug>/chapter_01.md`
+- `data/projects/<slug>/chapter_01_trace.json`
+
+## 8) Audit chapter grounding and constraints
+
+```bash
+bga story audit --project mithrandir-east --chapter 1
+```
+
+Generates:
+
+- `data/projects/<slug>/chapter_01_audit.json`
+- `data/projects/<slug>/chapter_01_audit.md`
+
 ## Notes
 
 - Basic flow requires no manual JSON editing.
 - Canon integration is read-only in this iteration (uses configured canon file when present).
 - `story plan` currently supports `--auto` mode only.
+- `story grow-shadow` currently supports `--auto` mode only.

--- a/docs/wiki/shadow-graph-research-brief.md
+++ b/docs/wiki/shadow-graph-research-brief.md
@@ -1,0 +1,86 @@
+# Shadow-Graph Statistical Synthesizer — Research Brief (MVP v1)
+
+Date: 2026-02-22
+
+## Scope
+Researched practical methods for:
+1. Narrative planning on knowledge/scene graphs
+2. Constrained generation with symbolic planners + LLM realization
+3. Probabilistic graph growth/search on event graphs
+4. Style transfer controls and budgeted motifs/references
+
+## Key findings (applied)
+
+### 1) Narrative planning on graphs
+- Classical narrative planning (IPOCL) emphasizes **causal coherence + character intentionality**, not just event ordering.
+- Recent KG-assisted storytelling work shows a practical loop: **initialize KG → generate scene conditioned on KG → update KG**, and users can edit KG for control.
+
+**Implication for this repo**
+- Keep a graph-first intermediate (`shadow_graph.json`) with typed nodes (`ShadowScene`, `ShadowEvent`, `ShadowMotif`) and explicit edge semantics (`NEXT`, `HAS_EVENT`, `INVOLVES`, `USES_MOTIF`).
+- Keep scene plan compatibility (`plan.json`) but map every plan scene to graph nodes.
+
+### 2) Constrained generation (symbolic + LM)
+- Lexically constrained decoding (GBS) and logic-constrained decoding (NeuroLogic) demonstrate that constraint satisfaction can be done at decode/search time.
+- For MVP and compatibility, full custom decoder integration is heavy; equivalent value can be achieved by **constraint-aware candidate generation + selection** before prose realization.
+
+**Implication for this repo**
+- Enforce hard constraints in `grow-shadow` and `solve` (forbidden terms rejected; required elements tracked).
+- Keep `draft --grounded` strictly downstream of solved graph trajectory (no freeform draft path in this workflow).
+
+### 3) Probabilistic growth/search on event graphs
+- Narrative exploration with MCTS and branching tree UI is effective for “what-if” exploration.
+- For CLI MVP, beam search is lower complexity and deterministic enough for repeatable tests.
+
+**Implication for this repo**
+- `context --graph-stats`: compute event transition priors from extracted events.
+- `grow-shadow --auto`: generate multiple candidates per scene with plausibility score from transition priors + participation priors + motif priors.
+- `solve`: beam-select best valid trajectory.
+
+### 4) Style controls + motif budgets
+- Controllable generation literature (e.g., FUDGE) supports lightweight modular control signals.
+- For this codebase, useful controls are **budget features** instead of model fine-tuning: words/scene targets, lore/song motif budgets, dialogue ratio target.
+
+**Implication for this repo**
+- Emit `register_style_budgets` in `context_stats.json`.
+- Use budgets as policy signals in generation/audit artifacts.
+
+## Selected implementation choices for MVP v1
+1. **Artifact-first architecture** (JSON contracts) over direct Neo4j dependency for commands:
+   - Works with existing repo data artifacts (`*_events.json`)
+   - Easier to test offline
+2. **Statistical priors from corpus event files**:
+   - Event transition probabilities (Markov-like)
+   - Character participation priors
+   - Motif/reference token priors
+3. **Probabilistic candidate graph growth**:
+   - 3 candidates per scene
+   - Plausibility score combines transition + character + motif priors
+4. **Beam solve**:
+   - Deterministic, transparent objective
+   - Constraint checks integrated
+5. **Grounded drafting with traceability**:
+   - Chapter prose generated from solved trajectory only
+   - Mandatory section trace mapping to shadow/canon identifiers
+6. **Audit command**:
+   - Coverage, constraint, and trace-reference checks
+
+## Why this is appropriate for current codebase
+- Aligns with existing `story` command surface and project artifacts.
+- Preserves backward compatibility (`init/plan/validate` still work).
+- Provides a true graph-native workflow path without requiring immediate infrastructure changes.
+- Testable with fast unit/integration tests using local JSON fixtures.
+
+## References
+1. Riedl, M. O., & Young, R. M. (2010). *Narrative Planning: Balancing Plot and Character*. JAIR.  
+   - https://jair.org/index.php/jair/article/view/10669
+   - https://arxiv.org/abs/1401.3841
+2. Hokamp, C., & Liu, Q. (2017). *Lexically Constrained Decoding for Sequence Generation Using Grid Beam Search*. ACL.  
+   - https://aclanthology.org/P17-1141/
+3. Lu, X. et al. (2021). *NeuroLogic Decoding: (Un)supervised Neural Text Generation with Predicate Logic Constraints*. NAACL.  
+   - https://arxiv.org/abs/2010.12884
+4. Yang, K., & Klein, D. (2021). *FUDGE: Controlled Text Generation With Future Discriminators*. NAACL.  
+   - https://aclanthology.org/2021.naacl-main.276/
+5. Ghaffari, P., & Hokamp, C. (2025). *Narrative Studio: Visual narrative exploration using LLMs and Monte Carlo Tree Search*.  
+   - https://arxiv.org/html/2504.02426
+6. Andronis, A. et al. (2025). *Guiding Generative Storytelling with Knowledge Graphs*.  
+   - https://arxiv.org/html/2505.24803v2

--- a/src/book_graph_analyzer/story_cli.py
+++ b/src/book_graph_analyzer/story_cli.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
 import json
+import math
+import random
+import re
+from collections import Counter, defaultdict
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -11,6 +15,19 @@ console = Console()
 
 
 DEFAULT_PROJECTS_DIR = Path("data") / "projects"
+DEFAULT_EVENT_FILES = [
+    "data/output/silmarillion_events.json",
+    "data/output/unfinished_tales_events.json",
+    "data/output/hobbit_events.json",
+    "data/output/fellowship_events.json",
+    "data/output/twotowers_events.json",
+    "data/output/return_events.json",
+]
+STOPWORDS = {
+    "the", "and", "with", "from", "that", "this", "into", "over", "under", "after", "before",
+    "their", "there", "where", "while", "about", "through", "during", "have", "has", "had",
+    "were", "was", "will", "would", "could", "should", "might", "must", "they", "them", "then",
+}
 
 
 def _slugify(text: str) -> str:
@@ -33,6 +50,76 @@ def _load_project(slug: str, projects_dir: Path | None = None) -> dict:
     if not path.exists():
         raise click.ClickException(f"Project '{slug}' not found at {path}")
     return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _load_json(path: Path, default: dict | list | None = None):
+    if not path.exists():
+        return {} if default is None else default
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _extract_events(payload: dict) -> list[dict]:
+    events = payload.get("events", {})
+    if isinstance(events, dict):
+        rows = list(events.values())
+    elif isinstance(events, list):
+        rows = events
+    else:
+        rows = []
+
+    def _year(row: dict) -> int:
+        y = row.get("year")
+        if isinstance(y, int):
+            return y
+        if isinstance(y, str) and y.lstrip("-").isdigit():
+            return int(y)
+        return 0
+
+    rows.sort(key=lambda r: (str(r.get("era") or ""), _year(r), str(r.get("id") or "")))
+    return rows
+
+
+def _project_event_files(project: dict) -> list[Path]:
+    configured = project.get("event_files")
+    files = configured if isinstance(configured, list) and configured else DEFAULT_EVENT_FILES
+    return [Path(p) for p in files if Path(p).exists()]
+
+
+def _tokenize(text: str) -> list[str]:
+    tokens = re.findall(r"[a-zA-Z][a-zA-Z'-]{2,}", text.lower())
+    return [t for t in tokens if t not in STOPWORDS]
+
+
+def _safe_prob(counter: dict[str, int]) -> dict[str, float]:
+    total = sum(counter.values())
+    if total <= 0:
+        return {}
+    return {k: round(v / total, 6) for k, v in counter.items()}
+
+
+def _load_constraints(proj_dir: Path) -> dict:
+    constraints_path = proj_dir / "constraints.json"
+    return (
+        json.loads(constraints_path.read_text(encoding="utf-8"))
+        if constraints_path.exists()
+        else _default_constraints()
+    )
+
+
+def _chapter_path(proj_dir: Path, chapter: int) -> Path:
+    return proj_dir / f"chapter_{chapter:02d}.md"
+
+
+def _trace_path(proj_dir: Path, chapter: int) -> Path:
+    return proj_dir / f"chapter_{chapter:02d}_trace.json"
+
+
+def _audit_json_path(proj_dir: Path, chapter: int) -> Path:
+    return proj_dir / f"chapter_{chapter:02d}_audit.json"
+
+
+def _audit_md_path(proj_dir: Path, chapter: int) -> Path:
+    return proj_dir / f"chapter_{chapter:02d}_audit.md"
 
 
 def _default_constraints() -> dict:
@@ -340,3 +427,441 @@ def story_validate(project_slug: str, projects_dir: str, json_out: str) -> None:
     console.print(f"Issues: {report['summary']['issues']} | Warnings: {report['summary']['warnings']}")
     console.print(f"Human report: {md_path}")
     console.print(f"JSON report: {json_report_path}")
+
+
+@story.command("context")
+@click.option("--project", "project_slug", required=True, help="Project slug")
+@click.option("--graph-stats", is_flag=True, help="Compute graph-derived statistical priors")
+@click.option("--projects-dir", default=str(DEFAULT_PROJECTS_DIR), show_default=True, type=click.Path())
+def story_context(project_slug: str, graph_stats: bool, projects_dir: str) -> None:
+    """Compute graph-native statistical context from event artifacts."""
+    if not graph_stats:
+        raise click.ClickException("Use --graph-stats for this command: bga story context --project <slug> --graph-stats")
+
+    project = _load_project(project_slug, Path(projects_dir))
+    proj_dir = _project_dir(project_slug, Path(projects_dir))
+    event_files = _project_event_files(project)
+    if not event_files:
+        raise click.ClickException("No event files found. Set project.event_files to one or more *_events.json files.")
+
+    transition_counts: dict[str, Counter] = defaultdict(Counter)
+    action_counts: Counter = Counter()
+    motif_counts: Counter = Counter()
+    character_counts: Counter = Counter()
+    register_word_lengths: list[int] = []
+    total_events = 0
+
+    for path in event_files:
+        payload = _load_json(path, default={})
+        events = _extract_events(payload)
+        total_events += len(events)
+        previous_action = None
+        for ev in events:
+            action = str(ev.get("action") or "unknown").strip().lower() or "unknown"
+            desc = str(ev.get("description") or "")
+            agent = str(ev.get("agent") or "Unknown").strip() or "Unknown"
+            action_counts[action] += 1
+            character_counts[agent] += 1
+            register_word_lengths.append(max(1, len(desc.split())))
+
+            for tok in _tokenize(desc):
+                motif_counts[tok] += 1
+
+            if previous_action is not None:
+                transition_counts[previous_action][action] += 1
+            previous_action = action
+
+    transition_probabilities = {
+        src: _safe_prob(dict(dest))
+        for src, dest in transition_counts.items()
+    }
+
+    motif_priors = _safe_prob(dict(motif_counts.most_common(80)))
+    character_priors = _safe_prob(dict(character_counts))
+    avg_words = int(round(sum(register_word_lengths) / max(1, len(register_word_lengths))))
+    register_style_budgets = {
+        "target_words_per_scene": max(180, min(900, avg_words * 3)),
+        "dialogue_ratio_target": 0.28,
+        "lore_reference_budget_per_scene": 2,
+        "song_reference_budget_per_chapter": 1,
+    }
+
+    context = {
+        "schema_version": "shadow-context-v1",
+        "project_slug": project_slug,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "source_event_files": [str(p) for p in event_files],
+        "totals": {
+            "events": total_events,
+            "actions": len(action_counts),
+            "characters": len(character_counts),
+            "motifs": len(motif_counts),
+        },
+        "event_transition_probabilities": transition_probabilities,
+        "motif_reference_density_priors": motif_priors,
+        "character_participation_priors": character_priors,
+        "register_style_budgets": register_style_budgets,
+    }
+
+    out_path = proj_dir / "context_stats.json"
+    out_path.write_text(json.dumps(context, indent=2), encoding="utf-8")
+    console.print(f"[green]OK[/green] Context stats generated: {out_path}")
+
+
+@story.command("grow-shadow")
+@click.option("--project", "project_slug", required=True, help="Project slug")
+@click.option("--auto", "auto_mode", is_flag=True, help="Auto-generate probabilistic shadow graph")
+@click.option("--projects-dir", default=str(DEFAULT_PROJECTS_DIR), show_default=True, type=click.Path())
+def story_grow_shadow(project_slug: str, auto_mode: bool, projects_dir: str) -> None:
+    """Grow a probabilistic shadow graph from context stats and plan."""
+    if not auto_mode:
+        raise click.ClickException("Use --auto mode: bga story grow-shadow --project <slug> --auto")
+
+    project = _load_project(project_slug, Path(projects_dir))
+    proj_dir = _project_dir(project_slug, Path(projects_dir))
+    context_path = proj_dir / "context_stats.json"
+    if not context_path.exists():
+        raise click.ClickException(f"Missing {context_path}. Run story context first.")
+
+    context = _load_json(context_path, default={})
+    constraints = _load_constraints(proj_dir)
+    plan_path = proj_dir / "plan.json"
+    if plan_path.exists():
+        plan = _load_json(plan_path, default={})
+    else:
+        plan = _build_plan(project, constraints, auto=True)
+        plan_path.write_text(json.dumps(plan, indent=2), encoding="utf-8")
+
+    transitions = context.get("event_transition_probabilities", {})
+    char_priors = context.get("character_participation_priors", {})
+    motif_priors = context.get("motif_reference_density_priors", {})
+    top_characters = [k for k, _ in sorted(char_priors.items(), key=lambda kv: kv[1], reverse=True)[:12]] or ["Beren", "Luthien"]
+    top_motifs = [k for k, _ in sorted(motif_priors.items(), key=lambda kv: kv[1], reverse=True)[:30]] or ["song", "oath", "shadow"]
+    seed = abs(hash(project_slug)) % (2**32)
+    rng = random.Random(seed)
+    required = [str(x) for x in constraints.get("required_elements", [])]
+    forbidden = {str(x).lower() for x in constraints.get("forbidden_terms", [])}
+
+    graph_nodes = []
+    graph_edges = []
+    candidates = []
+    selected = []
+    prev_action = "unknown"
+
+    for ch in plan.get("chapters", []):
+        chapter_num = int(ch.get("chapter_number", 1))
+        scenes = ch.get("scenes", [])
+        for scene in scenes:
+            scene_id = str(scene.get("scene_id"))
+            chapter_scene_key = f"shadow-{scene_id}"
+            scene_node = {
+                "id": chapter_scene_key,
+                "type": "ShadowScene",
+                "scene_id": scene_id,
+                "chapter": chapter_num,
+                "summary": scene.get("summary", ""),
+            }
+            graph_nodes.append(scene_node)
+
+            row_candidates = []
+            for rank in range(3):
+                action_choices = list(transitions.get(prev_action, {"journey": 0.34, "conflict": 0.33, "reveal": 0.33}).items())
+                action = action_choices[min(rank, len(action_choices) - 1)][0]
+                transition_prob = float(action_choices[min(rank, len(action_choices) - 1)][1])
+                chars = rng.sample(top_characters, k=min(2 + rank, len(top_characters)))
+                motifs = rng.sample(top_motifs, k=min(2, len(top_motifs)))
+                if required and chapter_num == 1 and rank == 0:
+                    motifs = list(dict.fromkeys((required[:1] + motifs)))
+
+                description = f"{scene.get('goal', 'Advance plot')} via {action}."
+                if any(term in description.lower() for term in forbidden):
+                    continue
+
+                char_score = sum(float(char_priors.get(c, 0.01)) for c in chars) / max(1, len(chars))
+                motif_score = sum(float(motif_priors.get(m, 0.005)) for m in motifs) / max(1, len(motifs))
+                plausibility = round(min(0.99, max(0.05, (0.5 * transition_prob) + (0.3 * char_score) + (0.2 * motif_score))), 6)
+                cid = f"{scene_id}-cand-{rank + 1}"
+                row_candidates.append(
+                    {
+                        "candidate_id": cid,
+                        "scene_id": scene_id,
+                        "chapter": chapter_num,
+                        "shadow_event": {
+                            "id": f"shadow-event-{cid}",
+                            "type": "ShadowEvent",
+                            "action": action,
+                            "description": description,
+                            "characters": chars,
+                            "motifs": motifs,
+                        },
+                        "transition_probability": round(transition_prob, 6),
+                        "plausibility_score": plausibility,
+                        "hard_constraints_ok": True,
+                    }
+                )
+            row_candidates.sort(key=lambda c: c["plausibility_score"], reverse=True)
+            if row_candidates:
+                selected.append(row_candidates[0])
+                prev_action = row_candidates[0]["shadow_event"]["action"]
+            candidates.extend(row_candidates)
+
+    for idx, chosen in enumerate(selected):
+        ev = chosen["shadow_event"]
+        graph_nodes.append(ev)
+        graph_edges.append({
+            "source": f"shadow-{chosen['scene_id']}",
+            "target": ev["id"],
+            "type": "HAS_EVENT",
+            "probability": chosen["plausibility_score"],
+        })
+        for c in ev["characters"]:
+            cid = f"shadow-char-{re.sub(r'[^a-z0-9]+', '-', c.lower()).strip('-')}"
+            graph_nodes.append({"id": cid, "type": "ShadowCharacter", "name": c})
+            graph_edges.append({"source": ev["id"], "target": cid, "type": "INVOLVES", "probability": 1.0})
+        for m in ev["motifs"]:
+            mid = f"shadow-motif-{re.sub(r'[^a-z0-9]+', '-', m.lower()).strip('-')}"
+            graph_nodes.append({"id": mid, "type": "ShadowMotif", "name": m})
+            graph_edges.append({"source": ev["id"], "target": mid, "type": "USES_MOTIF", "probability": round(float(motif_priors.get(m, 0.02)), 6)})
+        if idx > 0:
+            prev = selected[idx - 1]["shadow_event"]["id"]
+            graph_edges.append({"source": prev, "target": ev["id"], "type": "NEXT", "probability": chosen["transition_probability"]})
+
+    graph_payload = {
+        "schema_version": "shadow-graph-v1",
+        "project_slug": project_slug,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "nodes": graph_nodes,
+        "edges": graph_edges,
+    }
+    candidates_payload = {
+        "schema_version": "shadow-candidates-v1",
+        "project_slug": project_slug,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "constraints_snapshot": constraints,
+        "candidates": candidates,
+        "selected_auto": [c["candidate_id"] for c in selected],
+    }
+
+    (proj_dir / "shadow_graph.json").write_text(json.dumps(graph_payload, indent=2), encoding="utf-8")
+    (proj_dir / "shadow_candidates.json").write_text(json.dumps(candidates_payload, indent=2), encoding="utf-8")
+    console.print(f"[green]OK[/green] Shadow graph artifacts written under {proj_dir}")
+
+
+@story.command("solve")
+@click.option("--project", "project_slug", required=True, help="Project slug")
+@click.option("--projects-dir", default=str(DEFAULT_PROJECTS_DIR), show_default=True, type=click.Path())
+def story_solve(project_slug: str, projects_dir: str) -> None:
+    """Solve best valid trajectory through shadow candidates using beam search."""
+    proj_dir = _project_dir(project_slug, Path(projects_dir))
+    _load_project(project_slug, Path(projects_dir))
+    payload = _load_json(proj_dir / "shadow_candidates.json", default={})
+    candidates = payload.get("candidates", [])
+    if not candidates:
+        raise click.ClickException("No candidates found. Run story grow-shadow first.")
+
+    by_scene: dict[str, list[dict]] = defaultdict(list)
+    for cand in candidates:
+        by_scene[str(cand.get("scene_id"))].append(cand)
+    scene_ids = sorted(by_scene.keys())
+    constraints = _load_constraints(proj_dir)
+    required = [str(x).lower() for x in constraints.get("required_elements", [])]
+    forbidden = [str(x).lower() for x in constraints.get("forbidden_terms", [])]
+
+    beam: list[tuple[float, list[dict]]] = [(0.0, [])]
+    beam_width = 4
+
+    for sid in scene_ids:
+        next_beam: list[tuple[float, list[dict]]] = []
+        for base_score, path in beam:
+            for cand in by_scene[sid][:4]:
+                desc = str(cand.get("shadow_event", {}).get("description", "")).lower()
+                if any(term in desc for term in forbidden):
+                    continue
+                p = max(1e-6, float(cand.get("plausibility_score", 0.01)))
+                t = max(1e-6, float(cand.get("transition_probability", 0.01)))
+                score = base_score + math.log(p) + 0.5 * math.log(t)
+                next_beam.append((score, path + [cand]))
+        next_beam.sort(key=lambda x: x[0], reverse=True)
+        beam = next_beam[:beam_width] or beam
+
+    best_score, best_path = beam[0]
+    full_text = "\n".join(c.get("shadow_event", {}).get("description", "") for c in best_path).lower()
+    missing_required = [r for r in required if r not in full_text]
+    status = "pass" if not missing_required else "warn"
+
+    solved = {
+        "schema_version": "shadow-solution-v1",
+        "project_slug": project_slug,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "beam_width": beam_width,
+        "objective": "sum(log(plausibility)+0.5*log(transition_probability))",
+        "best_score": round(best_score, 6),
+        "status": status,
+        "missing_required_elements": missing_required,
+        "trajectory": [
+            {
+                "scene_id": c.get("scene_id"),
+                "candidate_id": c.get("candidate_id"),
+                "shadow_event_id": c.get("shadow_event", {}).get("id"),
+                "action": c.get("shadow_event", {}).get("action"),
+                "plausibility_score": c.get("plausibility_score"),
+            }
+            for c in best_path
+        ],
+    }
+    out_path = proj_dir / "shadow_solution.json"
+    out_path.write_text(json.dumps(solved, indent=2), encoding="utf-8")
+    console.print(f"[green]OK[/green] Solved trajectory written: {out_path}")
+
+
+@story.command("draft")
+@click.option("--project", "project_slug", required=True, help="Project slug")
+@click.option("--chapter", required=True, type=int, help="Chapter number")
+@click.option("--grounded", is_flag=True, help="Require graph-grounded drafting")
+@click.option("--projects-dir", default=str(DEFAULT_PROJECTS_DIR), show_default=True, type=click.Path())
+def story_draft(project_slug: str, chapter: int, grounded: bool, projects_dir: str) -> None:
+    """Draft chapter prose from solved shadow graph trajectory."""
+    if not grounded:
+        raise click.ClickException("Use --grounded for this command.")
+
+    proj_dir = _project_dir(project_slug, Path(projects_dir))
+    _load_project(project_slug, Path(projects_dir))
+    solved = _load_json(proj_dir / "shadow_solution.json", default={})
+    graph = _load_json(proj_dir / "shadow_graph.json", default={})
+    if not solved.get("trajectory"):
+        raise click.ClickException("Missing solved trajectory. Run story solve first.")
+
+    graph_node_by_id = {n.get("id"): n for n in graph.get("nodes", []) if isinstance(n, dict)}
+    chapter_rows = [row for row in solved.get("trajectory", []) if str(row.get("scene_id", "")).startswith(f"ch{chapter:02d}-")]
+    if not chapter_rows:
+        raise click.ClickException(f"No solved scenes found for chapter {chapter}.")
+
+    lines = [f"# Chapter {chapter}: Shadow-Woven Paths", ""]
+    trace_sections = []
+    for idx, row in enumerate(chapter_rows, start=1):
+        scene_id = row.get("scene_id")
+        event_id = row.get("shadow_event_id")
+        event = graph_node_by_id.get(event_id, {})
+        chars = event.get("characters", ["They"])
+        motifs = event.get("motifs", [])
+        action = event.get("action", "moved")
+        motif_clause = f" Motifs threading this passage: {', '.join(motifs[:2])}." if motifs else ""
+        prose = (
+            f"In scene {scene_id}, {chars[0]} and {chars[-1]} {action} through uncertain country, "
+            f"testing the cost of each vow against the weight of old memory. "
+            f"Their choices keep close to known history while opening a narrow, plausible margin for what may yet be told."
+            f"{motif_clause}"
+        )
+        lines.extend([f"## Scene {idx}", "", prose, ""])
+        trace_sections.append(
+            {
+                "section": idx,
+                "scene_id": scene_id,
+                "shadow_event_id": event_id,
+                "shadow_scene_id": f"shadow-{scene_id}",
+                "source_canon_node_ids": [f"canon-action-{action}"],
+                "text_excerpt": prose[:220],
+            }
+        )
+
+    chapter_path = _chapter_path(proj_dir, chapter)
+    chapter_path.write_text("\n".join(lines), encoding="utf-8")
+    trace_payload = {
+        "schema_version": "chapter-trace-v1",
+        "project_slug": project_slug,
+        "chapter": chapter,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "sections": trace_sections,
+    }
+    trace_out = _trace_path(proj_dir, chapter)
+    trace_out.write_text(json.dumps(trace_payload, indent=2), encoding="utf-8")
+    console.print(f"[green]OK[/green] Draft written: {chapter_path}")
+    console.print(f"Trace written: {trace_out}")
+
+
+@story.command("audit")
+@click.option("--project", "project_slug", required=True, help="Project slug")
+@click.option("--chapter", required=True, type=int, help="Chapter number")
+@click.option("--projects-dir", default=str(DEFAULT_PROJECTS_DIR), show_default=True, type=click.Path())
+def story_audit(project_slug: str, chapter: int, projects_dir: str) -> None:
+    """Audit chapter grounding, coverage, and hard constraints."""
+    proj_dir = _project_dir(project_slug, Path(projects_dir))
+    _load_project(project_slug, Path(projects_dir))
+    chapter_path = _chapter_path(proj_dir, chapter)
+    trace_path = _trace_path(proj_dir, chapter)
+    solution_path = proj_dir / "shadow_solution.json"
+    graph_path = proj_dir / "shadow_graph.json"
+
+    if not chapter_path.exists() or not trace_path.exists():
+        raise click.ClickException("Missing chapter or trace artifacts. Run story draft --grounded first.")
+
+    text = chapter_path.read_text(encoding="utf-8")
+    trace = _load_json(trace_path, default={})
+    solved = _load_json(solution_path, default={})
+    graph = _load_json(graph_path, default={})
+    constraints = _load_constraints(proj_dir)
+
+    expected_scenes = [row for row in solved.get("trajectory", []) if str(row.get("scene_id", "")).startswith(f"ch{chapter:02d}-")]
+    traced = trace.get("sections", [])
+    coverage = round(len(traced) / max(1, len(expected_scenes)), 6)
+
+    forbidden = [str(x).lower() for x in constraints.get("forbidden_terms", [])]
+    required = [str(x).lower() for x in constraints.get("required_elements", [])]
+    text_l = text.lower()
+    forbidden_hits = [t for t in forbidden if t in text_l]
+    required_missing = [t for t in required if t not in text_l]
+
+    node_ids = {n.get("id") for n in graph.get("nodes", []) if isinstance(n, dict)}
+    invalid_refs = []
+    for sec in traced:
+        for key in ("shadow_event_id", "shadow_scene_id"):
+            rid = sec.get(key)
+            if rid and rid not in node_ids:
+                invalid_refs.append({"section": sec.get("section"), "missing": rid, "field": key})
+
+    status = "pass"
+    if coverage < 0.99 or forbidden_hits or invalid_refs:
+        status = "fail"
+    elif required_missing:
+        status = "warn"
+
+    report = {
+        "schema_version": "chapter-audit-v1",
+        "project_slug": project_slug,
+        "chapter": chapter,
+        "audited_at": datetime.now(timezone.utc).isoformat(),
+        "status": status,
+        "coverage": {
+            "expected_scene_count": len(expected_scenes),
+            "traced_scene_count": len(traced),
+            "ratio": coverage,
+        },
+        "constraints": {
+            "forbidden_hits": forbidden_hits,
+            "required_missing": required_missing,
+        },
+        "grounding": {
+            "invalid_trace_refs": invalid_refs,
+        },
+    }
+
+    json_path = _audit_json_path(proj_dir, chapter)
+    md_path = _audit_md_path(proj_dir, chapter)
+    json_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    md = [
+        f"# Chapter {chapter} Audit — {project_slug}",
+        "",
+        f"- Status: **{status.upper()}**",
+        f"- Coverage: {len(traced)}/{len(expected_scenes)} ({coverage:.2%})",
+        f"- Forbidden hits: {len(forbidden_hits)}",
+        f"- Required missing: {len(required_missing)}",
+        f"- Invalid trace refs: {len(invalid_refs)}",
+        "",
+        "## Details",
+        f"- forbidden_hits: {forbidden_hits or '[]'}",
+        f"- required_missing: {required_missing or '[]'}",
+        f"- invalid_trace_refs: {invalid_refs or '[]'}",
+    ]
+    md_path.write_text("\n".join(md), encoding="utf-8")
+    console.print(f"[green]OK[/green] Audit written: {json_path}")
+    console.print(f"Markdown report: {md_path}")

--- a/tests/test_story_cli.py
+++ b/tests/test_story_cli.py
@@ -10,6 +10,11 @@ def test_story_group_registered():
     assert "init" in main.commands["story"].commands
     assert "plan" in main.commands["story"].commands
     assert "validate" in main.commands["story"].commands
+    assert "context" in main.commands["story"].commands
+    assert "grow-shadow" in main.commands["story"].commands
+    assert "solve" in main.commands["story"].commands
+    assert "draft" in main.commands["story"].commands
+    assert "audit" in main.commands["story"].commands
 
 
 def test_story_init_non_interactive(tmp_path):
@@ -120,3 +125,81 @@ def test_story_validate_generates_reports(tmp_path):
     report = json.loads((proj_dir / "validation_report.json").read_text(encoding="utf-8"))
     assert report["project_slug"] == "val-proj"
     assert report["status"] in {"pass", "fail"}
+
+
+def test_shadow_graph_workflow_end_to_end(tmp_path):
+    events_path = tmp_path / "events.json"
+    events_payload = {
+        "events": {
+            "1": {"id": "1", "description": "Beren enters Doriath in secret.", "agent": "Beren", "action": "enter", "patient": "Doriath", "era": "First Age", "year": 465},
+            "2": {"id": "2", "description": "Luthien sings beneath moonlit beeches.", "agent": "Luthien", "action": "sing", "patient": "song", "era": "First Age", "year": 465},
+            "3": {"id": "3", "description": "Thingol sets a perilous bride-price.", "agent": "Thingol", "action": "decree", "patient": "quest", "era": "First Age", "year": 466},
+            "4": {"id": "4", "description": "Beren swears an oath and departs.", "agent": "Beren", "action": "swear", "patient": "oath", "era": "First Age", "year": 466},
+        },
+        "relations": [],
+    }
+    events_path.write_text(json.dumps(events_payload, indent=2), encoding="utf-8")
+
+    proj_dir = tmp_path / "beren-luthien-expanded"
+    proj_dir.mkdir(parents=True, exist_ok=True)
+    (proj_dir / "project.json").write_text(
+        json.dumps(
+            {
+                "name": "Beren and Luthien Expanded",
+                "slug": "beren-luthien-expanded",
+                "genre": "fantasy",
+                "premise": "A grounded retelling that explores implied beats between canonical events.",
+                "target_chapters": 2,
+                "scenes_per_chapter": 2,
+                "event_files": [str(events_path)],
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    (proj_dir / "constraints.json").write_text(
+        json.dumps({"required_elements": ["oath"], "forbidden_terms": ["spaceship"], "style": {}}, indent=2),
+        encoding="utf-8",
+    )
+    (proj_dir / "plan.json").write_text(
+        json.dumps(
+            {
+                "project_slug": "beren-luthien-expanded",
+                "chapters": [
+                    {"chapter_number": 1, "title": "Ch1", "scenes": [{"scene_id": "ch01-sc01", "goal": "setup", "summary": "Beren enters"}, {"scene_id": "ch01-sc02", "goal": "vow", "summary": "Oath set"}]},
+                    {"chapter_number": 2, "title": "Ch2", "scenes": [{"scene_id": "ch02-sc01", "goal": "journey", "summary": "Road"}, {"scene_id": "ch02-sc02", "goal": "trial", "summary": "Trial"}]},
+                ],
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+    runner = CliRunner()
+    commands = [
+        ["story", "context", "--project", "beren-luthien-expanded", "--graph-stats", "--projects-dir", str(tmp_path)],
+        ["story", "grow-shadow", "--project", "beren-luthien-expanded", "--auto", "--projects-dir", str(tmp_path)],
+        ["story", "solve", "--project", "beren-luthien-expanded", "--projects-dir", str(tmp_path)],
+        ["story", "draft", "--project", "beren-luthien-expanded", "--chapter", "1", "--grounded", "--projects-dir", str(tmp_path)],
+        ["story", "audit", "--project", "beren-luthien-expanded", "--chapter", "1", "--projects-dir", str(tmp_path)],
+    ]
+    for cmd in commands:
+        result = runner.invoke(main, cmd)
+        assert result.exit_code == 0, result.output
+
+    assert (proj_dir / "context_stats.json").exists()
+    assert (proj_dir / "shadow_graph.json").exists()
+    assert (proj_dir / "shadow_candidates.json").exists()
+    assert (proj_dir / "shadow_solution.json").exists()
+    assert (proj_dir / "chapter_01.md").exists()
+    assert (proj_dir / "chapter_01_trace.json").exists()
+    assert (proj_dir / "chapter_01_audit.json").exists()
+
+    trace = json.loads((proj_dir / "chapter_01_trace.json").read_text(encoding="utf-8"))
+    assert trace["schema_version"] == "chapter-trace-v1"
+    assert trace["chapter"] == 1
+    assert len(trace["sections"]) == 2
+
+    audit = json.loads((proj_dir / "chapter_01_audit.json").read_text(encoding="utf-8"))
+    assert audit["schema_version"] == "chapter-audit-v1"
+    assert audit["status"] in {"pass", "warn", "fail"}


### PR DESCRIPTION
## Summary
- add research brief for graph-native narrative planning, constrained generation, probabilistic search, and style controls
- implement new story workflow commands: context, grow-shadow, solve, draft, audit
- add end-to-end tests for new artifact schemas and command chain
- update story workflow docs

## Validation
- python -m pytest tests/test_story_cli.py -q
- graph-grounded run on eren-luthien-expanded via context->grow-shadow->solve->draft->audit
